### PR TITLE
examples: fix setting LINK_FLAGS in the example-01-connection test

### DIFF
--- a/tests/integration/example-01-connection/CMakeLists.txt
+++ b/tests/integration/example-01-connection/CMakeLists.txt
@@ -30,8 +30,7 @@ target_include_directories(${TARGET} PRIVATE
 
 set_target_properties(${TARGET}
        PROPERTIES
-       LINK_FLAGS "-Wl,--wrap=fprintf"
-       LINK_FLAGS "-Wl,--wrap=_test_malloc")
+       LINK_FLAGS "-Wl,--wrap=_test_malloc,--wrap=fprintf")
 
 target_compile_definitions(${TARGET}
        PUBLIC TEST_MOCK_MAIN


### PR DESCRIPTION
LINK_FLAGS is set twice now, but the second one overwrites
the first one. LINK_FLAGS can be set only once.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/pmem/rpma/169)
<!-- Reviewable:end -->
