### PR TITLE
common: examples rework using a two newly introduced functions

### DIFF
--- a/examples/connection/connection-client.c
+++ b/examples/connection/connection-client.c
@@ -13,58 +13,140 @@
 
 #include <librpma.h>
 
+static void
+print_error(const char *fname, const int ret)
+{
+	int result = 0;
+
+	if (ret == RPMA_E_PROVIDER) {
+		int errnum = rpma_err_get_provider_error();
+		const char *errstr = strerror(errnum);
+		result = fprintf(stderr, "%s failed: %s (%s)\n", fname,
+				rpma_err_2str(ret), errstr);
+	} else {
+		result = fprintf(stderr, "%s failed: %s\n", fname,
+				rpma_err_2str(ret));
+	}
+
+	if (result < 0)
+		exit(-1);
+}
+
 int
 main(int argc, char *argv[])
 {
-	if (argc < 4) {
-		fprintf(stderr, "usage: %s <addr_local> <addr> <service>\n",
+	if (argc < 3) {
+		fprintf(stderr, "usage: %s <addr> <service>\n",
 			argv[0]);
-		abort();
+		exit(-1);
 	}
 
 	/* parameters */
-	char *addr_local = argv[1];
-	char *addr = argv[2];
-	char *service = argv[3];
+	char *addr = argv[1];
+	char *service = argv[2];
 
 	/* resources */
-	struct ibv_context *dev;
-	struct rpma_peer *peer;
-	struct rpma_conn_req *req;
-	struct rpma_conn *conn;
-	enum rpma_conn_event conn_event;
-	int ret;
+	struct ibv_context *dev = NULL;
+	struct rpma_peer *peer = NULL;
+	struct rpma_conn_req *req = NULL;
+	struct rpma_conn *conn = NULL;
+	enum rpma_conn_event conn_event = RPMA_CONN_UNDEFINED;
+	int ret = 0;
 
-	/* request for a connection and wait for its establishment */
-	ret = rpma_utils_get_ibv_context(addr_local,
-			RPMA_UTIL_IBV_CONTEXT_REMOTE, &dev);
-	assert(ret == 0);
+	/* obtain an IBV context for a remote IP address */
+	ret = rpma_utils_get_ibv_context(addr, RPMA_UTIL_IBV_CONTEXT_REMOTE,
+			&dev);
+	if (ret) {
+		print_error("rpma_utils_get_ibv_context", ret);
+		return -1;
+	}
 
+	/* create a new peer object */
 	ret = rpma_peer_new(dev, &peer);
-	assert(ret == 0);
+	if (ret) {
+		print_error("rpma_peer_new", ret);
+		return -1;
+	}
 
+	/* create a connection request */
 	ret = rpma_conn_req_new(peer, addr, service, &req);
-	assert(ret == 0);
+	if (ret) {
+		print_error("rpma_conn_req_new", ret);
+		goto err_peer_delete;
+	}
+
+	/* connect the connection request and obtain the connection object */
 	ret = rpma_conn_req_connect(&req, NULL, &conn);
-	assert(ret == 0);
+	if (ret) {
+		print_error("rpma_conn_req_connect", ret);
+		goto err_req_delete;
+	}
 
 	/* wait for the connection to establish */
 	ret = rpma_conn_next_event(conn, &conn_event);
-	assert(ret == 0 && conn_event == RPMA_CONN_ESTABLISHED);
+	if (ret) {
+		print_error("rpma_conn_next_event", ret);
+		goto err_conn_delete;
+	} else if (conn_event != RPMA_CONN_ESTABLISHED) {
+		fprintf(stderr, "rpma_conn_next_event returned an unexptected "
+				"event: %s\n",
+				rpma_utils_conn_event_2str(conn_event));
+		goto err_conn_delete;
+	} else {
+		fprintf(stderr, "rpma_conn_next_event returned an event: %s\n",
+				rpma_utils_conn_event_2str(conn_event));
+	}
 
 	/* here you can use the newly established connection */
 
-	/* disconnect the connection */
+	/* wait for the connection to being closed */
 	ret = rpma_conn_next_event(conn, &conn_event);
-	assert(ret == 0 && conn_event == RPMA_CONN_CLOSED);
+	if (ret) {
+		print_error("rpma_conn_next_event", ret);
+		goto err_conn_disconnect;
+	} else if (conn_event != RPMA_CONN_CLOSED) {
+		fprintf(stderr, "rpma_conn_next_event returned an unexptected "
+				"event: %s\n",
+				rpma_utils_conn_event_2str(conn_event));
+		goto err_conn_disconnect;
+	} else {
+		fprintf(stderr, "rpma_conn_next_event returned an event: %s\n",
+				rpma_utils_conn_event_2str(conn_event));
+	}
+
+	/* disconnect the connection */
 	ret = rpma_conn_disconnect(conn);
-	assert(ret == 0);
+	if (ret) {
+		print_error("rpma_conn_disconnect", ret);
+		goto err_conn_delete;
+	}
 
+	/* delete the connection object */
 	ret = rpma_conn_delete(&conn);
-	assert(ret == 0);
+	if (ret) {
+		print_error("rpma_conn_delete", ret);
+		goto err_peer_delete;
+	}
 
+	/* delete the peer object */
 	ret = rpma_peer_delete(&peer);
-	assert(ret == 0);
+	if (ret) {
+		print_error("rpma_peer_delete", ret);
+		goto err_exit;
+	}
 
 	return 0;
+
+err_conn_disconnect:
+	(void) rpma_conn_disconnect(conn);
+err_conn_delete:
+	(void) rpma_conn_delete(&conn);
+err_req_delete:
+	if (req)
+		(void) rpma_conn_req_delete(&req);
+err_peer_delete:
+	(void) rpma_peer_delete(&peer);
+
+err_exit:
+	return -1;
 }

--- a/examples/connection/connection-server.c
+++ b/examples/connection/connection-server.c
@@ -13,6 +13,25 @@
 
 #include <librpma.h>
 
+static void
+print_error(const char *fname, const int ret)
+{
+	int result = 0;
+
+	if (ret == RPMA_E_PROVIDER) {
+		int errnum = rpma_err_get_provider_error();
+		const char *errstr = strerror(errnum);
+		result = fprintf(stderr, "%s failed: %s (%s)\n", fname,
+				rpma_err_2str(ret), errstr);
+	} else {
+		result = fprintf(stderr, "%s failed: %s\n", fname,
+				rpma_err_2str(ret));
+	}
+
+	if (result < 0)
+		exit(-1);
+}
+
 int
 main(int argc, char *argv[])
 {
@@ -23,52 +42,128 @@ main(int argc, char *argv[])
 
 	/* parameters */
 	char *addr = argv[1];
-	char *service = argv[3];
+	char *service = argv[2];
 
 	/* resources */
-	struct ibv_context *dev;
-	struct rpma_peer *peer;
-	struct rpma_ep *ep;
-	struct rpma_conn_req *req;
-	struct rpma_conn *conn;
-	enum rpma_conn_event conn_event;
-	int ret;
+	struct ibv_context *dev = NULL;
+	struct rpma_peer *peer = NULL;
+	struct rpma_ep *ep = NULL;
+	struct rpma_conn_req *req = NULL;
+	struct rpma_conn *conn = NULL;
+	enum rpma_conn_event conn_event = RPMA_CONN_UNDEFINED;
+	int ret = 0;
 
-	/* listen for a connection and establish one */
+	/* obtain an IBV context for a local IP address */
 	ret = rpma_utils_get_ibv_context(addr, RPMA_UTIL_IBV_CONTEXT_LOCAL,
 			&dev);
-	assert(ret == 0);
+	if (ret) {
+		print_error("rpma_utils_get_ibv_context", ret);
+		return -1;
+	}
 
+	/* create a new peer object */
 	ret = rpma_peer_new(dev, &peer);
-	assert(ret == 0);
+	if (ret) {
+		print_error("rpma_peer_new", ret);
+		return -1;
+	}
 
+	/* create a new endpoint object */
 	ret = rpma_ep_listen(peer, addr, service, &ep);
-	assert(ret == 0);
-	ret = rpma_ep_next_conn_req(ep, &req);
-	assert(ret == 0);
-	ret = rpma_conn_req_connect(&req, NULL, &conn);
-	assert(ret == 0);
+	if (ret) {
+		print_error("rpma_ep_listen", ret);
+		goto err_peer_delete;
+	}
 
-	/* wait for the connection to establish */
+	/* obtain an incoming connection request */
+	ret = rpma_ep_next_conn_req(ep, &req);
+	if (ret) {
+		print_error("rpma_ep_next_conn_req", ret);
+		goto err_ep_shutdown;
+	}
+
+	/*
+	 * connect / accept the connection request and obtain the connection
+	 * object
+	 */
+	ret = rpma_conn_req_connect(&req, NULL, &conn);
+	if (ret) {
+		print_error("rpma_conn_req_connect", ret);
+		goto err_req_delete;
+	}
+
+	/* wait for the connection to being establish */
 	ret = rpma_conn_next_event(conn, &conn_event);
-	assert(ret == 0 && conn_event == RPMA_CONN_ESTABLISHED);
+	if (ret) {
+		print_error("rpma_conn_next_event", ret);
+		goto err_conn_delete;
+	} else if (conn_event != RPMA_CONN_ESTABLISHED) {
+		fprintf(stderr, "rpma_conn_next_event returned an unexptected "
+				"event: %s\n",
+				rpma_utils_conn_event_2str(conn_event));
+		goto err_conn_delete;
+	} else {
+		fprintf(stderr, "rpma_conn_next_event returned an event: %s\n",
+				rpma_utils_conn_event_2str(conn_event));
+	}
 
 	/* here you can use the newly established connection */
 
 	/* disconnect the connection */
 	ret = rpma_conn_disconnect(conn);
-	assert(ret == 0);
+	if (ret) {
+		print_error("rpma_conn_disconnect", ret);
+		goto err_conn_delete;
+	}
+
+	/* wait for the connection to being closed */
 	ret = rpma_conn_next_event(conn, &conn_event);
-	assert(ret == 0 && conn_event == RPMA_CONN_CLOSED);
+	if (ret) {
+		print_error("rpma_conn_next_event", ret);
+		goto err_conn_delete;
+	} else if (conn_event != RPMA_CONN_CLOSED) {
+		fprintf(stderr, "rpma_conn_next_event returned an unexptected "
+				"event: %s\n",
+				rpma_utils_conn_event_2str(conn_event));
+		goto err_conn_delete;
+	} else {
+		fprintf(stderr, "rpma_conn_next_event returned an event: %s\n",
+				rpma_utils_conn_event_2str(conn_event));
+	}
 
+	/* delete the connection object */
 	ret = rpma_conn_delete(&conn);
-	assert(ret == 0);
+	if (ret) {
+		print_error("rpma_conn_delete", ret);
+		goto err_ep_shutdown;
+	}
 
+	/* shutdown the endpoint */
 	ret = rpma_ep_shutdown(&ep);
-	assert(ret == 0);
+	if (ret) {
+		print_error("rpma_ep_shutdown", ret);
+		goto err_peer_delete;
+	}
 
+	/* delete the peer object */
 	ret = rpma_peer_delete(&peer);
-	assert(ret == 0);
+	if (ret) {
+		print_error("rpma_peer_delete", ret);
+		goto err_exit;
+	}
 
-	return ret;
+	return 0;
+
+err_conn_delete:
+	(void) rpma_conn_delete(&conn);
+err_req_delete:
+	if (req)
+		(void) rpma_conn_req_delete(&req);
+err_ep_shutdown:
+	(void) rpma_ep_shutdown(&ep);
+err_peer_delete:
+	(void) rpma_peer_delete(&peer);
+
+err_exit:
+	return -1;
 }

--- a/src/include/librpma.h
+++ b/src/include/librpma.h
@@ -24,11 +24,11 @@
 
 #define RPMA_W_WAIT_FOR_COMPLETION	(1)
 
-#define RPMA_E_UNKNOWN			(-100000)
-#define RPMA_E_NOSUPP			(-100001)
-#define RPMA_E_PROVIDER			(-100002)
-#define RPMA_E_NOMEM			(-100003)
-#define RPMA_E_INVAL			(-100004)
+#define RPMA_E_UNKNOWN			(-100000) /* Unknown error */
+#define RPMA_E_NOSUPP			(-100001) /* Not supported */
+#define RPMA_E_PROVIDER			(-100002) /* Provider error occurred */
+#define RPMA_E_NOMEM			(-100003) /* Out of memory */
+#define RPMA_E_INVAL			(-100004) /* Invalid argument */
 
 /* picking up an RDMA-capable device */
 
@@ -161,10 +161,10 @@ int rpma_mr_dereg(struct rpma_mr_local **mr);
 struct rpma_conn;
 
 enum rpma_conn_event {
-	RPMA_CONN_UNDEFINED = -1,
-	RPMA_CONN_ESTABLISHED,
-	RPMA_CONN_CLOSED,
-	RPMA_CONN_LOST
+	RPMA_CONN_UNDEFINED = -1,	/* Undefined connection event */
+	RPMA_CONN_ESTABLISHED,		/* Connection established */
+	RPMA_CONN_CLOSED,			/* Connection closed */
+	RPMA_CONN_LOST				/* Connection lost */
 };
 
 /** 3
@@ -188,6 +188,23 @@ enum rpma_conn_event {
  * - RPMA_E_PROVIDER - rdma_get_cm_event() or rdma_ack_cm_event() failed
  */
 int rpma_conn_next_event(struct rpma_conn *conn, enum rpma_conn_event *event);
+
+/** 3
+ * rpma_utils_conn_event_2str - convert RPMA_CONN_* enum to a string
+ *
+ * SYNOPSIS
+ *
+ *	#include <librpma.h>
+ *
+ *	const char *rpma_utils_conn_event_2str(enum rpma_conn_event conn_event);
+ *
+ * DESCRIPTION
+ * Return const string representation of RPMA_CONN_* enums.
+ *
+ * ERRORS
+ * rpma_utils_conn_event_2str() can not fail.
+ */
+const char *rpma_utils_conn_event_2str(enum rpma_conn_event conn_event);
 
 struct rpma_conn_private_data {
 	void *ptr;
@@ -498,5 +515,22 @@ int rpma_err_get_provider_error(void);
  * .B <https://pmem.io>
  */
 const char *rpma_err_get_msg(void);
+
+/** 3
+ * rpma_err_2str - convert RPMA error code to a string
+ *
+ * SYNOPSIS
+ *
+ *	#include <librpma.h>
+ *
+ *	const char *rpma_err_2str(int ret);
+ *
+ * DESCRIPTION
+ * Return const string representation of RPMA error codes.
+ *
+ * ERRORS
+ * rpma_err_2str() can not fail.
+ */
+const char *rpma_err_2str(int ret);
 
 #endif /* LIBRPMA_H */

--- a/src/librpma.map
+++ b/src/librpma.map
@@ -19,6 +19,7 @@ LIBRPMA_1.0 {
 		rpma_ep_listen;
 		rpma_ep_next_conn_req;
 		rpma_ep_shutdown;
+		rpma_err_2str;
 		rpma_err_get_msg;
 		rpma_err_get_provider_error;
 		rpma_mr_dereg;
@@ -26,6 +27,7 @@ LIBRPMA_1.0 {
 		rpma_peer_delete;
 		rpma_peer_new;
 		rpma_read;
+		rpma_utils_conn_event_2str;
 		rpma_utils_get_ibv_context;
 	local:
 		*;

--- a/src/rpma.c
+++ b/src/rpma.c
@@ -73,6 +73,27 @@ err_info_delete:
 }
 
 /*
+ * rpma_utils_conn_event_2str -- return const string representation of
+ * RPMA_CONN_* enums
+ */
+const char *
+rpma_utils_conn_event_2str(enum rpma_conn_event conn_event)
+{
+	switch (conn_event) {
+	case RPMA_CONN_UNDEFINED:
+		return "Undefined connection event";
+	case RPMA_CONN_ESTABLISHED:
+		return "Connection established";
+	case RPMA_CONN_CLOSED:
+		return "Connection closed";
+	case RPMA_CONN_LOST:
+		return "Connection lost";
+	default:
+		return "Unknown connection event";
+	}
+}
+
+/*
  * rpma_mr_reg -- XXX
  */
 int

--- a/src/rpma_err.c
+++ b/src/rpma_err.c
@@ -32,3 +32,24 @@ rpma_err_get_msg(void)
 {
 	return "";
 }
+
+/*
+ * rpma_e2str -- return const string representation of an RPMA error
+ */
+const char *
+rpma_err_2str(int ret)
+{
+	switch (ret) {
+	case RPMA_E_NOSUPP:
+		return "Not supported";
+	case RPMA_E_PROVIDER:
+		return "Provider error occurred";
+	case RPMA_E_NOMEM:
+		return "Out of memory";
+	case RPMA_E_INVAL:
+		return "Invalid argument";
+	case RPMA_E_UNKNOWN:
+	default:
+		return "Unknown error";
+	}
+}


### PR DESCRIPTION
1. introduce two new functions allowing converting error codes and connection events to strings
2. rework connection example to make it more useful for diagnosing connection issues

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/pmem/rpma/99)
<!-- Reviewable:end -->
