### PR TITLE
test: make the 'test-rpma-utils' library static

### DIFF
--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -32,7 +32,7 @@ if(LIBUNWIND_FOUND)
 	target_compile_definitions(test_backtrace PUBLIC USE_LIBUNWIND=1)
 endif()
 
-add_library(test-rpma-utils OBJECT
+add_library(test-rpma-utils STATIC
        ${LIBRPMA_SOURCE_DIR}/rpma_err.c
        ${LIBRPMA_SOURCE_DIR}/common/out.c
        ${LIBRPMA_SOURCE_DIR}/common/util.c)


### PR DESCRIPTION
It fixes the following error occurring on openSUSE Leap and CentOS 8:
```
CMake Error at tests/info-test/CMakeLists.txt:12 (target_link_libraries):
  Target "test-rpma-utils" of type OBJECT_LIBRARY may not be linked into
  another target.  One may link only to STATIC or SHARED libraries, or to
  executables with the ENABLE_EXPORTS property set.
```

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/pmem/rpma/77)
<!-- Reviewable:end -->
