### PR TITLE
common: _utils_get_ibv_context fix

### DIFF
--- a/examples/connection/connection-client.c
+++ b/examples/connection/connection-client.c
@@ -36,7 +36,8 @@ main(int argc, char *argv[])
 	int ret;
 
 	/* request for a connection and wait for its establishment */
-	ret = rpma_utils_get_ibv_context(addr_local, &dev);
+	ret = rpma_utils_get_ibv_context(addr_local,
+			RPMA_UTIL_IBV_CONTEXT_REMOTE, &dev);
 	assert(ret == 0);
 
 	ret = rpma_peer_new(dev, &peer);

--- a/examples/connection/connection-server.c
+++ b/examples/connection/connection-server.c
@@ -35,7 +35,8 @@ main(int argc, char *argv[])
 	int ret;
 
 	/* listen for a connection and establish one */
-	ret = rpma_utils_get_ibv_context(addr, &dev);
+	ret = rpma_utils_get_ibv_context(addr, RPMA_UTIL_IBV_CONTEXT_LOCAL,
+			&dev);
 	assert(ret == 0);
 
 	ret = rpma_peer_new(dev, &peer);

--- a/src/include/librpma.h
+++ b/src/include/librpma.h
@@ -32,6 +32,12 @@
 
 /* picking up an RDMA-capable device */
 
+/* pick a type of an ibv_context to lookup for */
+enum rpma_util_ibv_context_type {
+	RPMA_UTIL_IBV_CONTEXT_LOCAL, /* lookup for a local device */
+	RPMA_UTIL_IBV_CONTEXT_REMOTE /* lookup for a remote device */
+};
+
 /** 3
  * rpma_utils_get_ibv_context - obtain an RDMA device context by IP address
  *
@@ -40,15 +46,13 @@
  *	#include <librpma.h>
  *
  *	int rpma_utils_get_ibv_context(const char *addr,
- *		struct ibv_context **dev);
+ *	        enum rpma_util_ibv_context_type type, struct ibv_context **dev);
  *
  * DESCRIPTION
  * rpma_utils_get_ibv_context() obtains an RDMA device context
- * by the given IPv4/IPv6 address (local or remote) using
+ * by the given IPv4/IPv6 address (either local or remote) using
  * the TCP RDMA port space (RDMA_PS_TCP) - reliable, connection-oriented
  * and message based QP communication.
- * This function looks first for a local device and if it fails,
- * then for a remote device.
  *
  * RETURN VALUE
  * The rpma_utils_get_ibv_context() function returns 0 on success or a negative
@@ -58,13 +62,14 @@
  * ERRORS
  * rpma_utils_get_ibv_context() can fail with the following errors:
  *
- * - RPMA_E_INVAL - addr or dev is NULL
+ * - RPMA_E_INVAL - addr or dev is NULL or type is unknown
  * - RPMA_E_NOMEM - out of memory
  * - RPMA_E_PROVIDER - rdma_getaddrinfo(), rdma_create_id(), rdma_bind_addr()
  *   or rdma_resolve_addr() failed, errno can be checked using
  *   rpma_err_get_provider_error()
  */
-int rpma_utils_get_ibv_context(const char *addr, struct ibv_context **dev);
+int rpma_utils_get_ibv_context(const char *addr,
+		enum rpma_util_ibv_context_type type, struct ibv_context **dev);
 
 /* peer */
 

--- a/src/rpma.c
+++ b/src/rpma.c
@@ -20,26 +20,28 @@
  * rpma_utils_get_ibv_context -- obtain an RDMA device context by IP address
  */
 int
-rpma_utils_get_ibv_context(const char *addr, struct ibv_context **dev)
+rpma_utils_get_ibv_context(const char *addr,
+		enum rpma_util_ibv_context_type type, struct ibv_context **dev)
 {
-	struct rpma_info *info;
-
 	if (addr == NULL || dev == NULL)
 		return RPMA_E_INVAL;
 
-	/* at first, assume the address is local */
-	enum rpma_info_side side = RPMA_INFO_PASSIVE;
-	int ret = rpma_info_new(addr, NULL /* service */, side, &info);
-	if (ret) {
-		if (ret != RPMA_E_PROVIDER)
-			return ret;
-
-		/* if failed, check if it is a remote address */
+	enum rpma_info_side side;
+	switch (type) {
+	case RPMA_UTIL_IBV_CONTEXT_LOCAL:
+		side = RPMA_INFO_PASSIVE;
+		break;
+	case RPMA_UTIL_IBV_CONTEXT_REMOTE:
 		side = RPMA_INFO_ACTIVE;
-		ret = rpma_info_new(addr, NULL /* service */, side, &info);
-		if (ret)
-			return ret;
+		break;
+	default:
+		return RPMA_E_INVAL;
 	}
+
+	struct rpma_info *info;
+	int ret = rpma_info_new(addr, NULL /* service */, side, &info);
+	if (ret)
+		return ret;
 
 	struct rdma_cm_id *temp_id;
 	ret = rdma_create_id(NULL, &temp_id, NULL, RDMA_PS_TCP);
@@ -49,7 +51,6 @@ rpma_utils_get_ibv_context(const char *addr, struct ibv_context **dev)
 		goto err_info_delete;
 	}
 
-	/* either bind or resolve the address */
 	if (side == RPMA_INFO_PASSIVE) {
 		ret = rpma_info_bind_addr(info, temp_id);
 		if (ret)

--- a/tests/utils-test/utils-test.c
+++ b/tests/utils-test/utils-test.c
@@ -22,6 +22,8 @@
 #define MOCK_INFO	((struct rpma_info *)0xABC0)
 #define MOCK_VERBS	((struct ibv_context *)0xABC1)
 
+#define TYPE_UNKNOWN (enum rpma_util_ibv_context_type)(-1)
+
 #define ANY_ERRNO	0xFE00 /* mock errno value */
 
 /*
@@ -37,8 +39,11 @@ rpma_info_new(const char *addr, const char *service, enum rpma_info_side side,
 
 	*info_ptr = mock_type(struct rpma_info *);
 	if (*info_ptr == NULL) {
-		Rpma_provider_error = mock_type(int);
-		return mock_type(int);
+		int result = mock_type(int);
+		if (result == RPMA_E_PROVIDER)
+			Rpma_provider_error = mock_type(int);
+
+		return result;
 	}
 
 	expect_value(rpma_info_delete, *info_ptr, *info_ptr);
@@ -132,6 +137,18 @@ rpma_info_delete(struct rpma_info **info_ptr)
 }
 
 /*
+ * sanity_test_type_unknown - TYPE_UNKNOWN != RPMA_UTIL_IBV_CONTEXT_LOCAL &&
+ * TYPE_UNKNOWN != RPMA_UTIL_IBV_CONTEXT_REMOTE
+ */
+static void
+sanity_test_type_unknown(void **unused)
+{
+	/* run test */
+	assert_int_not_equal(TYPE_UNKNOWN, RPMA_UTIL_IBV_CONTEXT_LOCAL);
+	assert_int_not_equal(TYPE_UNKNOWN, RPMA_UTIL_IBV_CONTEXT_REMOTE);
+}
+
+/*
  * test_addr_NULL - test NULL addr parameter
  */
 static void
@@ -139,7 +156,8 @@ test_addr_NULL(void **unused)
 {
 	/* run test */
 	struct ibv_context *dev = NULL;
-	int ret = rpma_utils_get_ibv_context(NULL, &dev);
+	int ret = rpma_utils_get_ibv_context(NULL, RPMA_UTIL_IBV_CONTEXT_REMOTE,
+			&dev);
 
 	/* verify the results */
 	assert_int_equal(ret, RPMA_E_INVAL);
@@ -153,20 +171,36 @@ static void
 test_dev_NULL(void **unused)
 {
 	/* run test */
-	int ret = rpma_utils_get_ibv_context(IP_ADDRESS, NULL);
+	int ret = rpma_utils_get_ibv_context(IP_ADDRESS,
+			RPMA_UTIL_IBV_CONTEXT_REMOTE, NULL);
 
 	/* verify the results */
 	assert_int_equal(ret, RPMA_E_INVAL);
 }
 
 /*
- * test_addr_NULL_dev_NULL - test NULL addr and dev parameter
+ * test_type_unknown - type == TYPE_UNKNOWN
  */
 static void
-test_addr_NULL_dev_NULL(void **unused)
+test_type_unknown(void **unused)
 {
 	/* run test */
-	int ret = rpma_utils_get_ibv_context(NULL, NULL);
+	struct ibv_context *dev = NULL;
+	int ret = rpma_utils_get_ibv_context(IP_ADDRESS, TYPE_UNKNOWN, &dev);
+
+	/* verify the results */
+	assert_int_equal(ret, RPMA_E_INVAL);
+}
+
+/*
+ * test_addr_NULL_dev_NULL_type_unknown - test NULL addr and dev parameter and
+ * type == TYPE_UNKNOWN
+ */
+static void
+test_addr_NULL_dev_NULL_type_unknown(void **unused)
+{
+	/* run test */
+	int ret = rpma_utils_get_ibv_context(NULL, TYPE_UNKNOWN, NULL);
 
 	/* verify the results */
 	assert_int_equal(ret, RPMA_E_INVAL);
@@ -180,14 +214,8 @@ test_info_new_failed_E_PROVIDER(void **unused)
 {
 	/* configure mocks */
 	will_return(rpma_info_new, NULL /* info_ptr */);
-	/* Rpma_provider_error is valid only for RPMA_E_PROVIDER */
-	will_return(rpma_info_new, ANY_ERRNO /* Rpma_provider_error */);
 	will_return(rpma_info_new, RPMA_E_PROVIDER);
-
-	will_return(rpma_info_new, NULL /* info_ptr */);
-	/* Rpma_provider_error is valid only for RPMA_E_PROVIDER */
-	will_return(rpma_info_new, ANY_ERRNO /* Rpma_provider_error */);
-	will_return(rpma_info_new, RPMA_E_PROVIDER);
+	will_return(rpma_info_new, ANY_ERRNO);
 
 	struct rdma_cm_id id;
 	id.verbs = MOCK_VERBS;
@@ -196,7 +224,8 @@ test_info_new_failed_E_PROVIDER(void **unused)
 
 	/* run test */
 	struct ibv_context *dev = NULL;
-	int ret = rpma_utils_get_ibv_context(IP_ADDRESS, &dev);
+	int ret = rpma_utils_get_ibv_context(IP_ADDRESS,
+			RPMA_UTIL_IBV_CONTEXT_REMOTE, &dev);
 
 	/* verify the results */
 	assert_int_equal(ret, RPMA_E_PROVIDER);
@@ -212,8 +241,6 @@ test_info_new_failed_E_NOMEM(void **unused)
 {
 	/* configure mocks */
 	will_return(rpma_info_new, NULL /* info_ptr */);
-	/* Rpma_provider_error is valid only for RPMA_E_PROVIDER */
-	will_return(rpma_info_new, 0);
 	will_return(rpma_info_new, RPMA_E_NOMEM);
 
 	struct rdma_cm_id id;
@@ -223,7 +250,8 @@ test_info_new_failed_E_NOMEM(void **unused)
 
 	/* run test */
 	struct ibv_context *dev = NULL;
-	int ret = rpma_utils_get_ibv_context(IP_ADDRESS, &dev);
+	int ret = rpma_utils_get_ibv_context(IP_ADDRESS,
+			RPMA_UTIL_IBV_CONTEXT_REMOTE, &dev);
 
 	/* verify the results */
 	assert_int_equal(ret, RPMA_E_NOMEM);
@@ -250,7 +278,8 @@ test_create_id_failed(void **unused)
 
 	/* run test */
 	struct ibv_context *dev = NULL;
-	int ret = rpma_utils_get_ibv_context(IP_ADDRESS, &dev);
+	int ret = rpma_utils_get_ibv_context(IP_ADDRESS,
+			RPMA_UTIL_IBV_CONTEXT_LOCAL, &dev);
 
 	/* verify the results */
 	assert_int_equal(ret, RPMA_E_PROVIDER);
@@ -265,10 +294,7 @@ test_create_id_failed(void **unused)
 static void
 test_bind_addr_failed_E_PROVIDER(void **unused)
 {
-	/*
-	 * Configure mocks.
-	 * Passive side succeeds.
-	 */
+	/* configure mocks */
 	will_return(rpma_info_new, MOCK_INFO);
 
 	struct rdma_cm_id id;
@@ -285,7 +311,8 @@ test_bind_addr_failed_E_PROVIDER(void **unused)
 
 	/* run test */
 	struct ibv_context *dev = NULL;
-	int ret = rpma_utils_get_ibv_context(IP_ADDRESS, &dev);
+	int ret = rpma_utils_get_ibv_context(IP_ADDRESS,
+			RPMA_UTIL_IBV_CONTEXT_LOCAL, &dev);
 
 	/* verify the results */
 	assert_int_equal(ret, RPMA_E_PROVIDER);
@@ -300,16 +327,7 @@ test_bind_addr_failed_E_PROVIDER(void **unused)
 static void
 test_resolve_addr_failed_E_PROVIDER(void **unused)
 {
-	/*
-	 * Configure mocks.
-	 * Passive side fails.
-	 */
-	will_return(rpma_info_new, NULL /* info_ptr */);
-	/* Rpma_provider_error is valid only for RPMA_E_PROVIDER */
-	will_return(rpma_info_new, ANY_ERRNO /* Rpma_provider_error */);
-	will_return(rpma_info_new, RPMA_E_PROVIDER);
-
-	/* active side succeeds */
+	/* configure mocks */
 	will_return(rpma_info_new, MOCK_INFO);
 
 	struct rdma_cm_id id;
@@ -326,7 +344,8 @@ test_resolve_addr_failed_E_PROVIDER(void **unused)
 
 	/* run test */
 	struct ibv_context *dev = NULL;
-	int ret = rpma_utils_get_ibv_context(IP_ADDRESS, &dev);
+	int ret = rpma_utils_get_ibv_context(IP_ADDRESS,
+			RPMA_UTIL_IBV_CONTEXT_REMOTE, &dev);
 
 	/* verify the results */
 	assert_int_equal(ret, RPMA_E_PROVIDER);
@@ -341,10 +360,7 @@ test_resolve_addr_failed_E_PROVIDER(void **unused)
 static void
 test_success_destroy_id_failed_passive(void **unused)
 {
-	/*
-	 * Configure mocks.
-	 * Passive side succeeds.
-	 */
+	/* configure mocks */
 	will_return(rpma_info_new, MOCK_INFO);
 
 	struct rdma_cm_id id;
@@ -360,7 +376,8 @@ test_success_destroy_id_failed_passive(void **unused)
 
 	/* run test */
 	struct ibv_context *dev = NULL;
-	int ret = rpma_utils_get_ibv_context(IP_ADDRESS, &dev);
+	int ret = rpma_utils_get_ibv_context(IP_ADDRESS,
+			RPMA_UTIL_IBV_CONTEXT_LOCAL, &dev);
 
 	/* verify the results */
 	assert_int_equal(ret, 0);
@@ -374,16 +391,7 @@ test_success_destroy_id_failed_passive(void **unused)
 static void
 test_success_destroy_id_failed_active(void **unused)
 {
-	/*
-	 * Configure mocks.
-	 * Passive side fails.
-	 */
-	will_return(rpma_info_new, NULL /* info_ptr */);
-	/* Rpma_provider_error is valid only for RPMA_E_PROVIDER */
-	will_return(rpma_info_new, ANY_ERRNO /* Rpma_provider_error */);
-	will_return(rpma_info_new, RPMA_E_PROVIDER);
-
-	/* active side succeeds */
+	/* configure mocks */
 	will_return(rpma_info_new, MOCK_INFO);
 
 	struct rdma_cm_id id;
@@ -399,7 +407,8 @@ test_success_destroy_id_failed_active(void **unused)
 
 	/* run test */
 	struct ibv_context *dev = NULL;
-	int ret = rpma_utils_get_ibv_context(IP_ADDRESS, &dev);
+	int ret = rpma_utils_get_ibv_context(IP_ADDRESS,
+			RPMA_UTIL_IBV_CONTEXT_REMOTE, &dev);
 
 	/* verify the results */
 	assert_int_equal(ret, 0);
@@ -427,7 +436,8 @@ test_success_passive(void **unused)
 
 	/* run test */
 	struct ibv_context *dev = NULL;
-	int ret = rpma_utils_get_ibv_context(IP_ADDRESS, &dev);
+	int ret = rpma_utils_get_ibv_context(IP_ADDRESS,
+			RPMA_UTIL_IBV_CONTEXT_LOCAL, &dev);
 
 	/* verify the results */
 	assert_int_equal(ret, 0);
@@ -441,13 +451,6 @@ static void
 test_success_active(void **unused)
 {
 	/* configure mocks */
-	/* passive fails */
-	will_return(rpma_info_new, NULL /* info_ptr */);
-	/* Rpma_provider_error is valid only for RPMA_E_PROVIDER */
-	will_return(rpma_info_new, ANY_ERRNO /* Rpma_provider_error */);
-	will_return(rpma_info_new, RPMA_E_PROVIDER);
-
-	/* active succeeds */
 	will_return(rpma_info_new, MOCK_INFO);
 
 	struct rdma_cm_id id;
@@ -462,7 +465,8 @@ test_success_active(void **unused)
 
 	/* run test */
 	struct ibv_context *dev = NULL;
-	int ret = rpma_utils_get_ibv_context(IP_ADDRESS, &dev);
+	int ret = rpma_utils_get_ibv_context(IP_ADDRESS,
+			RPMA_UTIL_IBV_CONTEXT_REMOTE, &dev);
 
 	/* verify the results */
 	assert_int_equal(ret, 0);
@@ -473,9 +477,13 @@ int
 main(int argc, char *argv[])
 {
 	const struct CMUnitTest tests[] = {
+		/* sanity */
+		cmocka_unit_test(sanity_test_type_unknown),
+
 		cmocka_unit_test(test_addr_NULL),
 		cmocka_unit_test(test_dev_NULL),
-		cmocka_unit_test(test_addr_NULL_dev_NULL),
+		cmocka_unit_test(test_type_unknown),
+		cmocka_unit_test(test_addr_NULL_dev_NULL_type_unknown),
 		cmocka_unit_test(test_info_new_failed_E_PROVIDER),
 		cmocka_unit_test(test_info_new_failed_E_NOMEM),
 		cmocka_unit_test(test_create_id_failed),


### PR DESCRIPTION
# Rationale

```rdma_getaddrinfo(3)``` is more resilient than I have initially assumed. It allows getting address info even if the used IP address is not present on the expected side of the connection. The issue appears finally when we are trying to resolve/bind using obtained address info. So ```rpma_utils_get_ibv_context()``` needed a little bit rework to align to how ```rdma_getaddrinfo()``` behaves.

Taking into account all of the above I have come up with two implementations (active and passive) where the other is used when the first one fails. But with multiple fail paths. Testing this was a nightmare so I have decided to introduce additional argument to the API function which, this new argument, allows picking an applicable implementation. This new argument also allowed greatly simplified the firstly created implementation, somehow return to the initial one, but without the builtin flaw which has introduced the need for changes.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/pmem/rpma/100)
<!-- Reviewable:end -->
