### PR TITLE
common: find and rescue orphaned pronouns at the end of the line

### DIFF
--- a/examples/common/common.c
+++ b/examples/common/common.c
@@ -127,8 +127,8 @@ err_conn_delete:
 }
 
 /*
- * client_disconnect -- disconnect, wait for RPMA_CONN_CLOSED and delete the
- * connection structure
+ * client_disconnect -- disconnect, wait for RPMA_CONN_CLOSED and delete
+ * the connection structure
  */
 int
 client_disconnect(struct rpma_conn **conn_ptr)
@@ -233,8 +233,8 @@ server_accept_connection(struct rpma_ep *ep,
 }
 
 /*
- * server_disconnect -- wait for RPMA_CONN_CLOSED, disconnect and delete the
- * connection structure
+ * server_disconnect -- wait for RPMA_CONN_CLOSED, disconnect and delete
+ * the connection structure
  */
 int
 server_disconnect(struct rpma_conn **conn_ptr)

--- a/src/common/util.h
+++ b/src/common/util.h
@@ -12,8 +12,8 @@
  *
  *     * Redistributions in binary form must reproduce the above copyright
  *       notice, this list of conditions and the following disclaimer in
- *       the documentation and/or other materials provided with the
- *       distribution.
+ *       the documentation and/or other materials provided with
+ *       the distribution.
  *
  *     * Neither the name of the copyright holder nor the names of its
  *       contributors may be used to endorse or promote products derived

--- a/src/conn_req.c
+++ b/src/conn_req.c
@@ -83,8 +83,8 @@ err_destroy_cq:
 /*
  * rpma_conn_req_accept -- call rdma_accept()+rdma_ack_cm_event(). If succeeds
  * request re-packing the connection request to a connection object. Otherwise,
- * rdma_disconnect()+rdma_destroy_qp()+ibv_destroy_cq() to destroy the
- * unsuccessful connection request.
+ * rdma_disconnect()+rdma_destroy_qp()+ibv_destroy_cq() to destroy
+ * the unsuccessful connection request.
  */
 static int
 rpma_conn_req_accept(struct rpma_conn_req *req,
@@ -138,8 +138,8 @@ err_conn_req_delete:
 /*
  * rpma_conn_req_connect_active -- call rdma_connect(). If succeeds request
  * re-packing the connection request to a connection object. Otherwise,
- * rdma_destroy_qp()+ibv_destroy_cq()+rdma_destroy_id() to destroy the
- * unsuccessful connection request.
+ * rdma_destroy_qp()+ibv_destroy_cq()+rdma_destroy_id() to destroy
+ * the unsuccessful connection request.
  */
 static int
 rpma_conn_req_connect_active(struct rpma_conn_req *req,
@@ -275,8 +275,8 @@ err_conn_req_delete:
 
 /*
  * rpma_conn_req_new -- create a new outgoing connection request object. It uses
- * rdma_create_id, rpma_info_resolve_addr and rdma_resolve_route and feeds the
- * prepared ID into rpma_conn_req_from_id.
+ * rdma_create_id, rpma_info_resolve_addr and rdma_resolve_route and feeds
+ * the prepared ID into rpma_conn_req_from_id.
  */
 int
 rpma_conn_req_new(struct rpma_peer *peer, const char *addr, const char *service,

--- a/src/include/librpma.h
+++ b/src/include/librpma.h
@@ -342,8 +342,8 @@ struct rpma_conn_private_data {
  *	    struct rpma_conn_private_data *pdata);
  *
  * DESCRIPTION
- * Obtain a pointer to the private data given by the other side of the
- * connection.
+ * Obtain a pointer to the private data given by the other side
+ * of the connection.
  *
  * ERRORS
  * rpma_conn_get_private_data() can fail with the following error:
@@ -648,12 +648,12 @@ int rpma_err_get_provider_error(void);
  *	const char *rpma_err_get_msg(void);
  *
  * DESCRIPTION
- * If an error is detected during the call to a librpma(7) function, the
- * application may retrieve an error message describing the reason of the
- * failure from rpma_err_get_msg(). The error message buffer is thread-local;
- * errors encountered in one thread do not affect its value in
- * other threads. The buffer is never cleared by any library function; its
- * content is significant only when the return value of the immediately
+ * If an error is detected during the call to a librpma(7) function,
+ * the application may retrieve an error message describing the reason
+ * of the failure from rpma_err_get_msg(). The error message buffer
+ * is thread-local; errors encountered in one thread do not affect its value
+ * in other threads. The buffer is never cleared by any library function;
+ * its content is significant only when the return value of the immediately
  * preceding call to a librpma(7) function indicated an error.
  * The application must not modify or free the error message string.
  * Subsequent calls to other library functions may modify the previous message.

--- a/src/info.c
+++ b/src/info.c
@@ -70,8 +70,8 @@ err_freeaddrinfo:
 }
 
 /*
- * rpma_info_delete -- release the address translation cache and delete the
- * info object
+ * rpma_info_delete -- release the address translation cache and delete
+ * the info object
  */
 int
 rpma_info_delete(struct rpma_info **info_ptr)

--- a/tests/conn-test/conn-test-common.c
+++ b/tests/conn-test/conn-test-common.c
@@ -89,8 +89,8 @@ rdma_migrate_id(struct rdma_cm_id *id, struct rdma_event_channel *channel)
 
 	/*
 	 * This mock assumes the first call to rdma_migrate_id() always migrate
-	 * a CM ID to an event channel. Whereas the second call migrate the
-	 * CM ID from the event channel (channel == NULL).
+	 * a CM ID to an event channel. Whereas the second call migrate
+	 * the CM ID from the event channel (channel == NULL).
 	 */
 	if (Rdma_migrate_id_counter == RDMA_MIGRATE_TO_EVCH)
 		assert_ptr_equal(channel, MOCK_EVCH);

--- a/tests/example-01-client/example-01-client.c
+++ b/tests/example-01-client/example-01-client.c
@@ -110,8 +110,8 @@ ibv_alloc_pd(struct ibv_context *ibv_ctx)
 	/*
 	 * The ibv_alloc_pd(3) manual page does not document that this function
 	 * returns any error via errno but seemingly it is. For the usability
-	 * sake, in librpma we try to deduce what really happened using the
-	 * errno value.
+	 * sake, in librpma we try to deduce what really happened using
+	 * the errno value.
 	 */
 	errno = mock_type(int);
 

--- a/tests/mr-test/mr-test-common.c
+++ b/tests/mr-test/mr-test-common.c
@@ -140,8 +140,8 @@ teardown__dereg_success(void **pprestate)
 }
 
 /*
- * setup__mr_remote -- create a remote memory region structure based on a
- * pre-prepared memory region's descriptor
+ * setup__mr_remote -- create a remote memory region structure based
+ * on a pre-prepared memory region's descriptor
  */
 int
 setup__mr_remote(void **mr_ptr)

--- a/tests/mr-test/mr-test-descriptor.c
+++ b/tests/mr-test/mr-test-descriptor.c
@@ -242,8 +242,8 @@ test_remote_get_size__success(void **mr_ptr)
 /* rpma_mr_serialiaze()/_remote_from_descriptor() buffer alignment */
 
 /*
- * test_get_descriptor__desc_alignment - try rpma_mr_get_descriptor() with a
- * miscellaneous input descriptor alignment just to be sure the implementation
+ * test_get_descriptor__desc_alignment - try rpma_mr_get_descriptor() with
+ * a miscellaneous input descriptor alignment just to be sure the implementation
  * does not prefer certain alignments.
  */
 static void

--- a/tests/peer-test/peer-test.c
+++ b/tests/peer-test/peer-test.c
@@ -96,8 +96,8 @@ ibv_alloc_pd(struct ibv_context *ibv_ctx)
 	/*
 	 * The ibv_alloc_pd(3) manual page does not document that this function
 	 * returns any error via errno but seemingly it is. For the usability
-	 * sake, in librpma we try to deduce what really happened using the
-	 * errno value.
+	 * sake, in librpma we try to deduce what really happened using
+	 * the errno value.
 	 */
 	errno = mock_type(int);
 

--- a/tests/private_data-test/private_data-test.c
+++ b/tests/private_data-test/private_data-test.c
@@ -196,8 +196,8 @@ test_lifecycle(void **unused)
 }
 
 /*
- * test_copy__ptr_NULL_len_0 - ptr == NULL and len == 0 should prevent storing a
- * private data
+ * test_copy__ptr_NULL_len_0 - ptr == NULL and len == 0 should prevent storing
+ * a private data
  */
 static void
 test_copy__ptr_NULL_len_0(void **unused)

--- a/utils/cstyle
+++ b/utils/cstyle
@@ -482,6 +482,9 @@ line: while (<$filehandle>) {
 	if (/^\t+ [^ \t\*]/ || /^\t+  \S/ || /^\t+   \S/) {
 		err("continuation line not indented by 4 spaces");
 	}
+	if (/ a$/ || / an$/ || / the$/) {
+		err("orphaned pronoun at the end of the line");
+	}
 	if (/$warlock_re/ && !/\*\//) {
 		$in_warlock_comment = 1;
 		$prev = $line;


### PR DESCRIPTION
A pronoun should always go together with its noun.
It is inhumane and cruel to separate them,
so let's find and rescue all orphaned pronouns!

Make cstyle detect orphaned pronouns at the end of the line.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/pmem/rpma/150)
<!-- Reviewable:end -->
