### PR TITLE
common: push Docker images from GHA instead of Travis CI

### DIFF
--- a/.github/workflows/gha.yml
+++ b/.github/workflows/gha.yml
@@ -1,9 +1,10 @@
 #
-# The 'XXX_DISABLE_' suffix is used twice in this file to disable two actions:
-# 1) XXX_DISABLE_${CI_FILE_PUSH_IMAGE_TO_REPO} - disables pushing the rebuilt Docker image and
-# 2) XXX_DISABLE_AUTO_DOC_UPDATE - disables making pull requests with the update of documentation.
-# Those two actions are disabled, because they conflict with the same ones run on Travis.
-# Only one CI (Travis or GitHub Actions) can run them at the time, so they can be enabled here,
+# The 'XXX_DISABLE_' suffix is used only once in this file:
+#
+# XXX_DISABLE_AUTO_DOC_UPDATE - disables making pull requests with the update of documentation.
+#
+# This action is disabled, because it conflicts with the same one run on Travis.
+# Only one CI (Travis or GitHub Actions) can run it at the time, so it can be enabled here,
 # when we decide to switch from Travis to GitHub Actions. The 'XXX_DISABLE_' suffix should be removed then.
 #
 
@@ -19,6 +20,8 @@ jobs:
     name: Linux
     runs-on: ubuntu-latest
     env:
+      DOCKERHUB_USER:          ${{ secrets.DOCKERHUB_USER }}
+      DOCKERHUB_PASSWORD:      ${{ secrets.DOCKERHUB_PASSWORD }}
       HOST_WORKDIR:   /home/runner/work/rpma/rpma
       WORKDIR:        utils/docker
     strategy:
@@ -38,4 +41,4 @@ jobs:
          run: cd $WORKDIR && ${{ matrix.CONFIG }} ./build.sh
 
        - name: Push the image
-         run: cd $WORKDIR && source ./set-vars.sh && ${{ matrix.CONFIG }} /bin/bash -c "if [[ -f XXX_DISABLE_${CI_FILE_PUSH_IMAGE_TO_REPO} ]]; then images/push-image.sh; fi"
+         run: cd $WORKDIR && source ./set-vars.sh && ${{ matrix.CONFIG }} /bin/bash -c "if [[ -f ${CI_FILE_PUSH_IMAGE_TO_REPO} ]]; then images/push-image.sh; fi"

--- a/.travis.yml
+++ b/.travis.yml
@@ -12,8 +12,8 @@ env:
     - GITHUB_REPO=pmem/rpma
     - DOCKERHUB_REPO=pmem/rpma
   matrix:
-    - OS=ubuntu OS_VER=19.10 TYPE=normal PUSH_IMAGE=1
-    - OS=fedora OS_VER=31    TYPE=normal PUSH_IMAGE=1 AUTO_DOC_UPDATE=1
+    - OS=ubuntu OS_VER=19.10 TYPE=normal
+    - OS=fedora OS_VER=31    TYPE=normal AUTO_DOC_UPDATE=1
     - OS=ubuntu OS_VER=19.10 TYPE=normal COVERAGE=1
     - OS=ubuntu OS_VER=19.10 TYPE=coverity
 
@@ -25,7 +25,3 @@ before_install:
 
 script:
   - ./build.sh
-
-after_success:
-  - source ./set-vars.sh
-  - if [[ -f $CI_FILE_PUSH_IMAGE_TO_REPO ]]; then ./images/push-image.sh; fi

--- a/utils/docker/images/push-image.sh
+++ b/utils/docker/images/push-image.sh
@@ -7,9 +7,9 @@
 #
 # push-image.sh - pushes the Docker image to the Docker Hub.
 #
-# The script utilizes $DOCKERHUB_USER and $DOCKERHUB_PASSWORD variables to log in to
-# Docker Hub. The variables can be set in the Travis project's configuration
-# for automated builds.
+# The script utilizes $DOCKERHUB_USER and $DOCKERHUB_PASSWORD variables
+# to log in to Docker Hub. The variables can be set in the CI project's
+# configuration for automated builds.
 #
 
 set -e


### PR DESCRIPTION
Push Docker images from GHA instead of Travis CI,
because GHA builds finish faster.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/pmem/rpma/74)
<!-- Reviewable:end -->
