### PR TITLE
common: prepare examples for incoming completions

### DIFF
--- a/examples/02-read-to-volatile/client.c
+++ b/examples/02-read-to-volatile/client.c
@@ -118,6 +118,13 @@ main(int argc, char *argv[])
 	ret = rpma_read(conn, dst_mr, 0, src_mr, 0, src_size,
 			RPMA_F_COMPLETION_ALWAYS, NULL);
 
+	/* wait for the completion to be ready */
+	ret = rpma_conn_prepare_completions(conn);
+	if (ret) {
+		print_error_ex("rpma_conn_prepare_completions", ret);
+		goto err_conn_disconnect;
+	}
+
 	/* wait for a completion of the RDMA read */
 	ret = rpma_conn_next_completion(conn, &cmpl);
 	if (ret) {

--- a/examples/03-read-to-persistent/server.c
+++ b/examples/03-read-to-persistent/server.c
@@ -168,6 +168,13 @@ main(int argc, char *argv[])
 	if (ret)
 		goto err_disconnect;
 
+	/* wait for the completion to be ready */
+	ret = rpma_conn_prepare_completions(conn);
+	if (ret) {
+		print_error_ex("rpma_conn_prepare_completions", ret);
+		goto err_disconnect;
+	}
+
 	ret = rpma_conn_next_completion(conn, &cmpl);
 	if (ret) {
 		print_error_ex("rpma_conn_next_completion", ret);

--- a/examples/04-write-to-persistent/client.c
+++ b/examples/04-write-to-persistent/client.c
@@ -243,6 +243,13 @@ main(int argc, char *argv[])
 	if (ret)
 		goto err_conn_disconnect;
 
+	/* wait for the completion to be ready */
+	ret = rpma_conn_prepare_completions(conn);
+	if (ret) {
+		print_error_ex("rpma_conn_prepare_completions", ret);
+		goto err_conn_disconnect;
+	}
+
 	ret = rpma_conn_next_completion(conn, &cmpl);
 	if (ret) {
 		print_error_ex("rpma_conn_next_completion", ret);

--- a/examples/05-flush-to-persistent/client.c
+++ b/examples/05-flush-to-persistent/client.c
@@ -228,6 +228,13 @@ main(int argc, char *argv[])
 	if (ret)
 		goto err_conn_disconnect;
 
+	/* wait for the completion to be ready */
+	ret = rpma_conn_prepare_completions(conn);
+	if (ret) {
+		print_error_ex("rpma_conn_prepare_completions", ret);
+		goto err_conn_disconnect;
+	}
+
 	ret = rpma_conn_next_completion(conn, &cmpl);
 	if (ret) {
 		print_error_ex("rpma_conn_next_completion", ret);

--- a/tests/integration/example-02-read-to-volatile/example-02-read-to-volatile.c
+++ b/tests/integration/example-02-read-to-volatile/example-02-read-to-volatile.c
@@ -145,6 +145,13 @@ test_client__success(void **unused)
 	expect_value(rdma_ack_cm_event, event, &f_event);
 	will_return(rdma_ack_cm_event, MOCK_OK);
 
+	/* configure mocks for rpma_conn_prepare_completions() */
+	expect_value(ibv_get_cq_event, channel, MOCK_COMP_CHANNEL);
+	will_return(ibv_get_cq_event, MOCK_OK);
+	expect_value(ibv_ack_cq_events, cq, MOCK_CQ);
+	will_return(ibv_req_notify_cq_mock, MOCK_OK);
+
+	/* configure mock for rpma_conn_next_completion() */
 	struct ibv_wc wc = {0};
 	wc.opcode = IBV_WC_RDMA_READ;
 	expect_value(ibv_poll_cq_mock, cq, &Ibv_cq);


### PR DESCRIPTION
ibv_poll_cq() may return zero when no CQEs are ready.
rpma_conn_prepare_completions() allows waiting for CQE to appear.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/pmem/rpma/231)
<!-- Reviewable:end -->
