### PR TITLE
rpma: fix two error handling paths in conn.c and flush.c

### DIFF
--- a/src/conn.c
+++ b/src/conn.c
@@ -321,6 +321,9 @@ rpma_flush(struct rpma_conn *conn,
 	struct rpma_mr_remote *dst, size_t dst_offset, size_t len,
 	enum rpma_flush_type type, int flags, void *op_context)
 {
+	if (conn == NULL || dst == NULL || flags == 0)
+		return RPMA_E_INVAL;
+
 	rpma_flush_func flush = conn->flush->func;
 	return flush(conn->id->qp, conn->flush, dst, dst_offset,
 			len, type, flags, op_context);

--- a/src/flush.c
+++ b/src/flush.c
@@ -154,9 +154,9 @@ rpma_flush_delete(struct rpma_flush **flush_ptr)
 	struct rpma_flush_internal *flush_internal =
 			*(struct rpma_flush_internal **)flush_ptr;
 
-	flush_internal->delete_func(*flush_ptr);
+	int ret = flush_internal->delete_func(*flush_ptr);
 	free(*flush_ptr);
 	*flush_ptr = NULL;
 
-	return 0;
+	return ret;
 }


### PR DESCRIPTION


<!-- Reviewable:start -->
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/pmem/rpma/211)
<!-- Reviewable:end -->
