### PR TITLE
rpma: remove all ASSERTeq(errno, ENOMEM) for malloc() calls

### DIFF
--- a/src/conn.c
+++ b/src/conn.c
@@ -53,7 +53,6 @@ rpma_conn_new(struct rdma_cm_id *id, struct ibv_cq *cq,
 
 	struct rpma_conn *conn = Malloc(sizeof(*conn));
 	if (!conn) {
-		ASSERTeq(errno, ENOMEM);
 		ret = RPMA_E_NOMEM;
 		goto err_migrate_id_NULL;
 	}

--- a/src/conn_req.c
+++ b/src/conn_req.c
@@ -59,7 +59,6 @@ rpma_conn_req_from_id(struct rpma_peer *peer, struct rdma_cm_id *id,
 
 	*req = (struct rpma_conn_req *)Malloc(sizeof(struct rpma_conn_req));
 	if (*req == NULL) {
-		ASSERTeq(errno, ENOMEM);
 		ret = RPMA_E_NOMEM;
 		goto err_destroy_qp;
 	}

--- a/src/info.c
+++ b/src/info.c
@@ -54,7 +54,6 @@ rpma_info_new(const char *addr, const char *service, enum rpma_info_side side,
 
 	struct rpma_info *info = Malloc(sizeof(*info));
 	if (info == NULL) {
-		ASSERTeq(errno, ENOMEM);
 		ret = RPMA_E_NOMEM;
 		goto err_freeaddrinfo;
 	}

--- a/src/peer.c
+++ b/src/peer.c
@@ -129,7 +129,6 @@ rpma_peer_new(struct ibv_context *ibv_ctx, struct rpma_peer **peer_ptr)
 
 	struct rpma_peer *peer = Malloc(sizeof(*peer));
 	if (peer == NULL) {
-		ASSERTeq(errno, ENOMEM);
 		ret = RPMA_E_NOMEM;
 		goto err_dealloc_pd;
 	}


### PR DESCRIPTION
We decided that if malloc() fails
than RPMA_E_NOMEM is always returned,
no matter what a value of errno is.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/pmem/rpma/128)
<!-- Reviewable:end -->
