### PR TITLE
examples: rename print_error() to print_error_ex()

### DIFF
--- a/examples/01-connection/client.c
+++ b/examples/01-connection/client.c
@@ -18,7 +18,7 @@
 #endif
 
 static void
-print_error(const char *fname, const int ret)
+print_error_ex(const char *fname, const int ret)
 {
 	int result = 0;
 
@@ -61,21 +61,21 @@ main(int argc, char *argv[])
 	ret = rpma_utils_get_ibv_context(addr, RPMA_UTIL_IBV_CONTEXT_REMOTE,
 			&dev);
 	if (ret) {
-		print_error("rpma_utils_get_ibv_context", ret);
+		print_error_ex("rpma_utils_get_ibv_context", ret);
 		return -1;
 	}
 
 	/* create a new peer object */
 	ret = rpma_peer_new(dev, &peer);
 	if (ret) {
-		print_error("rpma_peer_new", ret);
+		print_error_ex("rpma_peer_new", ret);
 		return -1;
 	}
 
 	/* create a connection request */
 	ret = rpma_conn_req_new(peer, addr, service, &req);
 	if (ret) {
-		print_error("rpma_conn_req_new", ret);
+		print_error_ex("rpma_conn_req_new", ret);
 		goto err_peer_delete;
 	}
 
@@ -86,14 +86,14 @@ main(int argc, char *argv[])
 	pdata.len = (strlen(msg) + 1) * sizeof(char);
 	ret = rpma_conn_req_connect(&req, &pdata, &conn);
 	if (ret) {
-		print_error("rpma_conn_req_connect", ret);
+		print_error_ex("rpma_conn_req_connect", ret);
 		goto err_req_delete;
 	}
 
 	/* wait for the connection to establish */
 	ret = rpma_conn_next_event(conn, &conn_event);
 	if (ret) {
-		print_error("rpma_conn_next_event", ret);
+		print_error_ex("rpma_conn_next_event", ret);
 		goto err_conn_delete;
 	} else if (conn_event != RPMA_CONN_ESTABLISHED) {
 		fprintf(stderr, "rpma_conn_next_event returned an unexptected "
@@ -117,7 +117,7 @@ main(int argc, char *argv[])
 	/* wait for the connection to being closed */
 	ret = rpma_conn_next_event(conn, &conn_event);
 	if (ret) {
-		print_error("rpma_conn_next_event", ret);
+		print_error_ex("rpma_conn_next_event", ret);
 		goto err_conn_disconnect;
 	} else if (conn_event != RPMA_CONN_CLOSED) {
 		fprintf(stderr, "rpma_conn_next_event returned an unexptected "
@@ -132,21 +132,21 @@ main(int argc, char *argv[])
 	/* disconnect the connection */
 	ret = rpma_conn_disconnect(conn);
 	if (ret) {
-		print_error("rpma_conn_disconnect", ret);
+		print_error_ex("rpma_conn_disconnect", ret);
 		goto err_conn_delete;
 	}
 
 	/* delete the connection object */
 	ret = rpma_conn_delete(&conn);
 	if (ret) {
-		print_error("rpma_conn_delete", ret);
+		print_error_ex("rpma_conn_delete", ret);
 		goto err_peer_delete;
 	}
 
 	/* delete the peer object */
 	ret = rpma_peer_delete(&peer);
 	if (ret) {
-		print_error("rpma_peer_delete", ret);
+		print_error_ex("rpma_peer_delete", ret);
 		goto err_exit;
 	}
 

--- a/examples/01-connection/server.c
+++ b/examples/01-connection/server.c
@@ -18,7 +18,7 @@
 #endif
 
 static void
-print_error(const char *fname, const int ret)
+print_error_ex(const char *fname, const int ret)
 {
 	int result = 0;
 
@@ -61,21 +61,21 @@ main(int argc, char *argv[])
 	ret = rpma_utils_get_ibv_context(addr, RPMA_UTIL_IBV_CONTEXT_LOCAL,
 			&dev);
 	if (ret) {
-		print_error("rpma_utils_get_ibv_context", ret);
+		print_error_ex("rpma_utils_get_ibv_context", ret);
 		return -1;
 	}
 
 	/* create a new peer object */
 	ret = rpma_peer_new(dev, &peer);
 	if (ret) {
-		print_error("rpma_peer_new", ret);
+		print_error_ex("rpma_peer_new", ret);
 		return -1;
 	}
 
 	/* create a new endpoint object */
 	ret = rpma_ep_listen(peer, addr, service, &ep);
 	if (ret) {
-		print_error("rpma_ep_listen", ret);
+		print_error_ex("rpma_ep_listen", ret);
 		goto err_peer_delete;
 	}
 	fprintf(stdout, "Waiting for incoming connections...\n");
@@ -83,7 +83,7 @@ main(int argc, char *argv[])
 	/* obtain an incoming connection request */
 	ret = rpma_ep_next_conn_req(ep, &req);
 	if (ret) {
-		print_error("rpma_ep_next_conn_req", ret);
+		print_error_ex("rpma_ep_next_conn_req", ret);
 		goto err_ep_shutdown;
 	}
 
@@ -97,14 +97,14 @@ main(int argc, char *argv[])
 	pdata.len = (strlen(msg) + 1) * sizeof(char);
 	ret = rpma_conn_req_connect(&req, &pdata, &conn);
 	if (ret) {
-		print_error("rpma_conn_req_connect", ret);
+		print_error_ex("rpma_conn_req_connect", ret);
 		goto err_req_delete;
 	}
 
 	/* wait for the connection to being establish */
 	ret = rpma_conn_next_event(conn, &conn_event);
 	if (ret) {
-		print_error("rpma_conn_next_event", ret);
+		print_error_ex("rpma_conn_next_event", ret);
 		goto err_conn_delete;
 	} else if (conn_event != RPMA_CONN_ESTABLISHED) {
 		fprintf(stderr, "rpma_conn_next_event returned an unexptected "
@@ -128,14 +128,14 @@ main(int argc, char *argv[])
 	/* disconnect the connection */
 	ret = rpma_conn_disconnect(conn);
 	if (ret) {
-		print_error("rpma_conn_disconnect", ret);
+		print_error_ex("rpma_conn_disconnect", ret);
 		goto err_conn_delete;
 	}
 
 	/* wait for the connection to being closed */
 	ret = rpma_conn_next_event(conn, &conn_event);
 	if (ret) {
-		print_error("rpma_conn_next_event", ret);
+		print_error_ex("rpma_conn_next_event", ret);
 		goto err_conn_delete;
 	} else if (conn_event != RPMA_CONN_CLOSED) {
 		fprintf(stderr, "rpma_conn_next_event returned an unexptected "
@@ -150,21 +150,21 @@ main(int argc, char *argv[])
 	/* delete the connection object */
 	ret = rpma_conn_delete(&conn);
 	if (ret) {
-		print_error("rpma_conn_delete", ret);
+		print_error_ex("rpma_conn_delete", ret);
 		goto err_ep_shutdown;
 	}
 
 	/* shutdown the endpoint */
 	ret = rpma_ep_shutdown(&ep);
 	if (ret) {
-		print_error("rpma_ep_shutdown", ret);
+		print_error_ex("rpma_ep_shutdown", ret);
 		goto err_peer_delete;
 	}
 
 	/* delete the peer object */
 	ret = rpma_peer_delete(&peer);
 	if (ret) {
-		print_error("rpma_peer_delete", ret);
+		print_error_ex("rpma_peer_delete", ret);
 		goto err_exit;
 	}
 

--- a/examples/02-read-to-volatile/client.c
+++ b/examples/02-read-to-volatile/client.c
@@ -60,7 +60,7 @@ main(int argc, char *argv[])
 	ret = rpma_mr_reg(peer, dst_ptr, KILOBYTE, RPMA_MR_USAGE_READ_DST,
 			RPMA_MR_PLT_VOLATILE, &dst_mr);
 	if (ret) {
-		print_error("rpma_mr_reg", ret);
+		print_error_ex("rpma_mr_reg", ret);
 		goto err_mr_free;
 	}
 
@@ -73,10 +73,10 @@ main(int argc, char *argv[])
 	struct rpma_conn_private_data pdata;
 	ret = rpma_conn_get_private_data(conn, &pdata);
 	if (ret) {
-		print_error("rpma_conn_next_event", ret);
+		print_error_ex("rpma_conn_next_event", ret);
 		goto err_conn_disconnect;
 	} else if (pdata.ptr == NULL) {
-		print_error(
+		print_error_ex(
 				"The server has not provided a remote memory region. (the connection's private data is empty)",
 				ret);
 		goto err_conn_disconnect;
@@ -89,14 +89,14 @@ main(int argc, char *argv[])
 	rpma_mr_descriptor *desc = pdata.ptr;
 	ret = rpma_mr_remote_from_descriptor(desc, &src_mr);
 	if (ret) {
-		print_error("rpma_mr_remote_from_descriptor", ret);
+		print_error_ex("rpma_mr_remote_from_descriptor", ret);
 		goto err_conn_disconnect;
 	}
 
 	/* get the remote memory region size */
 	ret = rpma_mr_remote_get_size(src_mr, &src_size);
 	if (ret) {
-		print_error("rpma_mr_remote_size", ret);
+		print_error_ex("rpma_mr_remote_size", ret);
 		goto err_mr_remote_delete;
 	} else if (src_size > KILOBYTE) {
 		fprintf(stderr,
@@ -115,7 +115,7 @@ main(int argc, char *argv[])
 	/* wait for a completion of the RDMA read */
 	ret = rpma_conn_next_completion(conn, &cmpl);
 	if (ret) {
-		print_error("rpma_conn_next_completion", ret);
+		print_error_ex("rpma_conn_next_completion", ret);
 	} else if (cmpl.op != RPMA_OP_READ) {
 		fprintf(stderr,
 				"rpma_conn_next_completion returned a completion of an unexpected operation: %d\n",
@@ -132,7 +132,7 @@ err_mr_remote_delete:
 	/* delete the remote memory region's structure */
 	ret = rpma_mr_remote_delete(&src_mr);
 	if (ret)
-		print_error("rpma_mr_remote_delete", ret);
+		print_error_ex("rpma_mr_remote_delete", ret);
 
 err_conn_disconnect:
 	(void) common_disconnect_and_wait_for_conn_close(&conn);
@@ -141,7 +141,7 @@ err_mr_dereg:
 	/* deregister the memory region */
 	ret = rpma_mr_dereg(&dst_mr);
 	if (ret)
-		print_error("rpma_mr_dereg", ret);
+		print_error_ex("rpma_mr_dereg", ret);
 
 err_mr_free:
 	/* free the memory */
@@ -151,7 +151,7 @@ err_peer_delete:
 	/* delete the peer */
 	ret = rpma_peer_delete(&peer);
 	if (ret)
-		print_error("rpma_peer_delete", ret);
+		print_error_ex("rpma_peer_delete", ret);
 
 	return ret;
 }

--- a/examples/02-read-to-volatile/server.c
+++ b/examples/02-read-to-volatile/server.c
@@ -67,7 +67,7 @@ main(int argc, char *argv[])
 	ret = rpma_mr_reg(peer, mr_ptr, mr_size, RPMA_MR_USAGE_READ_SRC,
 			RPMA_MR_PLT_VOLATILE, &mr);
 	if (ret) {
-		print_error("rpma_mr_reg", ret);
+		print_error_ex("rpma_mr_reg", ret);
 		goto err_mr_free;
 	}
 
@@ -79,7 +79,7 @@ main(int argc, char *argv[])
 	/* receive the memory region's descriptor */
 	ret = rpma_mr_get_descriptor(mr, &desc);
 	if (ret) {
-		print_error("rpma_mr_get_descriptor", ret);
+		print_error_ex("rpma_mr_get_descriptor", ret);
 	}
 
 	/*
@@ -105,7 +105,7 @@ err_mr_dereg:
 	/* deregister the memory region */
 	ret = rpma_mr_dereg(&mr);
 	if (ret)
-		print_error("rpma_mr_dereg", ret);
+		print_error_ex("rpma_mr_dereg", ret);
 
 err_mr_free:
 	/* free the memory */
@@ -115,13 +115,13 @@ err_ep_shutdown:
 	/* shutdown the endpoint */
 	ret = rpma_ep_shutdown(&ep);
 	if (ret)
-		print_error("rpma_ep_shutdown", ret);
+		print_error_ex("rpma_ep_shutdown", ret);
 
 err_peer_delete:
 	/* delete the peer object */
 	ret = rpma_peer_delete(&peer);
 	if (ret)
-		print_error("rpma_peer_delete", ret);
+		print_error_ex("rpma_peer_delete", ret);
 
 	return ret;
 }

--- a/examples/common/common.c
+++ b/examples/common/common.c
@@ -12,10 +12,13 @@
 #include "common.h"
 
 /*
- * print_error -- print RPMA error to stderr
+ * print_error_ex -- print RPMA error to stderr
+ *
+ * The name is "print_error_ex" to distinguish
+ * from the cmocka's "print_error" function.
  */
 void
-print_error(const char *fname, int ret)
+print_error_ex(const char *fname, int ret)
 {
 	if (ret == RPMA_E_PROVIDER) {
 		int errnum = rpma_err_get_provider_error();
@@ -62,14 +65,14 @@ common_peer_via_address(const char *addr, enum rpma_util_ibv_context_type type,
 
 	int ret = rpma_utils_get_ibv_context(addr, type, &dev);
 	if (ret) {
-		print_error("rpma_utils_get_ibv_context", ret);
+		print_error_ex("rpma_utils_get_ibv_context", ret);
 		return -1;
 	}
 
 	/* create a new peer object */
 	ret = rpma_peer_new(dev, peer_ptr);
 	if (ret) {
-		print_error("rpma_peer_new", ret);
+		print_error_ex("rpma_peer_new", ret);
 		return -1;
 	}
 
@@ -91,14 +94,14 @@ client_connect(struct rpma_peer *peer, const char *addr, const char *service,
 	/* create a connection request */
 	int ret = rpma_conn_req_new(peer, addr, service, &req);
 	if (ret) {
-		print_error("rpma_conn_req_new", ret);
+		print_error_ex("rpma_conn_req_new", ret);
 		return -1;
 	}
 
 	/* connect the connection request and obtain the connection object */
 	ret = rpma_conn_req_connect(&req, pdata, conn_ptr);
 	if (ret) {
-		print_error("rpma_conn_req_connect", ret);
+		print_error_ex("rpma_conn_req_connect", ret);
 		(void) rpma_conn_req_delete(&req);
 		return -1;
 	}
@@ -106,7 +109,7 @@ client_connect(struct rpma_peer *peer, const char *addr, const char *service,
 	/* wait for the connection to establish */
 	ret = rpma_conn_next_event(*conn_ptr, &conn_event);
 	if (ret) {
-		print_error("rpma_conn_next_event", ret);
+		print_error_ex("rpma_conn_next_event", ret);
 		goto err_conn_delete;
 	} else if (conn_event != RPMA_CONN_ESTABLISHED) {
 		fprintf(stderr,
@@ -136,7 +139,7 @@ server_listen(struct rpma_peer *peer, const char *addr, const char *service,
 	/* create a new endpoint object */
 	int ret = rpma_ep_listen(peer, addr, service, ep_ptr);
 	if (ret) {
-		print_error("rpma_ep_listen", ret);
+		print_error_ex("rpma_ep_listen", ret);
 		return ret;
 	}
 	fprintf(stdout, "Waiting for incoming connections...\n");
@@ -159,7 +162,7 @@ server_accept_connection(struct rpma_ep *ep,
 	/* receive an incoming connection request */
 	int ret = rpma_ep_next_conn_req(ep, &req);
 	if (ret) {
-		print_error("rpma_ep_next_conn_req", ret);
+		print_error_ex("rpma_ep_next_conn_req", ret);
 		return ret;
 	}
 
@@ -169,7 +172,7 @@ server_accept_connection(struct rpma_ep *ep,
 	 */
 	ret = rpma_conn_req_connect(&req, pdata, conn_ptr);
 	if (ret) {
-		print_error("rpma_conn_req_connect", ret);
+		print_error_ex("rpma_conn_req_connect", ret);
 		(void) rpma_conn_req_delete(&req);
 		return ret;
 	}
@@ -177,7 +180,7 @@ server_accept_connection(struct rpma_ep *ep,
 	/* wait for the connection to be established */
 	ret = rpma_conn_next_event(*conn_ptr, &conn_event);
 	if (ret) {
-		print_error("rpma_conn_next_event", ret);
+		print_error_ex("rpma_conn_next_event", ret);
 	} else if (conn_event != RPMA_CONN_ESTABLISHED) {
 		fprintf(stderr,
 				"rpma_conn_next_event returned an unexptected event: %s\n",
@@ -204,7 +207,7 @@ common_disconnect_verbose(struct rpma_conn *conn)
 	/* disconnect the connection */
 	int ret = rpma_conn_disconnect(conn);
 	if (ret)
-		print_error("rpma_conn_disconnect", ret);
+		print_error_ex("rpma_conn_disconnect", ret);
 
 	return ret;
 }
@@ -221,7 +224,7 @@ common_wait_for_conn_close_verbose(struct rpma_conn *conn)
 	/* wait for the connection to be closed */
 	int ret = rpma_conn_next_event(conn, &conn_event);
 	if (ret) {
-		print_error("rpma_conn_next_event", ret);
+		print_error_ex("rpma_conn_next_event", ret);
 	} else if (conn_event != RPMA_CONN_CLOSED) {
 		fprintf(stderr,
 				"rpma_conn_next_event returned an unexptected event: %s\n",
@@ -245,7 +248,7 @@ common_conn_delete_verbose(struct rpma_conn **conn_ptr)
 	/* delete the connection object */
 	int ret = rpma_conn_delete(conn_ptr);
 	if (ret)
-		print_error("rpma_conn_delete", ret);
+		print_error_ex("rpma_conn_delete", ret);
 
 	return ret;
 }

--- a/examples/common/common.h
+++ b/examples/common/common.h
@@ -12,7 +12,7 @@
 
 #define KILOBYTE 1024
 
-void print_error(const char *fname, int ret);
+void print_error_ex(const char *fname, int ret);
 
 void *malloc_aligned(size_t size);
 


### PR DESCRIPTION
Rename `print_error()` to `print_error_ex()`,
because cmocka (a unit test framework we use)
also has the `print_error()` function
and they can be confused by a linker.

It happened for me that cmocka used
the version of librpma examples
(instead of its own one)
and the printed errors were incorrect
and many important information were missing.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/pmem/rpma/163)
<!-- Reviewable:end -->
