### PR TITLE
common: _conn_req_connect (active side) fix

### DIFF
--- a/src/conn_req.c
+++ b/src/conn_req.c
@@ -77,7 +77,9 @@ err_destroy_cq:
 
 /*
  * rpma_conn_req_accept -- call rdma_accept()+rdma_ack_cm_event(). If succeeds
- * request re-packing the connection request to a connection object.
+ * request re-packing the connection request to a connection object. Otherwise,
+ * rdma_disconnect()+rdma_destroy_qp()+ibv_destroy_cq() to destroy the
+ * unsuccessful connection request.
  */
 static int
 rpma_conn_req_accept(struct rpma_conn_req *req,
@@ -123,7 +125,9 @@ err_conn_req_delete:
 
 /*
  * rpma_conn_req_connect_active -- call rdma_connect(). If succeeds request
- * re-packing the connection request to a connection object.
+ * re-packing the connection request to a connection object. Otherwise,
+ * rdma_destroy_qp()+ibv_destroy_cq()+rdma_destroy_id() to destroy the
+ * unsuccessful connection request.
  */
 static int
 rpma_conn_req_connect_active(struct rpma_conn_req *req,
@@ -305,7 +309,7 @@ err_info_delete:
 /*
  * rpma_conn_req_connect -- prepare connection parameters and request
  * connecting a connection request (either active or passive). When done
- * release the connection request object.
+ * release the connection request object (regardless of the result).
  */
 int
 rpma_conn_req_connect(struct rpma_conn_req **req_ptr,

--- a/src/include/librpma.h
+++ b/src/include/librpma.h
@@ -313,11 +313,11 @@ int rpma_conn_req_delete(struct rpma_conn_req **req_ptr);
  * Connect the connection requests both incoming and outgoing.
  *
  * RETURN VALUE
- * The rpma_conn_req_connect() function returns 0 on success or a negative
- * error code on failure. The newly created connection object is stored in
- * *conn_ptr whereas *req_ptr is consumed and set to NULL.
- * rpma_conn_req_connect() does not set *conn_ptr neither *req_ptr values on
- * failure.
+ * The rpma_conn_req_connect() function returns 0 on success or a negative error
+ * code on failure. On success, the newly created connection object is stored in
+ * *conn_ptr whereas *req_ptr is consumed and set to NULL. On failure,
+ * rpma_conn_req_connect() does not set *conn_ptr whereas *req_ptr is consumed
+ * and set to NULL.
  *
  * ERRORS
  * rpma_conn_req_connect() can fail with the following errors:


### PR DESCRIPTION
A CM ID encapsulated in the connection request on the active side of the connection is initially not attached to any event channel. In a result of this, it works in blocking mode till first call to ```rdma_migrate_id(3)```. Because this whole connection process is done before the return from ```rdma_connect(3)``` so after migrating the CM ID to an event channel you can not expect ```RDMA_CM_EVENT_ESTABLISHED``` to appear on the event channel of the connection.

An easy fix for this is to reverse the order: migrate the CM ID to an event channel, so the CM ID works in the non-blocking mode, and after that calling ```rdma_connect()``` so all events regarding the connection will be delivered to the event channel.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/pmem/rpma/101)
<!-- Reviewable:end -->
