### PR TITLE
rpma: introduce rpma_err_get_provider_error()

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -16,6 +16,7 @@ add_check_whitespace(src
 set(SOURCES
 	common/alloc.c
 	librpma.c
+	rpma_err.c
 	rpma.c)
 
 add_library(rpma SHARED ${SOURCES})

--- a/src/include/librpma.h
+++ b/src/include/librpma.h
@@ -26,6 +26,7 @@
 
 #define RPMA_E_UNKNOWN			(-100000)
 #define RPMA_E_NOSUPP			(-100001)
+#define RPMA_E_PROVIDER			(-100002)
 
 /* picking up an RDMA-capable device */
 
@@ -169,8 +170,13 @@ int rpma_conn_next_completion(struct rpma_conn *conn,
 /* error handling */
 
 /** 3
- * rpma_errormsg - return the last error message
+ * rpma_err_get_provider_error - return the last provider error
  */
-const char *rpma_errormsg(void);
+int rpma_err_get_provider_error(void);
+
+/** 3
+ * rpma_err_get_msg - return the last error message
+ */
+const char *rpma_err_get_msg(void);
 
 #endif /* LIBRPMA_H */

--- a/src/librpma.c
+++ b/src/librpma.c
@@ -28,12 +28,3 @@ __attribute__((destructor)) static void
 librpma_fini(void)
 {
 }
-
-/*
- * rpma_errormsg -- return last error message
- */
-const char *
-rpma_errormsg(void)
-{
-	return "";
-}

--- a/src/librpma.map
+++ b/src/librpma.map
@@ -19,7 +19,8 @@ LIBRPMA_1.0 {
 		rpma_ep_listen;
 		rpma_ep_next_conn_req;
 		rpma_ep_shutdown;
-		rpma_errormsg;
+		rpma_err_get_msg;
+		rpma_err_get_provider_error;
 		rpma_mr_dereg;
 		rpma_mr_reg;
 		rpma_peer_delete;

--- a/src/rpma_err.c
+++ b/src/rpma_err.c
@@ -1,0 +1,32 @@
+/*
+ * SPDX-License-Identifier: BSD-3-Clause
+ * Copyright 2019-2020, Intel Corporation
+ */
+
+/*
+ * rpma_err.c -- error-handling related librpma definitions
+ */
+
+#include "rpma_err.h"
+
+#include "librpma.h"
+
+int Rpma_provider_error = 0;
+
+/*
+ * rpma_err_get_provider_error -- return the last provider error
+ */
+int
+rpma_err_get_provider_error(void)
+{
+	return Rpma_provider_error;
+}
+
+/*
+ * rpma_err_get_msg -- return the last error message
+ */
+const char *
+rpma_err_get_msg(void)
+{
+	return "";
+}

--- a/src/rpma_err.h
+++ b/src/rpma_err.h
@@ -1,0 +1,15 @@
+/*
+ * SPDX-License-Identifier: BSD-3-Clause
+ * Copyright 2020, Intel Corporation
+ */
+
+/*
+ * rpma_err.h -- internal definitions for librpma error handling
+ */
+
+#ifndef LIBRPMA_ERR_H
+#define LIBRPMA_ERR_H 1
+
+extern int Rpma_provider_error;
+
+#endif /* LIBRPMA_ERR_H */


### PR DESCRIPTION
+ rename rpma_errormsg() to rpma_err_get_msg()

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/pmem/rpma/34)
<!-- Reviewable:end -->
