### PR TITLE
common: link libibverbs as public

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -32,8 +32,9 @@ if(TESTS_USE_FAULT_INJECTION)
 	target_compile_definitions(rpma PUBLIC FAULT_INJECTION=1)
 endif()
 
-target_link_libraries(rpma PRIVATE
-	${LIBIBVERBS_LIBRARIES}
+target_link_libraries(rpma
+	PUBLIC ${LIBIBVERBS_LIBRARIES}
+	PRIVATE
 	${LIBRDMACM_LIBRARIES}
 	-Wl,--version-script=${CMAKE_SOURCE_DIR}/src/librpma.map)
 


### PR DESCRIPTION
Since librpma has a few libibverbs primitives in its interface it is desirable to allow build an application using librpma and libibverbs seamlessly. Linking libibverbs publicly to librpma allows specifying only librpma to use both in the resulting application.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/pmem/rpma/182)
<!-- Reviewable:end -->
