### PR TITLE
common: add missing 'file' package to Fedora Docker image

### DIFF
--- a/utils/docker/images/Dockerfile.fedora-31
+++ b/utils/docker/images/Dockerfile.fedora-31
@@ -34,6 +34,7 @@ ENV VALGRIND_DEPS "\
 # RPMA deps
 ENV RPMA_DEPS "\
 	cmake \
+	file \
 	txt2man \
 	groff \
 	graphviz \


### PR DESCRIPTION
It fixes following bug:
```
Checking copyright headers of modified files only...
../utils/check_license/check-headers.sh: line 103: file: command not found
```

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/pmem/rpma/56)
<!-- Reviewable:end -->
