### PR TITLE
test: variable init (fix)

### DIFF
--- a/tests/conn_req-test/conn_req-test.c
+++ b/tests/conn_req-test/conn_req-test.c
@@ -604,7 +604,7 @@ struct conn_req_test_state {
 static int
 conn_req_from_cm_event_setup(void **cstate_ptr)
 {
-	static struct conn_req_test_state cstate = {0};
+	static struct conn_req_test_state cstate = {{0}};
 	memset(&cstate, 0, sizeof(cstate));
 	cstate.event.event = RDMA_CM_EVENT_CONNECT_REQUEST;
 	cstate.event.id = &cstate.id;
@@ -996,7 +996,7 @@ struct conn_req_new_test_state {
 static int
 conn_req_new_setup(void **cstate_ptr)
 {
-	static struct conn_req_new_test_state cstate = {0};
+	static struct conn_req_new_test_state cstate = {{0}};
 	memset(&cstate, 0, sizeof(cstate));
 	cstate.id.verbs = MOCK_VERBS;
 

--- a/tests/ep-test/ep-test.c
+++ b/tests/ep-test/ep-test.c
@@ -643,7 +643,7 @@ ep_setup(void **estate_ptr)
 {
 	/* configure mocks: */
 	Mock_ctrl_defer_destruction = MOCK_CTRL_DEFER;
-	static struct ep_test_state estate = {0};
+	static struct ep_test_state estate = {{0}};
 	will_return(rdma_create_event_channel, &estate.evch);
 	will_return(rdma_create_id, &estate.cmid);
 	will_return(rpma_info_new, MOCK_INFO);


### PR DESCRIPTION
Some compilers prefer to initialize variables using double brackets.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/pmem/rpma/98)
<!-- Reviewable:end -->
