### PR TITLE
common: fix checking for module libpmem2

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -27,7 +27,8 @@ endif()
 
 set(LIBIBVERBS_REQUIRED_VERSION 1.0) # XXX set the required value
 set(LIBRDMACM_REQUIRED_VERSION 1.0)  # XXX set the required value
-set(LIBPMEM2_REQUIRED_VERSION 0.0) # required only for tests and examples
+# required only for tests and examples
+set(LIBPMEM2_REQUIRED_VERSION 1.0)   # XXX set the required value
 
 set(CMAKE_DISABLE_IN_SOURCE_BUILD ON)
 
@@ -99,7 +100,7 @@ pkg_check_modules(LIBIBVERBS REQUIRED libibverbs>=${LIBIBVERBS_REQUIRED_VERSION}
 pkg_check_modules(LIBRDMACM REQUIRED librdmacm>=${LIBRDMACM_REQUIRED_VERSION})
 
 if(BUILD_TESTS OR BUILD_EXAMPLES)
-	pkg_check_modules(LIBPMEM2 REQUIRED) # libpmem2>=${LIBPMEM2_REQUIRED_VERSION})
+	pkg_check_modules(LIBPMEM2 REQUIRED libpmem2>=${LIBPMEM2_REQUIRED_VERSION})
 endif()
 
 add_custom_target(checkers ALL)


### PR DESCRIPTION
pkg_check_modules() requires `moduleSpec` name,
otherwise it prints out the error message:
```
-- Checking for modules ''
Please specify at least one package name on the command line.
```

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/pmem/rpma/10)
<!-- Reviewable:end -->
