### PR TITLE
common: rpma_ep_next_conn_req can return RPMA_E_NO_NEXT

### DIFF
--- a/src/ep.c
+++ b/src/ep.c
@@ -160,6 +160,9 @@ rpma_ep_next_conn_req(struct rpma_ep *ep, struct rpma_conn_req **req)
 
 	/* get an event */
 	if (rdma_get_cm_event(ep->evch, &event)) {
+		if (errno == ENODATA)
+			return RPMA_E_NO_NEXT;
+
 		Rpma_provider_error = errno;
 		return RPMA_E_PROVIDER;
 	}

--- a/src/include/librpma.h
+++ b/src/include/librpma.h
@@ -30,6 +30,7 @@
 #define RPMA_E_NOMEM			(-100003) /* Out of memory */
 #define RPMA_E_INVAL			(-100004) /* Invalid argument */
 #define RPMA_E_NO_COMPLETION		(-100005) /* No completion available */
+#define RPMA_E_NO_NEXT			(-100006) /* No next event available */
 
 /* picking up an RDMA-capable device */
 
@@ -588,6 +589,7 @@ int rpma_ep_get_fd(struct rpma_ep *ep, int *fd);
  * - RPMA_E_INVAL - obtained an event different than a connection request
  * - RPMA_E_PROVIDER - rdma_get_cm_event(3) failed
  * - RPMA_E_NOMEM - out of memory
+ * - RPMA_E_NO_NEXT - no next connection request available
  */
 int rpma_ep_next_conn_req(struct rpma_ep *ep, struct rpma_conn_req **req);
 

--- a/tests/unit/ep-test/ep-test.c
+++ b/tests/unit/ep-test/ep-test.c
@@ -800,6 +800,28 @@ ep_next_conn_req_test_get_cm_event_EAGAIN(void **estate_ptr)
 }
 
 /*
+ * ep_next_conn_req_test_get_cm_event_ENODATA -
+ * rdma_get_cm_event() fails with ENODATA
+ */
+static void
+ep_next_conn_req_test_get_cm_event_ENODATA(void **estate_ptr)
+{
+	struct ep_test_state *estate = *estate_ptr;
+
+	expect_value(rdma_get_cm_event, channel, &estate->evch);
+	will_return(rdma_get_cm_event, NULL);
+	will_return(rdma_get_cm_event, ENODATA);
+
+	/* run test */
+	struct rpma_conn_req *req = NULL;
+	int ret = rpma_ep_next_conn_req(estate->ep, &req);
+
+	/* verify the results */
+	assert_int_equal(ret, RPMA_E_NO_NEXT);
+	assert_null(req);
+}
+
+/*
  * ep_next_conn_req_test_event_REJECTED -
  * RDMA_CM_EVENT_REJECTED is unexpected
  */
@@ -977,6 +999,9 @@ main(int argc, char *argv[])
 			ep_next_conn_req_test_req_NULL,
 			ep_setup, ep_teardown),
 		cmocka_unit_test(ep_next_conn_req_test_ep_NULL_req_NULL),
+		cmocka_unit_test_setup_teardown(
+			ep_next_conn_req_test_get_cm_event_ENODATA,
+			ep_setup, ep_teardown),
 		cmocka_unit_test_setup_teardown(
 			ep_next_conn_req_test_get_cm_event_EAGAIN,
 			ep_setup, ep_teardown),


### PR DESCRIPTION


<!-- Reviewable:start -->
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/pmem/rpma/190)
<!-- Reviewable:end -->
