### PR TITLE
common: remove goto from rpma_conn_req_from_cm_event

### DIFF
--- a/src/conn_req.c
+++ b/src/conn_req.c
@@ -257,18 +257,14 @@ rpma_conn_req_from_cm_event(struct rpma_peer *peer, struct rdma_cm_event *edata,
 	ASSERTne(req, NULL);
 
 	ret = rpma_private_data_store(edata, &req->data);
-	if (ret)
-		goto err_conn_req_delete;
-
+	if (ret) {
+		(void) rpma_conn_req_delete(&req);
+		return ret;
+	}
 	req->edata = edata;
 	*req_ptr = req;
 
 	return 0;
-
-err_conn_req_delete:
-	(void) rpma_conn_req_delete(&req);
-
-	return ret;
 }
 
 /* public librpma API */


### PR DESCRIPTION
Unnecesary goto in rpma_conn_req_from_cm_event removed

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/pmem/rpma/151)
<!-- Reviewable:end -->
