### PR TITLE
common: fall back to On-Demand Paging registration if supported

### DIFF
--- a/tests/integration/common/mocks.c
+++ b/tests/integration/common/mocks.c
@@ -16,6 +16,16 @@ struct ibv_cq Ibv_cq;		/* mock IBV CQ */
 struct ibv_mr Ibv_mr;		/* mock IBV MR */
 struct ibv_mr Ibv_mr_raw; /* mock IBV MR RAW */
 
+/* predefined IBV On-demand Paging caps */
+struct ibv_odp_caps Ibv_odp_capable_caps = {
+	.general_caps = IBV_ODP_SUPPORT,
+	.per_transport_caps = {
+			IBV_ODP_SUPPORT_WRITE | IBV_ODP_SUPPORT_READ,
+			0,
+			0
+	},
+};
+
 /*
  * ibv_query_device -- ibv_query_device() mock
  */

--- a/tests/integration/common/mocks.h
+++ b/tests/integration/common/mocks.h
@@ -39,6 +39,9 @@ extern struct ibv_cq Ibv_cq;		/* mock IBV CQ */
 extern struct ibv_mr Ibv_mr;		/* mock IBV MR */
 extern struct ibv_mr Ibv_mr_raw;	/* mock IBV MR RAW */
 
+/* predefined IBV On-demand Paging caps */
+extern struct ibv_odp_caps Ibv_odp_capable_caps;
+
 struct posix_memalign_args {
 	void *ptr;
 };

--- a/tests/integration/example-01-connection/example-01-connection.c
+++ b/tests/integration/example-01-connection/example-01-connection.c
@@ -48,6 +48,7 @@ test_client__success(void **unused)
 	expect_value(rdma_freeaddrinfo, res, &res1);
 
 	/* configure mocks for rpma_peer_new */
+	will_return(ibv_query_device_ex_mock, &Ibv_odp_capable_caps);
 	expect_value(ibv_alloc_pd, ibv_ctx, MOCK_VERBS);
 	will_return(ibv_alloc_pd, MOCK_IBV_PD);
 
@@ -181,6 +182,7 @@ test_server__success(void **unused)
 	expect_value(rdma_freeaddrinfo, res, &res1);
 
 	/* configure mocks for rpma_peer_new */
+	will_return(ibv_query_device_ex_mock, &Ibv_odp_capable_caps);
 	expect_value(ibv_alloc_pd, ibv_ctx, MOCK_VERBS);
 	will_return(ibv_alloc_pd, MOCK_IBV_PD);
 
@@ -311,6 +313,9 @@ test_server__success(void **unused)
 int
 main(int argc, char *argv[])
 {
+	MOCK_VERBS->abi_compat = __VERBS_ABI_IS_EXTENDED;
+	Verbs_context.query_device_ex = ibv_query_device_ex_mock;
+	Verbs_context.sz = sizeof(struct verbs_context);
 	MOCK_VERBS->ops.req_notify_cq = ibv_req_notify_cq_mock;
 	Ibv_cq.context = MOCK_VERBS;
 

--- a/tests/integration/example-02-read-to-volatile/example-02-read-to-volatile.c
+++ b/tests/integration/example-02-read-to-volatile/example-02-read-to-volatile.c
@@ -63,6 +63,7 @@ test_client__success(void **unused)
 	expect_value(rdma_freeaddrinfo, res, &res1);
 
 	/* configure mocks for rpma_peer_new() */
+	will_return(ibv_query_device_ex_mock, &Ibv_odp_capable_caps);
 	expect_value(ibv_alloc_pd, ibv_ctx, MOCK_VERBS);
 	will_return(ibv_alloc_pd, MOCK_IBV_PD);
 
@@ -232,6 +233,7 @@ test_server__success(void **unused)
 	expect_value(rdma_freeaddrinfo, res, &res1);
 
 	/* configure mocks for rpma_peer_new() */
+	will_return(ibv_query_device_ex_mock, &Ibv_odp_capable_caps);
 	expect_value(ibv_alloc_pd, ibv_ctx, MOCK_VERBS);
 	will_return(ibv_alloc_pd, MOCK_IBV_PD);
 
@@ -375,6 +377,9 @@ test_server__success(void **unused)
 int
 main(int argc, char *argv[])
 {
+	MOCK_VERBS->abi_compat = __VERBS_ABI_IS_EXTENDED;
+	Verbs_context.query_device_ex = ibv_query_device_ex_mock;
+	Verbs_context.sz = sizeof(struct verbs_context);
 	MOCK_VERBS->ops.post_send = ibv_post_send_mock;
 	MOCK_VERBS->ops.poll_cq = ibv_poll_cq_mock;
 	MOCK_VERBS->ops.req_notify_cq = ibv_req_notify_cq_mock;

--- a/tests/unit/common/mocks-rpma-utils.c
+++ b/tests/unit/common/mocks-rpma-utils.c
@@ -1,0 +1,33 @@
+/*
+ * SPDX-License-Identifier: BSD-3-Clause
+ * Copyright 2020, Intel Corporation
+ */
+
+/*
+ * mocks-rpma-utils.c -- librpma rpma.c module mocks (rpma_utils_*)
+ */
+
+#include <rdma/rdma_cma.h>
+#include <librpma.h>
+
+#include "cmocka_headers.h"
+#include "mocks-ibverbs.h"
+#include "test-common.h"
+
+/*
+ * rpma_utils_ibv_context_is_odp_capable --
+ * rpma_utils_ibv_context_is_odp_capable() mock
+ */
+int
+rpma_utils_ibv_context_is_odp_capable(struct ibv_context *dev,
+		int *is_odp_capable)
+{
+	assert_ptr_equal(dev, MOCK_VERBS);
+	assert_non_null(is_odp_capable);
+
+	*is_odp_capable = mock_type(int);
+	if (*is_odp_capable == MOCK_ERR_PENDING)
+		return mock_type(int);
+
+	return 0;
+}

--- a/tests/unit/common/test-common.h
+++ b/tests/unit/common/test-common.h
@@ -27,5 +27,6 @@
 
 #define MOCK_PASSTHROUGH	0
 #define MOCK_VALIDATE		1
+#define MOCK_ERR_PENDING	(-1)
 
 #endif /* TEST_COMMON_H */

--- a/tests/unit/peer-test/CMakeLists.txt
+++ b/tests/unit/peer-test/CMakeLists.txt
@@ -8,6 +8,7 @@ include(../../cmake/ctest_helpers.cmake)
 build_test_src(UNIT NAME peer-test SRCS
 	peer-test.c
 	${TEST_UNIT_COMMON_DIR}/mocks-ibverbs.c
+	${TEST_UNIT_COMMON_DIR}/mocks-rpma-utils.c
 	${LIBRPMA_SOURCE_DIR}/rpma_err.c
 	${LIBRPMA_SOURCE_DIR}/peer.c)
 

--- a/tests/unit/peer-test/peer-test.c
+++ b/tests/unit/peer-test/peer-test.c
@@ -139,6 +139,7 @@ peer_new_test_alloc_pd_fail_ENOMEM(void **unused)
 	will_return(ibv_alloc_pd, &alloc_args);
 	expect_value(ibv_alloc_pd, ibv_ctx, MOCK_VERBS);
 	will_return(ibv_alloc_pd, ENOMEM);
+	will_return_maybe(rpma_utils_ibv_context_is_odp_capable, 1);
 	will_return_maybe(__wrap__test_malloc, MOCK_OK);
 
 	/* run test */
@@ -166,6 +167,7 @@ peer_new_test_alloc_pd_fail_EAGAIN(void **unused)
 	will_return(ibv_alloc_pd, &alloc_args);
 	expect_value(ibv_alloc_pd, ibv_ctx, MOCK_VERBS);
 	will_return(ibv_alloc_pd, EAGAIN);
+	will_return_maybe(rpma_utils_ibv_context_is_odp_capable, 1);
 	will_return_maybe(__wrap__test_malloc, MOCK_OK);
 
 	/* run test */
@@ -193,6 +195,7 @@ peer_new_test_alloc_pd_fail_no_error(void **unused)
 	will_return(ibv_alloc_pd, &alloc_args);
 	expect_value(ibv_alloc_pd, ibv_ctx, MOCK_VERBS);
 	will_return(ibv_alloc_pd, MOCK_OK);
+	will_return_maybe(rpma_utils_ibv_context_is_odp_capable, 1);
 	will_return_maybe(__wrap__test_malloc, MOCK_OK);
 
 	/* run test */
@@ -211,13 +214,14 @@ static void
 peer_new_test_malloc_fail(void **unused)
 {
 	/* configure mocks */
+	will_return(__wrap__test_malloc, ENOMEM);
 	struct ibv_alloc_pd_mock_args alloc_args =
 		{MOCK_PASSTHROUGH, MOCK_IBV_PD};
 	will_return_maybe(ibv_alloc_pd, &alloc_args);
 	struct ibv_dealloc_pd_mock_args dealloc_args =
 		{MOCK_PASSTHROUGH, MOCK_OK};
 	will_return_maybe(ibv_dealloc_pd, &dealloc_args);
-	will_return(__wrap__test_malloc, ENOMEM);
+	will_return_maybe(rpma_utils_ibv_context_is_odp_capable, 1);
 
 	/* run test */
 	struct rpma_peer *peer = NULL;
@@ -239,6 +243,7 @@ peer_new_test_success(void **unused)
 	 * NOTE: it is not allowed to call ibv_dealloc_pd() if ibv_alloc_pd()
 	 * succeeded.
 	 */
+	will_return(rpma_utils_ibv_context_is_odp_capable, 1);
 	struct ibv_alloc_pd_mock_args alloc_args = {MOCK_VALIDATE, MOCK_IBV_PD};
 	will_return(ibv_alloc_pd, &alloc_args);
 	expect_value(ibv_alloc_pd, ibv_ctx, MOCK_VERBS);
@@ -320,6 +325,7 @@ peer_setup(void **peer_ptr)
 	 * NOTE: it is not allowed to call ibv_dealloc_pd() if ibv_alloc_pd()
 	 * succeeded.
 	 */
+	will_return(rpma_utils_ibv_context_is_odp_capable, 1);
 	struct ibv_alloc_pd_mock_args alloc_args = {MOCK_VALIDATE, MOCK_IBV_PD};
 	will_return(ibv_alloc_pd, &alloc_args);
 	expect_value(ibv_alloc_pd, ibv_ctx, MOCK_VERBS);


### PR DESCRIPTION
Includes:
- ODP detection - (rpma_utils_ibv_context_is_odp_capable)
- adding IBV_ACCESS_ON_DEMAND to the flags if regular memory
  registration will fail with EOPNOTSUPP and ODP is supported
- tweaking existing tests to use upgraded implementation

Does not include:
- new tests for handling the fails of the introduced API calls

Requires:
- [x] #240 

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/pmem/rpma/233)
<!-- Reviewable:end -->
