### PR TITLE
common: add an event channel creation and migration to rpma_conn_new

### DIFF
--- a/src/conn.h
+++ b/src/conn.h
@@ -18,10 +18,10 @@
  * ERRORS
  * rpma_conn_new() can fail with the following errors:
  *
- * - RPMA_E_INVAL - id, evch, cq or conn_ptr is NULL
+ * - RPMA_E_INVAL - id, cq or conn_ptr is NULL
  * - RPMA_E_NOMEM - out of memory
  */
-int rpma_conn_new(struct rdma_cm_id *id, struct rdma_event_channel *evch,
-		struct ibv_cq *cq, struct rpma_conn **conn_ptr);
+int rpma_conn_new(struct rdma_cm_id *id, struct ibv_cq *cq,
+		struct rpma_conn **conn_ptr);
 
 #endif /* LIBRPMA_CONN_H */


### PR DESCRIPTION
A CM ID can not be migrated to a separate event channel before it is
accepted and its connection request event is ACKed. It is repacked
into a rpma_conn at this point so it is convenient for the
rpma_conn_new() function to create an event channel for a CM ID and
migrate it while it is repacking.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/pmem/rpma/89)
<!-- Reviewable:end -->
