### PR TITLE
rpma: introduce _mr_get_descriptor, _mr_remote_from_descriptor, ...

### DIFF
--- a/examples/02-read-to-volatile/client.c
+++ b/examples/02-read-to-volatile/client.c
@@ -84,9 +84,12 @@ main(int argc, char *argv[])
 		goto err_conn_disconnect;
 	}
 
-	/* deserialize the remote memory registration structure */
-	ret = rpma_mr_deserialize(pdata.ptr, rpma_mr_serialize_get_size(),
-			&src_mr);
+	/*
+	 * Create a remote memory registration structure from the received
+	 * descriptor.
+	 */
+	rpma_mr_descriptor *desc = pdata.ptr;
+	ret = rpma_mr_remote_from_descriptor(desc, &src_mr);
 	if (ret) {
 		print_error("rpma_mr_deserialize", ret);
 		goto err_conn_disconnect;

--- a/examples/02-read-to-volatile/server.c
+++ b/examples/02-read-to-volatile/server.c
@@ -71,23 +71,14 @@ main(int argc, char *argv[])
 		goto err_mr_free;
 	}
 
-	/* prepare a buffer for serialized memory region information */
 	struct rpma_conn_private_data pdata;
-	pdata.len = rpma_mr_serialize_get_size();
-	pdata.ptr = malloc(pdata.len);
-	if (pdata.ptr == NULL) {
-		ret = -1;
-		goto err_mr_dereg;
-	}
+	rpma_mr_descriptor desc;
+	pdata.ptr = &desc;
 
-	/* serialize the memory region */
-	ret = rpma_mr_serialize(mr, pdata.ptr);
+	/* receive the memory region's descriptor */
+	ret = rpma_mr_get_descriptor(mr, &desc);
 	if (ret) {
-		print_error("rpma_mr_serialize", ret);
-	} else {
-		fprintf(stdout,
-				"Serialized memory region structure size: %"
-				PRIu8 "\n", pdata.len);
+		print_error("rpma_mr_get_descriptor", ret);
 	}
 
 	/*
@@ -96,7 +87,7 @@ main(int argc, char *argv[])
 	 */
 	ret = server_accept_connection(ep, &pdata, &conn);
 	if (ret)
-		goto err_pdata_ptr_free;
+		goto err_mr_dereg;
 
 	/*
 	 * Between the connection being established and the connection being
@@ -108,9 +99,6 @@ main(int argc, char *argv[])
 	 * structure.
 	 */
 	ret = server_disconnect(&conn);
-
-err_pdata_ptr_free:
-	free(pdata.ptr);
 
 err_mr_dereg:
 	/* deregister the memory region */

--- a/src/librpma.map
+++ b/src/librpma.map
@@ -22,12 +22,11 @@ LIBRPMA_1.0 {
 		rpma_err_2str;
 		rpma_err_get_msg;
 		rpma_err_get_provider_error;
-		rpma_mr_deserialize;
 		rpma_mr_dereg;
+		rpma_mr_get_descriptor;
 		rpma_mr_reg;
-		rpma_mr_serialize;
-		rpma_mr_serialize_get_size;
 		rpma_mr_remote_delete;
+		rpma_mr_remote_from_descriptor;
 		rpma_mr_remote_get_size;
 		rpma_peer_delete;
 		rpma_peer_new;

--- a/src/mr.c
+++ b/src/mr.c
@@ -5,6 +5,8 @@
  * mr.c -- librpma memory region-related implementations
  */
 
+#include <endian.h>
+
 #include "cmocka_alloc.h"
 #include "librpma.h"
 #include "mr.h"
@@ -22,6 +24,7 @@ struct rpma_mr_local {
 
 struct rpma_mr_remote {
 	uint64_t raddr; /* the base virtual address of the memory region */
+	uint64_t size; /* the size of the memory being registered */
 	uint32_t rkey; /* remote key of the memory region */
 	enum rpma_mr_plt plt; /* placement of the memory region */
 };
@@ -125,46 +128,92 @@ rpma_mr_dereg(struct rpma_mr_local **mr_ptr)
 }
 
 /*
- * rpma_mr_serialize_get_size -- XXX
- */
-size_t
-rpma_mr_serialize_get_size()
-{
-	return sizeof(struct rpma_mr_remote); /* XXX alignment? */
-}
-
-/*
- * rpma_mr_serialize -- XXX
+ * rpma_mr_get_descriptor -- get a descriptor of memory region
  */
 int
-rpma_mr_serialize(struct rpma_mr_local *mr, char *buff)
+rpma_mr_get_descriptor(struct rpma_mr_local *mr, rpma_mr_descriptor *desc)
 {
-	return RPMA_E_NOSUPP;
+	if (mr == NULL || desc == NULL)
+		return RPMA_E_INVAL;
+
+	char *buff = (char *)desc;
+
+	*((uint64_t *)buff) = htole64((uint64_t)mr->ibv_mr->addr);
+	buff += sizeof(uint64_t);
+	*((uint64_t *)buff) = htole64((uint64_t)mr->ibv_mr->length);
+	buff += sizeof(uint64_t);
+	*((uint32_t *)buff) = htole32(mr->ibv_mr->rkey);
+	buff += sizeof(uint32_t);
+	*((uint8_t *)buff) = (uint8_t)mr->plt;
+
+	return 0;
 }
 
 /*
- * rpma_mr_deserialize -- XXX
+ * rpma_mr_remote_from_descriptor -- create a remote memory region from
+ * a descriptor
  */
 int
-rpma_mr_deserialize(char *buff, size_t buff_size, struct rpma_mr_remote **mr)
+rpma_mr_remote_from_descriptor(const rpma_mr_descriptor *desc,
+		struct rpma_mr_remote **mr_ptr)
 {
-	return RPMA_E_NOSUPP;
+	if (desc == NULL || mr_ptr == NULL)
+		return RPMA_E_INVAL;
+
+	char *buff = (char *)desc;
+
+	uint64_t raddr =  le64toh(*(uint64_t *)buff);
+	buff += sizeof(uint64_t);
+	uint64_t size = le64toh(*(uint64_t *)buff);
+	buff += sizeof(uint64_t);
+	uint32_t rkey = le32toh(*(uint32_t *)buff);
+	buff += sizeof(uint32_t);
+	uint8_t plt = *(uint8_t *)buff;
+
+	if (plt != RPMA_MR_PLT_VOLATILE && plt != RPMA_MR_PLT_PERSISTENT)
+		return RPMA_E_NOSUPP;
+
+	struct rpma_mr_remote *mr = Malloc(sizeof(struct rpma_mr_remote));
+	if (mr == NULL)
+		return RPMA_E_NOMEM;
+
+	mr->raddr = raddr;
+	mr->size = size;
+	mr->rkey = rkey;
+	mr->plt = plt;
+	*mr_ptr = mr;
+
+	return 0;
 }
 
 /*
- * rpma_mr_remote_get_size -- XXX
+ * rpma_mr_remote_get_size -- get a remote memory region size
  */
 int
 rpma_mr_remote_get_size(struct rpma_mr_remote *mr, size_t *size)
 {
-	return RPMA_E_NOSUPP;
+	if (mr == NULL || size == NULL)
+		return RPMA_E_INVAL;
+
+	*size = mr->size;
+
+	return 0;
 }
 
 /*
- * rpma_mr_remote_delete -- XXX
+ * rpma_mr_remote_delete -- delete a remote memory region's structure
  */
 int
-rpma_mr_remote_delete(struct rpma_mr_remote **mr)
+rpma_mr_remote_delete(struct rpma_mr_remote **mr_ptr)
 {
-	return RPMA_E_NOSUPP;
+	if (mr_ptr == NULL)
+		return RPMA_E_INVAL;
+
+	if (*mr_ptr == NULL)
+		return 0;
+
+	Free(*mr_ptr);
+	*mr_ptr = NULL;
+
+	return 0;
 }

--- a/tests/mr-test/CMakeLists.txt
+++ b/tests/mr-test/CMakeLists.txt
@@ -5,14 +5,21 @@
 
 include(../cmake/ctest_helpers.cmake)
 
-build_test_src(mr-test
-       mr-test.c
-       ${LIBRPMA_SOURCE_DIR}/mr.c)
+function(add_mr_test test)
+	set(name mr-test-${test})
+	build_test_src(${name}
+		${name}.c
+		mr-test-common.c
+		${LIBRPMA_SOURCE_DIR}/mr.c)
 
-target_link_libraries(mr-test test-rpma-utils)
+	target_link_libraries(${name} test-rpma-utils)
 
-set_target_properties(mr-test
-       PROPERTIES
-       LINK_FLAGS "-Wl,--wrap=_test_malloc")
+	set_target_properties(${name}
+		PROPERTIES
+		LINK_FLAGS "-Wl,--wrap=_test_malloc")
 
-add_test_generic(NAME mr-test TRACERS none)
+	add_test_generic(NAME ${name} TRACERS none)
+endfunction()
+
+add_mr_test(descriptor)
+add_mr_test(reg)

--- a/tests/mr-test/mr-test-common.c
+++ b/tests/mr-test/mr-test-common.c
@@ -1,0 +1,139 @@
+/*
+ * SPDX-License-Identifier: BSD-3-Clause
+ * Copyright 2020, Intel Corporation
+ */
+
+/*
+ * mr-test-common.c -- the memory region unit tests's common functions
+ */
+
+#include "mr-test-common.h"
+
+struct ibv_mr Ibv_mr = {0};
+
+/*
+ * rpma_peer_mr_reg -- a mock of rpma_peer_mr_reg()
+ */
+int
+rpma_peer_mr_reg(struct rpma_peer *peer, struct ibv_mr **ibv_mr, void *addr,
+	size_t length, int access)
+{
+	/*
+	 * rpma_peer_mr_reg() and malloc() may be called in any order.
+	 * If the first one fails, then the second one won't be called,
+	 * so we cannot add cmocka's expects here.
+	 * Otherwise, unconsumed expects would cause a test failure.
+	 */
+	struct rpma_peer_mr_reg_args *args =
+				mock_type(struct rpma_peer_mr_reg_args *);
+	assert_ptr_equal(peer, MOCK_PEER);
+	assert_ptr_equal(addr, MOCK_PTR);
+	assert_int_equal(length, MOCK_SIZE);
+	assert_int_equal(access, args->access);
+
+	*ibv_mr = args->mr;
+	if (*ibv_mr == NULL) {
+		Rpma_provider_error = args->verrno;
+		return RPMA_E_PROVIDER;
+	}
+
+	(*ibv_mr)->addr = addr;
+	(*ibv_mr)->length = length;
+	(*ibv_mr)->rkey = MOCK_RKEY;
+
+	return 0;
+}
+
+/*
+ * ibv_dereg_mr -- a mock of ibv_dereg_mr()
+ */
+int
+ibv_dereg_mr(struct ibv_mr *mr)
+{
+	/*
+	 * rpma_peer_mr_reg() and malloc() may be called in any order.
+	 * If the first one fails, then the second one won't be called.
+	 * ibv_dereg_mr() will be called in rpma_mr_reg() only if:
+	 * 1) rpma_peer_mr_reg() succeeded and
+	 * 2) malloc() failed.
+	 * In the opposite case, when:
+	 * 1) malloc() succeeded and
+	 * 2) rpma_peer_mr_reg() failed,
+	 * ibv_dereg_mr() will not be called,
+	 * so we cannot add cmocka's expects here.
+	 * Otherwise, unconsumed expects would cause a test failure.
+	 */
+	assert_int_equal(mr, MOCK_MR);
+
+	return mock_type(int); /* errno */
+}
+
+void *__real__test_malloc(size_t size);
+
+/*
+ * __wrap__test_malloc -- malloc() mock
+ */
+void *
+__wrap__test_malloc(size_t size)
+{
+	errno = mock_type(int);
+
+	if (errno)
+		return NULL;
+
+	return __real__test_malloc(size);
+}
+
+/* common setups & teardowns */
+
+/*
+ * setup__reg_success -- create a local memory registration object
+ */
+int
+setup__reg_success(void **pprestate)
+{
+	struct prestate *prestate = *pprestate;
+
+	/* configure mocks */
+	struct rpma_peer_mr_reg_args mr_reg_args;
+	mr_reg_args.usage = prestate->usage;
+	mr_reg_args.access = prestate->access;
+	mr_reg_args.mr = MOCK_MR;
+	will_return_maybe(rpma_peer_mr_reg, &mr_reg_args);
+	will_return(__wrap__test_malloc, MOCK_OK);
+
+	/* run test */
+	struct rpma_mr_local *mr = NULL;
+	int ret = rpma_mr_reg(MOCK_PEER, MOCK_PTR, MOCK_SIZE,
+				mr_reg_args.usage, MOCK_PLT, &mr);
+
+	/* verify the result */
+	assert_int_equal(ret, MOCK_OK);
+	assert_non_null(mr);
+
+	/* pass mr to the test */
+	prestate->mr = mr;
+
+	return 0;
+}
+
+/*
+ * teardown__dereg_success -- delete the local memory registration object
+ */
+int
+teardown__dereg_success(void **pprestate)
+{
+	struct prestate *prestate = *pprestate;
+	struct rpma_mr_local *mr = prestate->mr;
+
+	/* configure mocks */
+	will_return(ibv_dereg_mr, MOCK_OK);
+
+	int ret = rpma_mr_dereg(&mr);
+
+	/* verify the result */
+	assert_int_equal(ret, MOCK_OK);
+	assert_null(mr);
+
+	return 0;
+}

--- a/tests/mr-test/mr-test-common.h
+++ b/tests/mr-test/mr-test-common.h
@@ -1,0 +1,60 @@
+/*
+ * SPDX-License-Identifier: BSD-3-Clause
+ * Copyright 2020, Intel Corporation
+ */
+
+/*
+ * mr-test-common.h -- the memory region unit tests's common definitions
+ */
+
+#ifndef MR_COMMON_H
+#define MR_COMMON_H
+
+#include <stdlib.h>
+#include <infiniband/verbs.h>
+
+#include "cmocka_headers.h"
+#include "mr.h"
+#include "librpma.h"
+#include "rpma_err.h"
+
+extern struct ibv_mr Ibv_mr;
+
+#define MOCK_PEER	(struct rpma_peer *)0x0AD0
+#define MOCK_PTR	(void *)0x0001020304050607
+#define MOCK_SIZE	(size_t)0x08090a0b0c0d0e0f
+#define MOCK_RKEY	(uint32_t)0x10111213
+#define MOCK_USAGE	(int)(RPMA_MR_USAGE_READ_SRC | RPMA_MR_USAGE_READ_DST)
+#define MOCK_PLT	RPMA_MR_PLT_PERSISTENT
+#define MOCK_MR		(struct ibv_mr *)&Ibv_mr
+#define MOCK_ERRNO	(int)(123)
+#define MOCK_OK		(int)0
+
+#define DESC_EXP	{0x07, 0x06, 0x05, 0x04, 0x03, 0x02, 0x01, 0x00, \
+			0x0f, 0x0e, 0x0d, 0x0c, 0x0b, 0x0a, 0x09, 0x08, \
+			0x13, 0x12, 0x11, 0x10, \
+			0x01}
+
+/* prestate structure passed to unit test functions */
+struct prestate {
+	int usage;
+	int access;
+	/* mr passed from setup to test and to teardown */
+	struct rpma_mr_local *mr;
+};
+
+/* structure of arguments used in rpma_peer_mr_reg() */
+struct rpma_peer_mr_reg_args {
+	int usage;
+	int access;
+	struct ibv_mr *mr;
+	int verrno;
+};
+
+/* setups & teardowns */
+
+int setup__reg_success(void **pprestate);
+
+int teardown__dereg_success(void **pprestate);
+
+#endif /* MR_COMMON_H */

--- a/tests/mr-test/mr-test-descriptor.c
+++ b/tests/mr-test/mr-test-descriptor.c
@@ -1,0 +1,432 @@
+/*
+ * SPDX-License-Identifier: BSD-3-Clause
+ * Copyright 2020, Intel Corporation
+ */
+
+/*
+ * mr-descriptor.c -- the memory region serialization unit tests
+ *
+ * APIs covered:
+ * - rpma_mr_get_descriptor()
+ * - rpma_mr_remote_from_descriptor()
+ * - rpma_mr_remote_delete()
+ * - rpma_mr_remote_get_size()
+ */
+
+#include <stdlib.h>
+#include <infiniband/verbs.h>
+
+#include "mr-test-common.h"
+
+#define MR_DESC_SIZE sizeof(rpma_mr_descriptor)
+
+static const rpma_mr_descriptor Desc_exp = DESC_EXP;
+
+/* setups & teardowns */
+
+/*
+ * setup__mr_remote -- create a remote memory region structure based on a
+ * pre-prepared memory region's descriptor
+ */
+int
+setup__mr_remote(void **mr_ptr)
+{
+	/* configure mock */
+	will_return_maybe(__wrap__test_malloc, MOCK_OK);
+
+	/*
+	 * create a remote memory structure based on a pre-prepared descriptor
+	 */
+	struct rpma_mr_remote *mr = NULL;
+	int ret = rpma_mr_remote_from_descriptor(&Desc_exp, &mr);
+
+	/* verify the results */
+	assert_int_equal(ret, MOCK_OK);
+	assert_non_null(mr);
+
+	*mr_ptr = mr;
+
+	return 0;
+}
+
+/*
+ * teardown__mr_remote -- delete the remote memory region's structure
+ */
+int
+teardown__mr_remote(void **mr_ptr)
+{
+	struct rpma_mr_remote *mr = *mr_ptr;
+
+	/* delete the remote memory region's structure */
+	int ret = rpma_mr_remote_delete(&mr);
+	assert_int_equal(ret, MOCK_OK);
+	assert_null(mr);
+
+	return 0;
+}
+
+/* rpma_mr_get_descriptor() unit test */
+
+/*
+ * test_get_descriptor__mr_NULL - NULL mr is invalid
+ */
+static void
+test_get_descriptor__mr_NULL(void **unused)
+{
+	rpma_mr_descriptor desc = {0};
+
+	/* run test */
+	int ret = rpma_mr_get_descriptor(NULL, &desc);
+
+	/* verify the result */
+	assert_int_equal(ret, RPMA_E_INVAL);
+}
+
+/*
+ * test_get_descriptor__desc_NULL - NULL desc is invalid
+ */
+static void
+test_get_descriptor__desc_NULL(void **mr_ptr)
+{
+	struct rpma_mr_local *mr = *mr_ptr;
+
+	/* run test */
+	int ret = rpma_mr_get_descriptor(mr, NULL);
+
+	/* verify the result */
+	assert_int_equal(ret, RPMA_E_INVAL);
+}
+
+/*
+ * test_get_descriptor__mr_NULL_desc_NULL - NULL mr and NULL desc are invalid
+ */
+static void
+test_get_descriptor__mr_NULL_desc_NULL(void **unused)
+{
+	/* run test */
+	int ret = rpma_mr_get_descriptor(NULL, NULL);
+
+	/* verify the result */
+	assert_int_equal(ret, RPMA_E_INVAL);
+}
+
+/* rpma_mr_remote_from_descriptor() unit test */
+
+/*
+ * test_remote_from_descriptor__desc_NULL - NULL desc is invalid
+ */
+static void
+test_remote_from_descriptor__desc_NULL(void **unused)
+{
+	/* run test */
+	struct rpma_mr_remote *mr = NULL;
+	int ret = rpma_mr_remote_from_descriptor(NULL, &mr);
+
+	/* verify the results */
+	assert_int_equal(ret, RPMA_E_INVAL);
+	assert_null(mr);
+}
+
+/*
+ * test_remote_from_descriptor__mr_ptr_NULL - NULL mr_ptr is invalid
+ */
+static void
+test_remote_from_descriptor__mr_ptr_NULL(void **unused)
+{
+	/* run test */
+	int ret = rpma_mr_remote_from_descriptor(&Desc_exp, NULL);
+
+	/* verify the results */
+	assert_int_equal(ret, RPMA_E_INVAL);
+}
+
+/*
+ * test_remote_from_descriptor__mr_ptr_NULL_desc_NULL - NULL mr_ptr and NULL
+ * desc are invalid
+ */
+static void
+test_remote_from_descriptor__mr_ptr_NULL_desc_NULL(void **unused)
+{
+	/* run test */
+	int ret = rpma_mr_remote_from_descriptor(NULL, NULL);
+
+	/* verify the results */
+	assert_int_equal(ret, RPMA_E_INVAL);
+}
+
+/*
+ * test_remote_from_descriptor__malloc_ENOMEM - malloc() fail with ENOMEM
+ */
+static void
+test_remote_from_descriptor__malloc_ENOMEM(void **unused)
+{
+	/* configure mock */
+	will_return_maybe(__wrap__test_malloc, ENOMEM);
+
+	/* run test */
+	struct rpma_mr_remote *mr = NULL;
+	int ret = rpma_mr_remote_from_descriptor(&Desc_exp, &mr);
+
+	/* verify the results */
+	assert_int_equal(ret, RPMA_E_NOMEM);
+}
+
+/*
+ * test_remote_from_descriptor__desc_plt_invalid - buff with invalid contents
+ * should be detected as long as it breaks placement value
+ */
+static void
+test_remote_from_descriptor__buff_plt_invalid(void **unused)
+{
+	rpma_mr_descriptor desc_invalid = {0};
+	memset(&desc_invalid, 0xff, sizeof(rpma_mr_descriptor));
+
+	/* configure mock */
+	will_return_maybe(__wrap__test_malloc, MOCK_OK);
+
+	/* run test */
+	struct rpma_mr_remote *mr = NULL;
+	int ret = rpma_mr_remote_from_descriptor(&desc_invalid, &mr);
+
+	/* verify the results */
+	assert_int_equal(ret, RPMA_E_NOSUPP);
+	assert_null(mr);
+}
+
+/* rpma_mr_remote_delete() unit test */
+
+/*
+ * test_remote_delete__mr_ptr_NULL - NULL mr_ptr is invalid
+ */
+static void
+test_remote_delete__mr_ptr_NULL(void **unused)
+{
+	/* run test */
+	int ret = rpma_mr_remote_delete(NULL);
+
+	/* verify the results */
+	assert_int_equal(ret, RPMA_E_INVAL);
+}
+
+/*
+ * test_remote_delete__mr_NULL - NULL mr should exit quickly
+ */
+static void
+test_remote_delete__mr_NULL(void **unused)
+{
+	/* run test */
+	struct rpma_mr_remote *mr = NULL;
+	int ret = rpma_mr_remote_delete(&mr);
+
+	/* verify the results */
+	assert_int_equal(ret, MOCK_OK);
+	assert_null(mr);
+}
+
+/* rpma_mr_remote_get_size() unit test */
+
+/*
+ * test_remote_get_size__mr_ptr_NULL - NULL mr_ptr is invalid
+ */
+static void
+test_remote_get_size__mr_ptr_NULL(void **unused)
+{
+	/* run test */
+	size_t size = 0;
+	int ret = rpma_mr_remote_get_size(NULL, &size);
+
+	/* verify the results */
+	assert_int_equal(ret, RPMA_E_INVAL);
+	assert_int_equal(size, 0);
+}
+
+/*
+ * test_remote_get_size__size_NULL - NULL size pointer is invalid
+ */
+static void
+test_remote_get_size__size_NULL(void **mr_ptr)
+{
+	struct rpma_mr_remote *mr = *mr_ptr;
+
+	/* run test */
+	int ret = rpma_mr_remote_get_size(mr, NULL);
+
+	/* verify the results */
+	assert_int_equal(ret, RPMA_E_INVAL);
+}
+
+/*
+ * test_remote_get_size__mr_ptr_NULL_size_NULL - NULL mr_ptr and NULL size
+ * pointer are invalid
+ */
+static void
+test_remote_get_size__mr_ptr_NULL_size_NULL(void **unused)
+{
+	/* run test */
+	int ret = rpma_mr_remote_get_size(NULL, NULL);
+
+	/* verify the results */
+	assert_int_equal(ret, RPMA_E_INVAL);
+}
+
+/*
+ * test_remote_get_size__success - rpma_mr_remote_get_size() success
+ */
+static void
+test_remote_get_size__success(void **mr_ptr)
+{
+	struct rpma_mr_remote *mr = *mr_ptr;
+
+	/* verify the remote memory region correctness */
+	size_t size = 0;
+	int ret = rpma_mr_remote_get_size(mr, &size);
+	assert_int_equal(ret, MOCK_OK);
+	assert_int_equal(size, MOCK_SIZE);
+}
+
+/* rpma_mr_serialiaze()/_remote_from_descriptor() buffer alignment */
+
+/*
+ * test_get_descriptor__desc_alignment - try rpma_mr_get_descriptor() with a
+ * miscellaneous input descriptor alignment just to be sure the implementation
+ * does not prefer certain alignments.
+ */
+static void
+test_get_descriptor__desc_alignment(void **pprestate)
+{
+	struct prestate *prestate = *pprestate;
+	struct rpma_mr_local *mr = prestate->mr;
+
+	char buff_base[MR_DESC_SIZE * 2];
+	char pattern[MR_DESC_SIZE * 2];
+	memset(pattern, 0xff, MR_DESC_SIZE * 2);
+	rpma_mr_descriptor *desc = NULL;
+	int ret = 0;
+
+	/*
+	 * Generate a miscellaneous output descriptor alignment just to be sure
+	 * the implementation does not prefer certain alignments.
+	 */
+	for (uintptr_t i = 0; i < MR_DESC_SIZE; ++i) {
+		memset(buff_base, 0xff, MR_DESC_SIZE * 2);
+
+		/* run test */
+		desc = (rpma_mr_descriptor *)(buff_base + i);
+		ret = rpma_mr_get_descriptor(mr, desc);
+
+		/* verify the results */
+		assert_int_equal(ret, 0);
+		assert_memory_equal(desc, &Desc_exp, MR_DESC_SIZE);
+		assert_memory_equal(buff_base, pattern, i);
+		assert_memory_equal(
+				buff_base + i + MR_DESC_SIZE,
+				pattern + i + MR_DESC_SIZE,
+				MR_DESC_SIZE - i);
+	}
+}
+
+/*
+ * test_remote_from_descriptor__desc_alignment -- try
+ * rpma_mr_remote_from_descriptor() with a miscellaneous output descriptor
+ * alignment just to be sure the implementation does not prefer certain
+ * alignments.
+ */
+static void
+test_remote_from_descriptor__desc_alignment(void **unused)
+{
+	char buff_base[MR_DESC_SIZE * 2];
+	char pattern[MR_DESC_SIZE * 2];
+	memset(pattern, 0xff, MR_DESC_SIZE * 2);
+
+	rpma_mr_descriptor *desc = NULL;
+	struct rpma_mr_remote *mr = NULL;
+	size_t size = 0;
+	int ret = 0;
+
+	/* configure mock */
+	will_return_always(__wrap__test_malloc, MOCK_OK);
+
+	/*
+	 * Generate a miscellaneous input descriptor alignment just to be sure
+	 * the implementation does not prefer certain alignments.
+	 */
+	for (uintptr_t i = 0; i < MR_DESC_SIZE; ++i) {
+		memset(buff_base, 0xff, MR_DESC_SIZE * 2);
+
+		/* prepare a buffer contents */
+		desc = (rpma_mr_descriptor *)(buff_base + i);
+		memcpy(desc, &Desc_exp, MR_DESC_SIZE);
+
+		/* run test */
+		ret = rpma_mr_remote_from_descriptor(desc, &mr);
+
+		/* verify the results */
+		assert_int_equal(ret, MOCK_OK);
+		assert_non_null(mr);
+		ret = rpma_mr_remote_get_size(mr, &size);
+		assert_int_equal(ret, MOCK_OK);
+		assert_int_equal(size, MOCK_SIZE);
+		/*
+		 * XXX When it will be possible verify addr, rkey, and placement
+		 * using rpma_read or newly introduced getters.
+		 */
+
+		/* cleanup */
+		ret = rpma_mr_remote_delete(&mr);
+		assert_int_equal(ret, MOCK_OK);
+		assert_null(mr);
+	}
+}
+
+int
+main(int argc, char *argv[])
+{
+	struct prestate prestate =
+		{RPMA_MR_USAGE_READ_SRC, IBV_ACCESS_REMOTE_READ, NULL};
+
+	const struct CMUnitTest tests[] = {
+		/* rpma_mr_get_descriptor() unit test */
+		cmocka_unit_test(test_get_descriptor__mr_NULL),
+		cmocka_unit_test_prestate_setup_teardown(
+			test_get_descriptor__desc_NULL,
+			setup__reg_success,
+			teardown__dereg_success,
+			&prestate),
+		cmocka_unit_test(test_get_descriptor__mr_NULL_desc_NULL),
+
+		/* rpma_mr_remote_from_descriptor() unit test */
+		cmocka_unit_test(test_remote_from_descriptor__desc_NULL),
+		cmocka_unit_test(test_remote_from_descriptor__mr_ptr_NULL),
+		cmocka_unit_test(
+			test_remote_from_descriptor__mr_ptr_NULL_desc_NULL),
+		cmocka_unit_test(test_remote_from_descriptor__malloc_ENOMEM),
+		cmocka_unit_test(test_remote_from_descriptor__buff_plt_invalid),
+
+		/* rpma_mr_remote_delete() unit test */
+		cmocka_unit_test(test_remote_delete__mr_ptr_NULL),
+		cmocka_unit_test(test_remote_delete__mr_NULL),
+
+		/* rpma_mr_remote_get_size() unit test */
+		cmocka_unit_test(test_remote_get_size__mr_ptr_NULL),
+		cmocka_unit_test_setup_teardown(test_remote_get_size__size_NULL,
+			setup__mr_remote,
+			teardown__mr_remote),
+		cmocka_unit_test(test_remote_get_size__mr_ptr_NULL_size_NULL),
+		cmocka_unit_test_setup_teardown(test_remote_get_size__success,
+			setup__mr_remote,
+			teardown__mr_remote),
+
+		/*
+		 * rpma_mr_get_descriptor()/rpma_mr_remote_from_descriptor()
+		 * buffer alignment
+		 */
+		cmocka_unit_test_prestate_setup_teardown(
+			test_get_descriptor__desc_alignment,
+			setup__reg_success,
+			teardown__dereg_success,
+			&prestate),
+		cmocka_unit_test(test_remote_from_descriptor__desc_alignment),
+	};
+
+	return cmocka_run_group_tests(tests, NULL, NULL);
+}

--- a/tests/mr-test/mr-test-reg.c
+++ b/tests/mr-test/mr-test-reg.c
@@ -4,34 +4,19 @@
  */
 
 /*
- * mr-test.c -- the memory region unit tests
+ * mr-test.c -- the memory region registration/deregistration unit tests
+ *
+ * APIs covered:
+ * - rpma_mr_reg()
+ * - rpma_mr_dereg()
  */
 
 #include <stdlib.h>
 #include <infiniband/verbs.h>
 
-#include "cmocka_headers.h"
-#include "mr.h"
-#include "librpma.h"
-#include "rpma_err.h"
+#include "mr-test-common.h"
 
-#define MOCK_PEER	(struct rpma_peer *)0x0AD0
-#define MOCK_PTR	(void *)0x0AD1
-#define MOCK_SIZE	(size_t)0x0AD2
-#define MOCK_PLT	(enum rpma_mr_plt)0x0AD4
-#define MOCK_MR		(struct ibv_mr *)0x0AD5
-#define MOCK_ERRNO	(int)(123)
-#define MOCK_OK		(int)0
-#define MOCK_USAGE	(RPMA_MR_USAGE_READ_SRC | RPMA_MR_USAGE_READ_DST)
 #define USAGE_WRONG	(~((int)0)) /* not allowed value of usage */
-
-/* prestate structure passed to unit test functions */
-struct prestate {
-	int usage;
-	int access;
-	/* mr passed from setup to test and to teardown */
-	struct rpma_mr_local *mr;
-};
 
 /* array of prestate structures */
 static struct prestate prestates[] = {
@@ -43,87 +28,6 @@ static struct prestate prestates[] = {
 	{(RPMA_MR_USAGE_READ_SRC | RPMA_MR_USAGE_READ_DST),
 		(IBV_ACCESS_REMOTE_READ | IBV_ACCESS_LOCAL_WRITE), NULL},
 };
-
-/* structure of arguments used in rpma_peer_mr_reg() */
-struct rpma_peer_mr_reg_args {
-	int usage;
-	int access;
-	struct ibv_mr *mr;
-	int verrno;
-};
-
-/* mocks */
-
-/*
- * rpma_peer_mr_reg -- a mock of rpma_peer_mr_reg()
- */
-int
-rpma_peer_mr_reg(struct rpma_peer *peer, struct ibv_mr **ibv_mr, void *addr,
-	size_t length, int access)
-{
-	/*
-	 * rpma_peer_mr_reg() and malloc() may be called in any order.
-	 * If the first one fails, then the second one won't be called,
-	 * so we cannot add cmocka's expects here.
-	 * Otherwise, unconsumed expects would cause a test failure.
-	 */
-	struct rpma_peer_mr_reg_args *args =
-				mock_type(struct rpma_peer_mr_reg_args *);
-	assert_ptr_equal(peer, MOCK_PEER);
-	assert_ptr_equal(addr, MOCK_PTR);
-	assert_int_equal(length, MOCK_SIZE);
-	assert_int_equal(access, args->access);
-
-	*ibv_mr = args->mr;
-	if (*ibv_mr == NULL) {
-		Rpma_provider_error = args->verrno;
-		return RPMA_E_PROVIDER;
-	}
-
-	return 0;
-}
-
-/*
- * ibv_dereg_mr -- a mock of ibv_dereg_mr()
- */
-int
-ibv_dereg_mr(struct ibv_mr *mr)
-{
-	/*
-	 * rpma_peer_mr_reg() and malloc() may be called in any order.
-	 * If the first one fails, then the second one won't be called.
-	 * ibv_dereg_mr() will be called in rpma_mr_reg() only if:
-	 * 1) rpma_peer_mr_reg() succeeded and
-	 * 2) malloc() failed.
-	 * In the opposite case, when:
-	 * 1) malloc() succeeded and
-	 * 2) rpma_peer_mr_reg() failed,
-	 * ibv_dereg_mr() will not be called,
-	 * so we cannot add cmocka's expects here.
-	 * Otherwise, unconsumed expects would cause a test failure.
-	 */
-	assert_int_equal(mr, MOCK_MR);
-
-	return mock_type(int); /* errno */
-}
-
-void *__real__test_malloc(size_t size);
-
-/*
- * __wrap__test_malloc -- malloc() mock
- */
-void *
-__wrap__test_malloc(size_t size)
-{
-	errno = mock_type(int);
-
-	if (errno)
-		return NULL;
-
-	return __real__test_malloc(size);
-}
-
-/* unit tests */
 
 /*
  * test_reg__NULL_peer -- NULL peer is invalid
@@ -285,58 +189,6 @@ test_reg__peer_mr_reg_failed_E_PROVIDER(void **unused)
 }
 
 /*
- * setup__reg_success -- create a local memory registration object
- */
-static int
-setup__reg_success(void **pprestate)
-{
-	struct prestate *prestate = *pprestate;
-
-	/* configure mocks */
-	struct rpma_peer_mr_reg_args mr_reg_args;
-	mr_reg_args.usage = prestate->usage;
-	mr_reg_args.access = prestate->access;
-	mr_reg_args.mr = MOCK_MR;
-	will_return_maybe(rpma_peer_mr_reg, &mr_reg_args);
-	will_return(__wrap__test_malloc, MOCK_OK);
-
-	/* run test */
-	struct rpma_mr_local *mr = NULL;
-	int ret = rpma_mr_reg(MOCK_PEER, MOCK_PTR, MOCK_SIZE,
-				mr_reg_args.usage, MOCK_PLT, &mr);
-
-	/* verify the result */
-	assert_int_equal(ret, MOCK_OK);
-	assert_non_null(mr);
-
-	/* pass mr to the test */
-	prestate->mr = mr;
-
-	return 0;
-}
-
-/*
- * teardown__dereg_success -- delete the local memory registration object
- */
-static int
-teardown__dereg_success(void **pprestate)
-{
-	struct prestate *prestate = *pprestate;
-	struct rpma_mr_local *mr = prestate->mr;
-
-	/* configure mocks */
-	will_return(ibv_dereg_mr, MOCK_OK);
-
-	int ret = rpma_mr_dereg(&mr);
-
-	/* verify the result */
-	assert_int_equal(ret, MOCK_OK);
-	assert_null(mr);
-
-	return 0;
-}
-
-/*
  * test_reg_dereg__success -- happy day scenario
  */
 static void
@@ -347,6 +199,8 @@ test_reg_dereg__success(void **unused)
 	 * and teardown__dereg_success().
 	 */
 }
+
+/* rpma_mr_dereg() unit tests */
 
 /*
  * test_dereg__NULL_mr_ptr -- NULL mr_ptr is invalid


### PR DESCRIPTION
... _mr_remote_get_size and _mr_remote_delete.

Requires:
- [x] rpma_mr_(de)reg implementation #124 
- [x] ~~#130~~

TODO:
- [x] UTs

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/pmem/rpma/125)
<!-- Reviewable:end -->
