### PR TITLE
common: ignore src/common/ files in checking code coverage

### DIFF
--- a/.codecov.yml
+++ b/.codecov.yml
@@ -2,8 +2,8 @@ ignore:
   - cmake/
   - doc/
   - examples/
+  - src/common/
   - src/valgrind/
-  - src/sys/
   - tests/
   - utils/
 


### PR DESCRIPTION
It increases code coverage by 73.11% ! ;-)
(from 17.12% to 90.24%)

---
<!-- Reviewable:start -->
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/pmem/rpma/67)
<!-- Reviewable:end -->
