### PR TITLE
common: adjust push-image.sh script to GHA CI

### DIFF
--- a/.github/workflows/gha.yml
+++ b/.github/workflows/gha.yml
@@ -38,4 +38,4 @@ jobs:
          run: cd $WORKDIR && ${{ matrix.CONFIG }} ./build.sh
 
        - name: Push the image
-         run: cd $WORKDIR && source ./set-vars.sh && ${{ matrix.CONFIG }} /bin/bash -c "if [[ -f XXX_DISABLE_${CI_FILE_PUSH_IMAGE_TO_REPO} ]]; then images/push-image.sh $OS-$OS_VER; fi"
+         run: cd $WORKDIR && source ./set-vars.sh && ${{ matrix.CONFIG }} /bin/bash -c "if [[ -f XXX_DISABLE_${CI_FILE_PUSH_IMAGE_TO_REPO} ]]; then images/push-image.sh; fi"

--- a/.travis.yml
+++ b/.travis.yml
@@ -28,4 +28,4 @@ script:
 
 after_success:
   - source ./set-vars.sh
-  - if [[ -f $CI_FILE_PUSH_IMAGE_TO_REPO ]]; then ./images/push-image.sh $OS-$OS_VER; fi
+  - if [[ -f $CI_FILE_PUSH_IMAGE_TO_REPO ]]; then ./images/push-image.sh; fi

--- a/utils/docker/images/push-image.sh
+++ b/utils/docker/images/push-image.sh
@@ -5,8 +5,7 @@
 #
 
 #
-# push-image.sh <OS-VER> - pushes the Docker image tagged with OS-VER
-#                          to the Docker Hub.
+# push-image.sh - pushes the Docker image to the Docker Hub.
 #
 # The script utilizes $DOCKERHUB_USER and $DOCKERHUB_PASSWORD variables to log in to
 # Docker Hub. The variables can be set in the Travis project's configuration
@@ -17,26 +16,28 @@ set -e
 
 source $(dirname $0)/../set-ci-vars.sh
 
-function usage {
-	echo "Usage:"
-	echo "    push-image.sh <OS-VER>"
-	echo "where <OS-VER>, for example, can be 'fedora-30', provided " \
-		"a Docker image tagged with ${DOCKERHUB_REPO}:0.1-fedora-30 exists " \
-		"locally."
-}
-
-# Check if the first argument is nonempty
-if [[ -z "$1" ]]; then
-	usage
+if [[ -z "$OS" ]]; then
+	echo "OS environment variable is not set"
 	exit 1
 fi
 
-# Check if the image tagged with ${DOCKERHUB_REPO}:0.1-OS-VER exists locally
-if [[ ! $(docker images -a | awk -v pattern="^${DOCKERHUB_REPO}:0.1-$1\$" \
+if [[ -z "$OS_VER" ]]; then
+	echo "OS_VER environment variable is not set"
+	exit 1
+fi
+
+if [[ -z "${DOCKERHUB_REPO}" ]]; then
+	echo "DOCKERHUB_REPO environment variable is not set"
+	exit 1
+fi
+
+TAG="0.1-${OS}-${OS_VER}"
+
+# Check if the image tagged with pmdk/OS-VER exists locally
+if [[ ! $(docker images -a | awk -v pattern="^${DOCKERHUB_REPO}:${TAG}\$" \
 	'$1":"$2 ~ pattern') ]]
 then
-	echo "ERROR: wrong argument."
-	usage
+	echo "ERROR: Docker image tagged ${DOCKERHUB_REPO}:${TAG} does not exists locally."
 	exit 1
 fi
 
@@ -44,4 +45,4 @@ fi
 docker login -u="$DOCKERHUB_USER" -p="$DOCKERHUB_PASSWORD"
 
 # Push the image to the repository
-docker push ${DOCKERHUB_REPO}:0.1-$1
+docker push ${DOCKERHUB_REPO}:${TAG}


### PR DESCRIPTION
The 'push-image.sh' script is called in the following way now:

$ push-image.sh $OS-$OS_VER

but 'OS' and 'OS_VER' variables cannot be set in command line
in GHA yaml script, so value of tag '$' has to be set manually
inside the script.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/pmem/rpma/22)
<!-- Reviewable:end -->
