### PR TITLE
rpma: rpma_conn_req_from_cm_event()/_delete() implementation & unit tests

### DIFF
--- a/examples/connection/connection-client.c
+++ b/examples/connection/connection-client.c
@@ -44,7 +44,7 @@ main(int argc, char *argv[])
 
 	ret = rpma_conn_req_new(peer, addr, service, &req);
 	assert(ret == 0);
-	ret = rpma_conn_req_connect(req, NULL, NULL, 0, &conn);
+	ret = rpma_conn_req_connect(&req, NULL, 0, &conn);
 	assert(ret == 0);
 
 	/* wait for the connection to establish */

--- a/examples/connection/connection-server.c
+++ b/examples/connection/connection-server.c
@@ -45,7 +45,7 @@ main(int argc, char *argv[])
 	assert(ret == 0);
 	ret = rpma_ep_next_conn_req(ep, &req);
 	assert(ret == 0);
-	ret = rpma_conn_req_connect(req, NULL, NULL, 0, &conn);
+	ret = rpma_conn_req_connect(&req, NULL, 0, &conn);
 	assert(ret == 0);
 
 	/* wait for the connection to establish */

--- a/src/conn_req.c
+++ b/src/conn_req.c
@@ -8,6 +8,7 @@
  */
 
 #include "cmocka_alloc.h"
+#include "conn.h"
 #include "conn_req.h"
 #include "out.h"
 #include "peer.h"
@@ -18,15 +19,22 @@ struct rpma_conn_req {
 	struct rdma_cm_event *edata;
 	/* CM ID of the connection request */
 	struct rdma_cm_id *id;
+	/* completion queue of the CM ID */
+	struct ibv_cq *cq;
 };
 
 /*
- * rpma_conn_req_from_id -- allocate a new conn_req object from CM ID
+ * rpma_conn_req_from_id -- allocate a new conn_req object from CM ID and equip
+ * the latter with QP and CQ
  */
 static int
 rpma_conn_req_from_id(struct rpma_peer *peer, struct rdma_cm_id *id,
 		struct rpma_conn_req **req)
 {
+	ASSERTne(peer, NULL);
+	ASSERTne(id, NULL);
+	ASSERTne(req, NULL);
+
 	/* create a CQ */
 	struct ibv_cq *cq = ibv_create_cq(id->verbs, RPMA_DEFAULT_Q_SIZE,
 				NULL /* cq_context */,
@@ -49,7 +57,9 @@ rpma_conn_req_from_id(struct rpma_peer *peer, struct rdma_cm_id *id,
 		goto err_destroy_qp;
 	}
 
+	(*req)->edata = NULL;
 	(*req)->id = id;
+	(*req)->cq = cq;
 
 	return 0;
 
@@ -69,12 +79,24 @@ err_destroy_cq:
  * rpma_conn_req_from_id and add the event to conn_req
  */
 int
-rpma_conn_req_from_cm_event(struct rpma_peer *peer, struct rdma_cm_event *event,
-		struct rpma_conn_req **req)
+rpma_conn_req_from_cm_event(struct rpma_peer *peer, struct rdma_cm_event *edata,
+		struct rpma_conn_req **req_ptr)
 {
-	(void) rpma_conn_req_from_id;
+	if (peer == NULL || edata == NULL || req_ptr == NULL)
+		return RPMA_E_INVAL;
 
-	return RPMA_E_NOSUPP;
+	if (edata->event != RDMA_CM_EVENT_CONNECT_REQUEST)
+		return RPMA_E_INVAL;
+
+	struct rpma_conn_req *req = NULL;
+	int ret = rpma_conn_req_from_id(peer, edata->id, &req);
+	if (ret)
+		return ret;
+
+	req->edata = edata;
+	*req_ptr = req;
+
+	return 0;
 }
 
 /* public librpma API */
@@ -97,18 +119,81 @@ rpma_conn_req_new(struct rpma_peer *peer, const char *addr, const char *service,
  * or rdma_accept to transform rpma_conn_req into rpma_conn
  */
 int
-rpma_conn_req_connect(struct rpma_conn_req *req, struct rpma_conn_cfg *ccfg,
-		const void *private_data, uint8_t private_data_len,
-		struct rpma_conn **conn)
+rpma_conn_req_connect(struct rpma_conn_req **req_ptr, const void *private_data,
+		uint8_t private_data_len, struct rpma_conn **conn)
 {
 	return RPMA_E_NOSUPP;
 }
 
 /*
- * rpma_conn_req_delete -- XXX teardown of the conn_req object
+ * rpma_conn_req_delete -- destroy QP and CQ of the CM ID and reject the
+ * connection or XXX. Finally, free the connection request object.
  */
 int
-rpma_conn_req_delete(struct rpma_conn_req **req)
+rpma_conn_req_delete(struct rpma_conn_req **req_ptr)
 {
-	return RPMA_E_NOSUPP;
+	if (req_ptr == NULL)
+		return RPMA_E_INVAL;
+
+	struct rpma_conn_req *req = *req_ptr;
+	if (req == NULL)
+		return 0;
+
+	int ret = 0;
+
+	rdma_destroy_qp(req->id);
+
+	Rpma_provider_error = ibv_destroy_cq(req->cq);
+	if (Rpma_provider_error) {
+		ret = RPMA_E_PROVIDER;
+		goto err_reject_or_XXX;
+	}
+
+	if (req->edata) {
+		if (rdma_reject(req->id,
+				NULL /* private data */,
+				0 /* private data len */)) {
+			Rpma_provider_error = errno;
+			ret = RPMA_E_PROVIDER;
+			goto err_ack;
+		}
+
+		if (rdma_ack_cm_event(req->edata)) {
+			Rpma_provider_error = errno;
+			ret = RPMA_E_PROVIDER;
+			goto err_free;
+		}
+	} else {
+		/*
+		 * XXX to be implemented when rpma_conn_req_new() will be
+		 * ready
+		 */
+		ASSERT(0);
+	}
+
+	Free(req);
+	*req_ptr = NULL;
+
+	return 0;
+
+err_reject_or_XXX:
+	if (req->edata == NULL) {
+		/*
+		 * XXX to be implemented when rpma_conn_req_new() will be
+		 * ready
+		 */
+		ASSERT(0);
+	}
+
+	/* error path when req->edata != NULL */
+	(void) rdma_reject(req->id, NULL, 0);
+
+err_ack:
+	(void) rdma_ack_cm_event(req->edata);
+
+err_free:
+	Free(req);
+	*req_ptr = NULL;
+
+	return ret;
 }

--- a/src/conn_req.h
+++ b/src/conn_req.h
@@ -16,7 +16,10 @@
 
 #define RPMA_DEFAULT_TIMEOUT 1000 /* ms */
 
-/* for the simplicity sake, it is assumed all CQ/SQ/RQ sizes are equal */
+/*
+ * For the simplicity sake, it is assumed all CQ/SQ/RQ sizes are equal.
+ * XXX Later on, it should be configurable on a per-connection basis.
+ */
 #define RPMA_DEFAULT_Q_SIZE 10
 
 /* the maximum number of scatter/gather elements in any Work Request */
@@ -25,7 +28,15 @@
 /* the maximum message size (in bytes) that can be posted inline */
 #define RPMA_MAX_INLINE_DATA 0
 
+/*
+ * ERRORS
+ * rpma_conn_req_from_cm_event() can fail with the following errors:
+ *
+ * - RPMA_E_INVAL - peer, event or req_ptr is NULL
+ * - RPMA_E_INVAL - event is not RDMA_CM_EVENT_CONNECT_REQUEST
+ * - RPMA_E_PROVIDER - ibv_create_cq(3) or rdma_create_qp(3) failed
+ */
 int rpma_conn_req_from_cm_event(struct rpma_peer *peer,
-		struct rdma_cm_event *event, struct rpma_conn_req **req);
+		struct rdma_cm_event *event, struct rpma_conn_req **req_ptr);
 
 #endif /* LIBRPMA_CONN_REQ_H */

--- a/src/include/librpma.h
+++ b/src/include/librpma.h
@@ -221,7 +221,6 @@ int rpma_conn_delete(struct rpma_conn **conn_ptr);
 
 /* incoming / outgoing connection request */
 
-struct rpma_conn_cfg;
 struct rpma_conn_req;
 
 /** 3
@@ -238,19 +237,28 @@ int rpma_conn_req_new(struct rpma_peer *peer, const char *addr,
 	const char *service, struct rpma_conn_req **req);
 
 /** 3
- * rpma_conn_req_delete - XXX
+ * rpma_conn_req_delete - delete the connection request
  *
  * SYNOPSIS
  *
  *	#include <librpma.h>
  *
- *	int rpma_conn_req_delete(struct rpma_conn_req **req);
+ *	int rpma_conn_req_delete(struct rpma_conn_req **req_ptr);
  *
  * DESCRIPTION
- * Delete the connection request both incoming and
- * outgoing.
+ * Delete the connection request both incoming and outgoing.
+ *
+ * ERRORS
+ * rpma_conn_req_delete() can fail with the following errors:
+ *
+ * - RPMA_E_INVAL - req_ptr is NULL
+ * - RPMA_E_PROVIDER - destroying the completion queue failed
+ * - RPMA_E_PROVIDER - rdma_destroy_qp(3) or ibv_destroy_cq(3) failed
+ * - RPMA_E_PROVIDER - rdma_reject(3) or rdma_ack_cm_event(3) failed
+ *                     (passive side only)
+ * - XXX to be implemented when rpma_conn_req_new() will be ready
  */
-int rpma_conn_req_delete(struct rpma_conn_req **req);
+int rpma_conn_req_delete(struct rpma_conn_req **req_ptr);
 
 /** 3
  * rpma_conn_req_connect - XXX
@@ -260,16 +268,16 @@ int rpma_conn_req_delete(struct rpma_conn_req **req);
  *	#include <librpma.h>
  *
  *	int rpma_conn_req_connect(struct rpma_conn_req *req,
- *		struct rpma_conn_cfg *ccfg, const void *private_data,
- *		uint8_t private_data_len, struct rpma_conn **conn);
+ *		const void *private_data, uint8_t private_data_len,
+ *		struct rpma_conn **conn);
  *
  * DESCRIPTION
  * Connect the connection request both incoming and
  * outgoing.
  */
-int rpma_conn_req_connect(struct rpma_conn_req *req, struct rpma_conn_cfg *ccfg,
+int rpma_conn_req_connect(struct rpma_conn_req **req_ptr,
 	const void *private_data, uint8_t private_data_len,
-	struct rpma_conn **conn);
+	struct rpma_conn **conn_ptr);
 
 /* server-side setup */
 

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -49,6 +49,7 @@ add_check_whitespace(tests-all
        ${CMAKE_CURRENT_SOURCE_DIR}/*/*.c)
 
 add_subdirectory(conn-test)
+add_subdirectory(conn_req-test)
 add_subdirectory(ep-test)
 add_subdirectory(error-test)
 add_subdirectory(info-test)

--- a/tests/conn_req-test/CMakeLists.txt
+++ b/tests/conn_req-test/CMakeLists.txt
@@ -1,0 +1,18 @@
+#
+# SPDX-License-Identifier: BSD-3-Clause
+# Copyright 2020, Intel Corporation
+#
+
+include(../cmake/ctest_helpers.cmake)
+
+build_test_src(conn_req-test
+       conn_req-test.c
+       ${LIBRPMA_SOURCE_DIR}/conn_req.c)
+
+target_link_libraries(conn_req-test test-rpma-utils)
+
+set_target_properties(conn_req-test
+       PROPERTIES
+       LINK_FLAGS "-Wl,--wrap=_test_malloc")
+
+add_test_generic(NAME conn_req-test TRACERS none)

--- a/tests/conn_req-test/conn_req-test.c
+++ b/tests/conn_req-test/conn_req-test.c
@@ -1,0 +1,684 @@
+/*
+ * SPDX-License-Identifier: BSD-3-Clause
+ * Copyright 2020, Intel Corporation
+ */
+
+/*
+ * conn_req-test.c -- a connection request unit test
+ */
+
+#include <infiniband/verbs.h>
+
+#include "cmocka_headers.h"
+#include "conn_req.h"
+#include "rpma_err.h"
+
+/* random values */
+#define MOCK_VERBS	(struct ibv_context *)0x4E4B
+#define MOCK_CQ		(struct ibv_cq *)0x00C0
+#define MOCK_PEER	(struct rpma_peer *)0xFEEF
+
+#define CM_EVENT_CONNECTION_REQUEST_INIT \
+	{NULL, NULL, RDMA_CM_EVENT_CONNECT_REQUEST, 0, {{0}}}
+
+#define CM_EVENT_CONNECT_ERROR_INIT \
+	{NULL, NULL, RDMA_CM_EVENT_CONNECT_ERROR, 0, {{0}}}
+
+#define NO_ERROR 0
+
+/* mocks */
+
+/*
+ * rpma_conn_new -- rpma_conn_new()  mock
+ */
+int
+rpma_conn_new(struct rdma_cm_id *id, struct rdma_event_channel *evch,
+		struct ibv_cq *cq, struct rpma_conn **conn_ptr)
+{
+	check_expected_ptr(id);
+	check_expected_ptr(evch);
+	check_expected_ptr(cq);
+
+	assert_non_null(conn_ptr);
+
+	struct rpma_conn *conn = mock_type(struct rpma_conn *);
+	if (!conn) {
+		return mock_type(int);
+	}
+
+	*conn_ptr = conn;
+	return 0;
+}
+
+/*
+ * rpma_conn_delete -- rpma_conn_delete()  mock
+ */
+int
+rpma_conn_delete(struct rpma_conn **conn_ptr)
+{
+	assert_non_null(conn_ptr);
+
+	struct rpma_conn *conn = *conn_ptr;
+	check_expected_ptr(conn);
+
+	int result = mock_type(int);
+	if (result)
+		return result;
+
+	*conn_ptr = NULL;
+	return 0;
+}
+
+/*
+ * ibv_create_cq -- ibv_create_cq() mock
+ */
+struct ibv_cq *
+ibv_create_cq(struct ibv_context *context, int cqe, void *cq_context,
+		struct ibv_comp_channel *channel, int comp_vector)
+{
+	assert_ptr_equal(context, MOCK_VERBS);
+	assert_int_equal(cqe, RPMA_DEFAULT_Q_SIZE);
+	assert_null(channel);
+	assert_int_equal(comp_vector, 0);
+
+	struct ibv_cq *cq = mock_type(struct ibv_cq *);
+	if (!cq) {
+		errno = mock_type(int);
+		return NULL;
+	}
+
+	return cq;
+}
+
+/*
+ * ibv_destroy_cq -- ibv_destroy_cq() mock
+ */
+int
+ibv_destroy_cq(struct ibv_cq *cq)
+{
+	assert_int_equal(cq, MOCK_CQ);
+
+	return mock_type(int);
+}
+
+/*
+ * rpma_peer_create_qp -- rpma_peer_create_qp() mock
+ */
+int
+rpma_peer_create_qp(struct rpma_peer *peer, struct rdma_cm_id *id,
+		struct ibv_cq *cq)
+{
+	assert_ptr_equal(peer, MOCK_PEER);
+	check_expected_ptr(id);
+	assert_ptr_equal(cq, MOCK_CQ);
+
+	int result = mock_type(int);
+	if (result == RPMA_E_PROVIDER)
+		Rpma_provider_error = mock_type(int);
+
+	return result;
+}
+
+/*
+ * rdma_destroy_qp -- rdma_destroy_qp() mock
+ */
+void
+rdma_destroy_qp(struct rdma_cm_id *id)
+{
+	check_expected_ptr(id);
+}
+
+/*
+ * rdma_reject -- rdma_reject() mock
+ */
+int
+rdma_reject(struct rdma_cm_id *id, const void *private_data,
+		uint8_t private_data_len)
+{
+	check_expected_ptr(id);
+	assert_null(private_data);
+	assert_int_equal(private_data_len, 0);
+
+	errno = mock_type(int);
+	if (errno)
+		return -1;
+
+	return 0;
+}
+
+/*
+ * rdma_ack_cm_event -- rdma_ack_cm_event() mock
+ */
+int
+rdma_ack_cm_event(struct rdma_cm_event *event)
+{
+	check_expected_ptr(event);
+
+	errno = mock_type(int);
+	if (errno)
+		return -1;
+
+	return 0;
+}
+
+void *__real__test_malloc(size_t size);
+
+/*
+ * __wrap__test_malloc -- malloc() mock
+ */
+void *
+__wrap__test_malloc(size_t size)
+{
+	errno = mock_type(int);
+
+	if (errno)
+		return NULL;
+
+	return __real__test_malloc(size);
+}
+
+/* tests */
+
+/*
+ * from_cm_event_test_peer_NULL -- NULL peer is invalid
+ */
+static void
+from_cm_event_test_peer_NULL(void **unused)
+{
+	/* run test */
+	struct rdma_cm_event event = CM_EVENT_CONNECTION_REQUEST_INIT;
+	struct rpma_conn_req *req = NULL;
+	int ret = rpma_conn_req_from_cm_event(NULL, &event, &req);
+
+	/* verify the results */
+	assert_int_equal(ret, RPMA_E_INVAL);
+	assert_null(req);
+}
+
+/*
+ * from_cm_event_test_edata_NULL -- NULL edata is invalid
+ */
+static void
+from_cm_event_test_edata_NULL(void **unused)
+{
+	/* run test */
+	struct rpma_conn_req *req = NULL;
+	int ret = rpma_conn_req_from_cm_event(MOCK_PEER, NULL, &req);
+
+	/* verify the results */
+	assert_int_equal(ret, RPMA_E_INVAL);
+	assert_null(req);
+}
+
+/*
+ * from_cm_event_test_req_ptr_NULL -- NULL req_ptr is invalid
+ */
+static void
+from_cm_event_test_req_ptr_NULL(void **unused)
+{
+	/* run test */
+	struct rdma_cm_event event = CM_EVENT_CONNECTION_REQUEST_INIT;
+	int ret = rpma_conn_req_from_cm_event(MOCK_PEER, &event, NULL);
+
+	/* verify the results */
+	assert_int_equal(ret, RPMA_E_INVAL);
+}
+
+/*
+ * from_cm_event_test_peer_NULL_edata_NULL_req_ptr_NULL -- NULL peer,
+ * NULL edata and NULL req_ptr are not valid
+ */
+static void
+from_cm_event_test_peer_NULL_edata_NULL_req_ptr_NULL(void **unused)
+{
+	/* run test */
+	int ret = rpma_conn_req_from_cm_event(NULL, NULL, NULL);
+
+	/* verify the results */
+	assert_int_equal(ret, RPMA_E_INVAL);
+}
+
+/*
+ * from_cm_event_test_RDMA_CM_EVENT_CONNECT_ERROR -- edata of type
+ * RDMA_CM_EVENT_CONNECT_ERROR
+ */
+static void
+from_cm_event_test_RDMA_CM_EVENT_CONNECT_ERROR(void **unused)
+{
+	/* run test */
+	struct rdma_cm_event event = CM_EVENT_CONNECT_ERROR_INIT;
+	struct rpma_conn_req *req = NULL;
+	int ret = rpma_conn_req_from_cm_event(MOCK_PEER, &event, &req);
+
+	/* verify the results */
+	assert_int_equal(ret, RPMA_E_INVAL);
+	assert_null(req);
+}
+
+/*
+ * from_cm_event_test_create_cq_EAGAIN -- ibv_create_cq() fails with EAGAIN
+ */
+static void
+from_cm_event_test_create_cq_EAGAIN(void **unused)
+{
+	/* configure mocks */
+	struct rdma_cm_event event = CM_EVENT_CONNECTION_REQUEST_INIT;
+	struct rdma_cm_id id = {0};
+	id.verbs = MOCK_VERBS;
+	event.id = &id;
+	will_return(ibv_create_cq, NULL);
+	will_return(ibv_create_cq, EAGAIN);
+
+	/* run test */
+	struct rpma_conn_req *req = NULL;
+	int ret = rpma_conn_req_from_cm_event(MOCK_PEER, &event, &req);
+
+	/* verify the results */
+	assert_int_equal(ret, RPMA_E_PROVIDER);
+	assert_int_equal(rpma_err_get_provider_error(), EAGAIN);
+	assert_null(req);
+}
+
+/*
+ * from_cm_event_test_peer_create_qp_E_PROVIDER_EAGAIN -- rpma_peer_create_qp()
+ * fails with RPMA_E_PROVIDER+EAGAIN
+ */
+static void
+from_cm_event_test_peer_create_qp_E_PROVIDER_EAGAIN(void **unused)
+{
+	/* configure mocks */
+	struct rdma_cm_event event = CM_EVENT_CONNECTION_REQUEST_INIT;
+	struct rdma_cm_id id = {0};
+	id.verbs = MOCK_VERBS;
+	event.id = &id;
+	will_return(ibv_create_cq, MOCK_CQ);
+	expect_value(rpma_peer_create_qp, id, &id);
+	will_return(rpma_peer_create_qp, RPMA_E_PROVIDER);
+	will_return(rpma_peer_create_qp, EAGAIN);
+	will_return(ibv_destroy_cq, NO_ERROR);
+
+	/* run test */
+	struct rpma_conn_req *req = NULL;
+	int ret = rpma_conn_req_from_cm_event(MOCK_PEER, &event, &req);
+
+	/* verify the results */
+	assert_int_equal(ret, RPMA_E_PROVIDER);
+	assert_int_equal(rpma_err_get_provider_error(), EAGAIN);
+	assert_null(req);
+}
+
+/*
+ * from_cm_event_test_create_qp_EAGAIN_destroy_cq_EIO -- rpma_peer_create_qp()
+ * fail with RPMA_E_PROVIDER+EAGAIN followed by ibv_destroy_cq() fail with EIO
+ */
+static void
+from_cm_event_test_create_qp_EAGAIN_destroy_cq_EIO(
+		void **unused)
+{
+	/* configure mocks */
+	struct rdma_cm_event event = CM_EVENT_CONNECTION_REQUEST_INIT;
+	struct rdma_cm_id id = {0};
+	id.verbs = MOCK_VERBS;
+	event.id = &id;
+	will_return(ibv_create_cq, MOCK_CQ);
+	expect_value(rpma_peer_create_qp, id, &id);
+	will_return(rpma_peer_create_qp, RPMA_E_PROVIDER); /* first error */
+	will_return(rpma_peer_create_qp, EAGAIN);
+	will_return(ibv_destroy_cq, EIO); /* second error */
+
+	/* run test */
+	struct rpma_conn_req *req = NULL;
+	int ret = rpma_conn_req_from_cm_event(MOCK_PEER, &event, &req);
+
+	/* verify the results */
+	assert_int_equal(ret, RPMA_E_PROVIDER);
+	assert_int_equal(rpma_err_get_provider_error(), EAGAIN);
+	assert_null(req);
+}
+
+/*
+ * from_cm_event_test_malloc_ENOMEM -- malloc() fails with ENOMEM
+ */
+static void
+from_cm_event_test_malloc_ENOMEM(void **unused)
+{
+	/* configure mocks */
+	struct rdma_cm_event event = CM_EVENT_CONNECTION_REQUEST_INIT;
+	struct rdma_cm_id id = {0};
+	id.verbs = MOCK_VERBS;
+	event.id = &id;
+	will_return(ibv_create_cq, MOCK_CQ);
+	expect_value(rpma_peer_create_qp, id, &id);
+	will_return(rpma_peer_create_qp, NO_ERROR);
+	will_return(__wrap__test_malloc, ENOMEM);
+	expect_value(rdma_destroy_qp, id, &id);
+	will_return(ibv_destroy_cq, NO_ERROR);
+
+	/* run test */
+	struct rpma_conn_req *req = NULL;
+	int ret = rpma_conn_req_from_cm_event(MOCK_PEER, &event, &req);
+
+	/* verify the results */
+	assert_int_equal(ret, RPMA_E_NOMEM);
+	assert_null(req);
+}
+
+/*
+ * from_cm_event_test_malloc_ENOMEM_destroy_cq_EAGAIN -- malloc() fail with
+ * ENOMEM followed by ibv_destroy_cq() fail with EAGAIN
+ */
+static void
+from_cm_event_test_malloc_ENOMEM_destroy_cq_EAGAIN(void **unused)
+{
+	/* configure mocks */
+	struct rdma_cm_event event = CM_EVENT_CONNECTION_REQUEST_INIT;
+	struct rdma_cm_id id = {0};
+	id.verbs = MOCK_VERBS;
+	event.id = &id;
+	will_return(ibv_create_cq, MOCK_CQ);
+	expect_value(rpma_peer_create_qp, id, &id);
+	will_return(rpma_peer_create_qp, NO_ERROR);
+	will_return(__wrap__test_malloc, ENOMEM); /* first error */
+	expect_value(rdma_destroy_qp, id, &id);
+	will_return(ibv_destroy_cq, EAGAIN); /* second error */
+
+	/* run test */
+	struct rpma_conn_req *req = NULL;
+	int ret = rpma_conn_req_from_cm_event(MOCK_PEER, &event, &req);
+
+	/* verify the results */
+	assert_int_equal(ret, RPMA_E_NOMEM);
+	assert_null(req);
+}
+
+/*
+ * all the resources used between conn_req_setup and conn_req_teardown
+ */
+struct conn_req_test_state {
+	struct rdma_cm_event event;
+	struct rdma_cm_id id;
+	struct rpma_conn_req *req;
+};
+
+/*
+ * conn_req_from_cm_event_setup -- prepare a valid rpma_conn_req object from CM
+ * event
+ */
+static int
+conn_req_from_cm_event_setup(void **cstate_ptr)
+{
+	static struct conn_req_test_state cstate = {0};
+	memset(&cstate, 0, sizeof(cstate));
+	cstate.event.event = RDMA_CM_EVENT_CONNECT_REQUEST;
+	cstate.event.id = &cstate.id;
+	cstate.id.verbs = MOCK_VERBS;
+
+	/* configure mocks */
+	will_return(ibv_create_cq, MOCK_CQ);
+	expect_value(rpma_peer_create_qp, id, &cstate.id);
+	will_return(rpma_peer_create_qp, NO_ERROR);
+	will_return(__wrap__test_malloc, NO_ERROR);
+
+	/* run test */
+	int ret = rpma_conn_req_from_cm_event(MOCK_PEER, &cstate.event,
+		&cstate.req);
+
+	/* verify the results */
+	assert_int_equal(ret, NO_ERROR);
+	assert_non_null(cstate.req);
+
+	*cstate_ptr = &cstate;
+
+	return 0;
+}
+
+/*
+ * conn_req_from_cm_event_teardown -- delete the rpma_conn_req object created
+ * from a CM event
+ */
+static int
+conn_req_from_cm_event_teardown(void **cstate_ptr)
+{
+	struct conn_req_test_state *cstate = *cstate_ptr;
+
+	/* configure mocks */
+	expect_value(rdma_destroy_qp, id, &cstate->id);
+	will_return(ibv_destroy_cq, NO_ERROR);
+	expect_value(rdma_reject, id, &cstate->id);
+	will_return(rdma_reject, NO_ERROR);
+	expect_value(rdma_ack_cm_event, event, &cstate->event);
+	will_return(rdma_ack_cm_event, NO_ERROR);
+
+	/* run test */
+	int ret = rpma_conn_req_delete(&cstate->req);
+
+	/* verify the results */
+	assert_int_equal(ret, NO_ERROR);
+	assert_null(cstate->req);
+
+	*cstate_ptr = NULL;
+
+	return 0;
+}
+
+/*
+ * conn_req_from_cm_test_lifecycle - happy day scenario
+ */
+static void
+conn_req_from_cm_test_lifecycle(void **unused)
+{
+	/*
+	 * The thing is done by conn_req_from_cm_event_setup() and
+	 * conn_req_from_cm_event_teardown().
+	 */
+}
+
+/*
+ * delete_test_req_ptr_NULL -- NULL req_ptr is invalid
+ */
+static void
+delete_test_req_ptr_NULL(void **unused)
+{
+	/* run test */
+	int ret = rpma_conn_req_delete(NULL);
+
+	/* verify the results */
+	assert_int_equal(ret, RPMA_E_INVAL);
+}
+
+/*
+ * delete_test_req_NULL -- NULL req is valid - quick exit
+ */
+static void
+delete_test_req_NULL(void **unused)
+{
+	/* run test */
+	struct rpma_conn_req *req = NULL;
+	int ret = rpma_conn_req_delete(&req);
+
+	/* verify the results */
+	assert_int_equal(ret, NO_ERROR);
+}
+
+/*
+ * delete_test_destroy_cq_EAGAIN - ibv_destroy_cq() fails with EAGAIN
+ */
+static void
+delete_test_destroy_cq_EAGAIN(void **unused)
+{
+	/* WA for cmocka/issues#47 */
+	struct conn_req_test_state *cstate = NULL;
+	assert_int_equal(conn_req_from_cm_event_setup((void **)&cstate), 0);
+	assert_non_null(cstate);
+
+	/* configure mocks */
+	expect_value(rdma_destroy_qp, id, &cstate->id);
+	will_return(ibv_destroy_cq, EAGAIN);
+	expect_value(rdma_reject, id, &cstate->id);
+	will_return(rdma_reject, NO_ERROR);
+	expect_value(rdma_ack_cm_event, event, &cstate->event);
+	will_return(rdma_ack_cm_event, NO_ERROR);
+
+	/* run test */
+	int ret = rpma_conn_req_delete(&cstate->req);
+
+	/* verify the results */
+	assert_int_equal(ret, RPMA_E_PROVIDER);
+	assert_int_equal(rpma_err_get_provider_error(), EAGAIN);
+	assert_null(cstate->req);
+}
+
+/*
+ * delete_test_destroy_cq_EAGAIN_reject_EIO_ack_EINTR - rdma_ack_cm_event()
+ * fails with EINTR after rdma_reject() failed with EIO after ibv_destroy_cq()
+ * failed with EAGAIN
+ */
+static void
+delete_test_destroy_cq_EAGAIN_reject_EIO_ack_EINTR(void **unused)
+{
+	/* WA for cmocka/issues#47 */
+	struct conn_req_test_state *cstate = NULL;
+	assert_int_equal(conn_req_from_cm_event_setup((void **)&cstate), 0);
+	assert_non_null(cstate);
+
+	/* configure mocks */
+	expect_value(rdma_destroy_qp, id, &cstate->id);
+	will_return(ibv_destroy_cq, EAGAIN);
+	expect_value(rdma_reject, id, &cstate->id);
+	will_return(rdma_reject, EIO);
+	expect_value(rdma_ack_cm_event, event, &cstate->event);
+	will_return(rdma_ack_cm_event, EINTR);
+
+	/* run test */
+	int ret = rpma_conn_req_delete(&cstate->req);
+
+	/* verify the results */
+	assert_int_equal(ret, RPMA_E_PROVIDER);
+	assert_int_equal(rpma_err_get_provider_error(), EAGAIN);
+	assert_null(cstate->req);
+}
+
+/*
+ * delete_test_reject_EAGAIN - rdma_reject() fails with EAGAIN
+ */
+static void
+delete_test_reject_EAGAIN(void **unused)
+{
+	/* WA for cmocka/issues#47 */
+	struct conn_req_test_state *cstate = NULL;
+	assert_int_equal(conn_req_from_cm_event_setup((void **)&cstate), 0);
+	assert_non_null(cstate);
+
+	/* configure mocks */
+	expect_value(rdma_destroy_qp, id, &cstate->id);
+	will_return(ibv_destroy_cq, NO_ERROR);
+	expect_value(rdma_reject, id, &cstate->id);
+	will_return(rdma_reject, EAGAIN);
+	expect_value(rdma_ack_cm_event, event, &cstate->event);
+	will_return(rdma_ack_cm_event, NO_ERROR);
+
+	/* run test */
+	int ret = rpma_conn_req_delete(&cstate->req);
+
+	/* verify the results */
+	assert_int_equal(ret, RPMA_E_PROVIDER);
+	assert_int_equal(rpma_err_get_provider_error(), EAGAIN);
+	assert_null(cstate->req);
+}
+
+/*
+ * delete_test_reject_EAGAIN_ack_EIO - rdma_ack_cm_event() fails with EIO after
+ * rdma_reject() failed with EAGAIN
+ */
+static void
+delete_test_reject_EAGAIN_ack_EIO(void **unused)
+{
+	/* WA for cmocka/issues#47 */
+	struct conn_req_test_state *cstate = NULL;
+	assert_int_equal(conn_req_from_cm_event_setup((void **)&cstate), 0);
+	assert_non_null(cstate);
+
+	/* configure mocks */
+	expect_value(rdma_destroy_qp, id, &cstate->id);
+	will_return(ibv_destroy_cq, NO_ERROR);
+	expect_value(rdma_reject, id, &cstate->id);
+	will_return(rdma_reject, EAGAIN);
+	expect_value(rdma_ack_cm_event, event, &cstate->event);
+	will_return(rdma_ack_cm_event, EIO);
+
+	/* run test */
+	int ret = rpma_conn_req_delete(&cstate->req);
+
+	/* verify the results */
+	assert_int_equal(ret, RPMA_E_PROVIDER);
+	assert_int_equal(rpma_err_get_provider_error(), EAGAIN);
+	assert_null(cstate->req);
+}
+
+/*
+ * delete_test_ack_EAGAIN - rdma_ack_cm_event() fails with EAGAIN
+ */
+static void
+delete_test_ack_EAGAIN(void **unused)
+{
+	/* WA for cmocka/issues#47 */
+	struct conn_req_test_state *cstate = NULL;
+	assert_int_equal(conn_req_from_cm_event_setup((void **)&cstate), 0);
+	assert_non_null(cstate);
+
+	/* configure mocks */
+	expect_value(rdma_destroy_qp, id, &cstate->id);
+	will_return(ibv_destroy_cq, NO_ERROR);
+	expect_value(rdma_reject, id, &cstate->id);
+	will_return(rdma_reject, NO_ERROR);
+	expect_value(rdma_ack_cm_event, event, &cstate->event);
+	will_return(rdma_ack_cm_event, EAGAIN);
+
+	/* run test */
+	int ret = rpma_conn_req_delete(&cstate->req);
+
+	/* verify the results */
+	assert_int_equal(ret, RPMA_E_PROVIDER);
+	assert_int_equal(rpma_err_get_provider_error(), EAGAIN);
+	assert_null(cstate->req);
+}
+
+int
+main(int argc, char *argv[])
+{
+	const struct CMUnitTest tests[] = {
+		/* rpma_conn_req_from_cm_event() unit tests */
+		cmocka_unit_test(from_cm_event_test_peer_NULL),
+		cmocka_unit_test(from_cm_event_test_edata_NULL),
+		cmocka_unit_test(from_cm_event_test_req_ptr_NULL),
+		cmocka_unit_test(
+			from_cm_event_test_peer_NULL_edata_NULL_req_ptr_NULL),
+		cmocka_unit_test(
+			from_cm_event_test_RDMA_CM_EVENT_CONNECT_ERROR),
+		cmocka_unit_test(from_cm_event_test_create_cq_EAGAIN),
+		cmocka_unit_test(
+			from_cm_event_test_peer_create_qp_E_PROVIDER_EAGAIN),
+		cmocka_unit_test(
+			from_cm_event_test_create_qp_EAGAIN_destroy_cq_EIO),
+		cmocka_unit_test(from_cm_event_test_malloc_ENOMEM),
+		cmocka_unit_test(
+			from_cm_event_test_malloc_ENOMEM_destroy_cq_EAGAIN),
+
+		/* rpma_conn_req_from_cm_event()/_delete() lifecycle */
+		cmocka_unit_test_setup_teardown(conn_req_from_cm_test_lifecycle,
+			conn_req_from_cm_event_setup,
+			conn_req_from_cm_event_teardown),
+
+		/* rpma_conn_req_delete() unit tests */
+		cmocka_unit_test(delete_test_req_ptr_NULL),
+		cmocka_unit_test(delete_test_req_NULL),
+		cmocka_unit_test(delete_test_destroy_cq_EAGAIN),
+		cmocka_unit_test(
+			delete_test_destroy_cq_EAGAIN_reject_EIO_ack_EINTR),
+		cmocka_unit_test(delete_test_reject_EAGAIN),
+		cmocka_unit_test(delete_test_reject_EAGAIN_ack_EIO),
+		cmocka_unit_test(delete_test_ack_EAGAIN),
+	};
+
+	return cmocka_run_group_tests(tests, NULL, NULL);
+}


### PR DESCRIPTION
Additionally:
- removal of struct rpma_conn_cfg (for now)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/pmem/rpma/82)
<!-- Reviewable:end -->
