### PR TITLE
common: split the log module

### DIFF
--- a/examples/CMakeLists.txt
+++ b/examples/CMakeLists.txt
@@ -92,6 +92,10 @@ add_example(NAME 06-multiple-connections BIN server USE_LIBPMEM_IF_FOUND
 add_example(NAME 06-multiple-connections BIN client USE_LIBPMEM_IF_FOUND
 	SRCS 06-multiple-connections/client.c common/common.c)
 
-add_example(NAME log BIN log SRCS log/log-example.c log/log-worker.c)
+add_example(NAME log BIN log SRCS
+	log/log-example.c
+	log/log-worker.c
+	${LIBRPMA_SOURCE_DIR}/log.c
+	${LIBRPMA_SOURCE_DIR}/log_default.c)
 
 add_library(doc_snippets_template-snippet OBJECT doc_snippets/template-snippet.c)

--- a/examples/log/log-worker.c
+++ b/examples/log/log-worker.c
@@ -16,5 +16,4 @@ log_worker_is_doing_something(void)
 	RPMA_LOG_NOTICE("Just a notice");
 	RPMA_LOG_WARNING("Important warning about value: %d", 720401);
 	RPMA_LOG_ERROR("Error due to order %x", 102);
-	RPMA_PRINTF("PRINTF message requires explicit '\\n' at the end\n");
 }

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -19,6 +19,7 @@ set(SOURCES
 	info.c
 	librpma.c
 	log.c
+	log_default.c
 	mr.c
 	peer.c
 	private_data.c

--- a/src/include/librpma_log.h
+++ b/src/include/librpma_log.h
@@ -35,25 +35,41 @@ typedef enum {
 	RPMA_LOG_LEVEL_DEBUG,
 } rpma_log_level;
 
+typedef enum {
+	/*
+	 * the main threshold level - the logging messages above this level
+	 * won't trigger the logging functions
+	 */
+	RPMA_LOG_THRESHOLD_PRIMARY,
+	/*
+	 * the auxiliary threshold level - may or may not be used by
+	 * the logging function
+	 */
+	RPMA_LOG_THRESHOLD_SECONDARY,
+	RPMA_LOG_THRESHOLD_MAX
+} rpma_threshold;
+
 /*
- * for passing user-defined log call
+ * the type used for defining logging functions
  */
 typedef void log_function(
-	/* log level of actuall message passed to the function */
+	/* the log level of the message */
 	rpma_log_level level,
-	/* name of the current source file */
+	/* name of the source file where the message coming from */
 	const char *file_name,
-	/* current source file line */
+	/* the source file line where the message coming from */
 	const int line_no,
-	/* current source function name */
+	/* the function name where the message coming from */
 	const char *function_name,
-	/* printf(3) like format string for the message */
+	/* printf(3)-like format string of the message */
 	const char *message_format,
-	/* additional arguments for format string */
-	va_list args);
+	/* additional arguments of the message format string */
+	...);
+
+#define RPMA_LOG_DEFAULT_FUNCTION (NULL)
 
 /** 3
- * rpma_log_init - initialize logging module of the librpma
+ * rpma_log_set_function - set the log function
  *
  * SYNOPSIS
  *
@@ -65,67 +81,46 @@ typedef void log_function(
  *	const int line_no,
  *	const char *function_name,
  *	const char *message_format,
- *	va_list args);
+ *	...);
  *
- * int rpma_log_init(log_function *user_defined_log_function);
+ * void rpma_log_set_function(log_function *log_function);
  *
  * DESCRIPTION
- * rpma_log_init() initializes the logging module. Messages prior to this call
- * will be dropped. The logged messages are written either to syslog(3)/
- * stderr(3) or delivered to end-user application via function given by
- * the user_defined_log_function parameter.
+ * rpma_log_set_function() allows choosing the function which will get all
+ * the generated logging messages. The log_function can be either
+ * RPMA_LOG_DEFAULT_FUNCTION which will use the default logging function
+ * (built into the library) or a pointer to user-defined function.
  *
- * Logging thresholds to syslog(3)/stderr(3) are set using
- * rpma_log_syslog_set_threshold(3) and rpma_log_stderr_set_threshold(3).
- *
- * rpma_log_init() is automatically called when librpma library is loaded
- * and the default thresholds are set:
- * - RPMA_LOG_WARNING for syslog(3)
- * - RPMA_LOG_DISABLED for stderr(3).
- *
- * Logging to syslog(3)/stderr(3) is disabled when user_defined_log_function
- * is provided. In such case all messages are passed directly
- * to the given function.
+ * The initial value of the logging function is RPMA_LOG_DEFAULT_FUNCTION.
+ * This function writes messages to syslog(3) and to stderr(3). Where syslog(3)
+ * is the primary destination (RPMA_LOG_THRESHOLD_PRIMARY applies) whereas
+ * stderr(3) is the secondary destination (RPMA_LOG_THRESHOLD_SECONDARY
+ * applies).
  *
  * Parameters of a user-defined log function are as follow:
- * - level - actual logging level of message - see rpma_log_level
- * - file_name - source file name where log message is produced. It could be
- * set to NULL and in such case neither line_no nor function_name are provided
- * - line_no - source file line number where log message is produced
- * - function_name - function name where log message is produced
- * - message_format - printf(3) like format of the message
- * - args - va_list of arguments as described in message_format
+ * - level - the log level of the message
+ * - file_name - name of the source file where the message coming from.
+ * It could be set to NULL and in such case neither line_no nor function_name
+ * are provided.
+ * - line_no - the source file line where the message coming from
+ * - function_name - the function name where the message coming from
+ * - message_format - printf(3)-like format string of the message
+ * - ... - additional arguments of the message format string
  *
- * ERRORS
- * rpma_log_init() can fail with the following error:
- * * - -1 - logging has already been started. Call rpma_log_fini (3) to close
- * the currently active log.
+ * NOTE
+ * The logging messages on the levels above the RPMA_LOG_THRESHOLD_PRIMARY
+ * level won't trigger the logging function.
  */
-int rpma_log_init(log_function *user_defined_log_function);
+void rpma_log_set_function(log_function *log_function);
 
 /** 3
- * rpma_log_fini - closes the currently active log
+ * rpma_log_set_threshold - set the logging threshold level
  *
  * SYNOPSIS
  *
  * #include <librpma_log.h>
  *
- * void rpma_log_fini(void);
- *
- * DESCRIPTION
- * rpma_log_fini() closes the currently active log. All messages after this call
- * will be dropped.
- */
-void rpma_log_fini(void);
-
-/** 3
- * rpma_log_syslog_set_threshold - set the threshold level for logging to syslog
- *
- * SYNOPSIS
- *
- * #include <librpma_log.h>
- *
- * int rpma_log_syslog_set_threshold(rpma_log_level level);
+ * int rpma_log_set_threshold(rpma_threshold threshold, rpma_log_level level);
  *
  * typedef enum {
  *	RPMA_LOG_DISABLED,
@@ -137,14 +132,24 @@ void rpma_log_fini(void);
  *	RPMA_LOG_LEVEL_DEBUG,
  * } rpma_log_level;
  *
- * DESCRIPTION
- * rpma_log_syslog_set_threshold() sets the threshold level for the default
- * logging function for logging to syslog(3). Messages with a higher level than
- * this are ignored. RPMA_LOG_DISABLED shall be used to completely suppress
- * writing to syslog(3).
+ * typedef enum {
+ *	RPMA_LOG_THRESHOLD_PRIMARY,
+ *	RPMA_LOG_THRESHOLD_SECONDARY,
+ *	RPMA_LOG_THRESHOLD_MAX
+ * } rpma_threshold;
  *
- * The threshold for stderr(3) is controlled separately via
- * rpma_log_stderr_set_threshold()
+ * DESCRIPTION
+ * rpma_log_set_threshold() sets the logging threshold level.
+ *
+ * Available thresholds are:
+ * - RPMA_LOG_THRESHOLD_PRIMARY - the main threshold used to filter out
+ * undesired logging messages. Messages on a higher level than the primary
+ * threshold level are ignored. RPMA_LOG_DISABLED shall be used to suppress
+ * logging. The default value is RPMA_LOG_WARNING.
+ * - RPMA_LOG_THRESHOLD_SECONDARY - the auxiliary threshold intended for use
+ * inside the logging function (please see rpma_log_get_threshold(3)).
+ * The logging function may or may not take this threshold into consideration.
+ * The default value is RPMA_LOG_DISABLED.
  *
  * Available threshold levels are defined by rpma_log_level:
  * - RPMA_LOG_DISABLED - all messages will be suppressed
@@ -163,99 +168,36 @@ void rpma_log_fini(void);
  * on failure.
  *
  * ERRORS
- * rpma_log_syslog_set_threshold() can fail with the following error:
- * - -1 - level out of scope
- *
- * NOTES
- * - rpma_log_syslog_set_threshold() is automatically called during loading of
- * the library to set the default syslog(3) logging threshold to
- * RPMA_LOG_LEVEL_WARNING
- * - rpma_log_syslog_set_threshold() does not affect calling
- * user_defined_log_function() in any way.
+ * rpma_log_set_threshold() can fail with the following errors:
+ * - RPMA_E_INVAL - threshold is not RPMA_LOG_THRESHOLD_PRIMARY nor
+ * RPMA_LOG_THRESHOLD_SECONDARY
+ * - RPMA_E_INVAL - level is not a value defined by rpma_log_level type
  */
-int rpma_log_syslog_set_threshold(rpma_log_level level);
+int rpma_log_set_threshold(rpma_threshold threshold, rpma_log_level level);
 
 /** 3
- * rpma_log_syslog_get_threshold - get the current threshold level for logging
- * to syslog
+ * rpma_log_get_threshold - get the logging threshold level
  *
  * SYNOPSIS
  *
  * #include <librpma_log.h>
  *
- * rpma_log_level rpma_log_syslog_get_threshold(void);
+ * int rpma_log_get_threshold(rpma_threshold threshold, rpma_log_level *level);
  *
  * DESCRIPTION
- * rpma_log_syslog_get_threshold() gets the current log level threshold for
- * messages written to syslog(3).
- *
- * RPMA_LOG_DISABLED indicates that writing to syslog(3) is disabled.
- *
- * See rpma_log_syslog_set_threshold(3) for available thresholds.
+ * rpma_log_get_threshold() gets the current level of the threshold.
+ * See rpma_log_set_threshold(3) for available thresholds and levels.
  *
  * RETURN VALUE
- * rpma_log_syslog_get_threshold() returns the actual threshold for logging
- * to syslog(3) or RPMA_LOG_DISABLED if logging to syslog(3) is disabled.
- *
- */
-rpma_log_level rpma_log_syslog_get_threshold(void);
-
-/** 3
- * rpma_log_stderr_set_threshold - set the threshold level for logging to
- * stderr
- *
- * SYNOPSIS
- *
- * #include <librpma_log.h>
- *
- * int rpma_log_stderr_set_threshold(rpma_log_level level);
- *
- * DESCRIPTION
- * rpma_log_stderr_set_threshold() sets the threshold level for the default
- * logging function for logging to stderr(3). Messages with a higher level
- * than this are not shown on stderr(3). RPMA_LOG_DISABLED shall be used
- * to completely suppress writing to stderr(3).
- *
- * See rpma_log_syslog_set_threshold(3) for available thresholds.
- *
- * RETURN VALUE
- * rpma_log_stderr_set_threshold() function returns 0 on success or error code
+ * rpma_log_get_threshold() function returns 0 on success or error code
  * on failure.
  *
  * ERRORS
- * rpma_log_stderr_set_threshold() can fail with the following error:
- * - -1 - level out of scope
- *
- * NOTES
- * - rpma_log_stderr_set_threshold() is automatically called during loading of
- * the library to disable logging to stderr(3) (RPMA_LOG_DISABLED).
- * - rpma_log_stderr_set_threshold() does not affect calling
- * user_defined_log_function() in any way.
- *
+ * rpma_log_get_threshold() can fail with the following errors:
+ * - RPMA_E_INVAL - threshold is not RPMA_LOG_THRESHOLD_PRIMARY nor
+ * RPMA_LOG_THRESHOLD_SECONDARY
+ * - RPMA_E_INVAL - level is NULL
  */
-int rpma_log_stderr_set_threshold(rpma_log_level level);
-
-/** 3
- * rpma_log_stderr_get_threshold - get the current log level to stderr threshold
- *
- * SYNOPSIS
- *
- * #include <librpma_log.h>
- *
- * rpma_log_level rpma_log_stderr_get_threshold(void);
- *
- * DESCRIPTION
- * rpma_log_stderr_get_threshold(3) gets the current log level to stderr(3)
- * threshold.
- *
- * RPMA_LOG_DISABLED indicates that writing to stderr(3) is disabled.
- *
- * See rpma_log_syslog_set_threshold(3) for available thresholds.
- *
- * RETURN VALUE
- * rpma_log_stderr_get_threshold() returns the actual threshold for logging
- * to stderr(3) or RPMA_LOG_DISABLED if logging to stderr(3) is disabled.
- */
-rpma_log_level rpma_log_stderr_get_threshold(void);
+int rpma_log_get_threshold(rpma_threshold threshold, rpma_log_level *level);
 
 #endif /* LIBRPMA_LOG_H */

--- a/src/librpma.c
+++ b/src/librpma.c
@@ -8,6 +8,7 @@
  */
 
 #include "librpma.h"
+#include "log_internal.h"
 
 /*
  * librpma_init -- load-time initialization for librpma
@@ -17,6 +18,7 @@
 __attribute__((constructor)) static void
 librpma_init(void)
 {
+	rpma_log_init();
 }
 
 /*
@@ -27,4 +29,5 @@ librpma_init(void)
 __attribute__((destructor)) static void
 librpma_fini(void)
 {
+	rpma_log_fini();
 }

--- a/src/librpma.map
+++ b/src/librpma.map
@@ -41,13 +41,9 @@ LIBRPMA_1.0 {
 		rpma_utils_get_ibv_context;
 		rpma_write;
 		rpma_write_atomic;
-		rpma_log_init;
-		rpma_log_fini;
-		rpma_log;
-		rpma_log_syslog_set_threshold;
-		rpma_log_stderr_set_threshold;
-		rpma_log_syslog_get_threshold;
-		rpma_log_stderr_get_threshold;
+		rpma_log_set_function;
+		rpma_log_set_threshold;
+		rpma_log_get_threshold;
 	local:
 		*;
 };

--- a/src/log_default.c
+++ b/src/log_default.c
@@ -1,0 +1,147 @@
+// SPDX-License-Identifier: BSD-3-Clause
+/* Copyright 2020, Intel Corporation */
+
+/*
+ * log_default.c -- the default logging function with support for logging either
+ * to syslog or to stderr
+ */
+
+#include <stdarg.h>
+#include <syslog.h>
+#include <time.h>
+#include <string.h>
+
+#include "log_default.h"
+#include "log_internal.h"
+
+static const char *const rpma_log_level_names[] = {
+	[RPMA_LOG_LEVEL_FATAL]	= "FATAL",
+	[RPMA_LOG_LEVEL_ERROR]	= "ERROR",
+	[RPMA_LOG_LEVEL_WARNING] = "WARNING",
+	[RPMA_LOG_LEVEL_NOTICE]	= "NOTICE",
+	[RPMA_LOG_LEVEL_INFO]	= "INFO",
+	[RPMA_LOG_LEVEL_DEBUG]	= "DEBUG",
+};
+
+static const int rpma_log_level_syslog_severity[] = {
+	[RPMA_LOG_LEVEL_FATAL]	= LOG_CRIT,
+	[RPMA_LOG_LEVEL_ERROR]	= LOG_ERR,
+	[RPMA_LOG_LEVEL_WARNING] = LOG_WARNING,
+	[RPMA_LOG_LEVEL_NOTICE]	= LOG_NOTICE,
+	[RPMA_LOG_LEVEL_INFO]	= LOG_INFO,
+	[RPMA_LOG_LEVEL_DEBUG]	= LOG_DEBUG,
+};
+
+/*
+ * get_timestamp_prefix -- provide actual time in a readable string
+ *
+ * ASSUMPTIONS:
+ * - buf != NULL && buf_size >= 16
+ */
+static void
+get_timestamp_prefix(char *buf, size_t buf_size)
+{
+	struct tm *info;
+	char date[24];
+	struct timespec ts;
+	long usec;
+
+	const char error_message[] = "[time error] ";
+
+	if (clock_gettime(CLOCK_REALTIME, &ts) ||
+	    (NULL == (info = localtime(&ts.tv_sec)))) {
+		memcpy(buf, error_message, sizeof(error_message));
+		return;
+	}
+
+	usec = ts.tv_nsec / 1000;
+	if (!strftime(date, sizeof(date), "%Y-%m-%d %H:%M:%S", info)) {
+		memcpy(buf, error_message, sizeof(error_message));
+		return;
+	}
+
+	if (snprintf(buf, buf_size, "[%s.%06ld] ", date, usec) < 0) {
+		memcpy(buf, error_message, sizeof(error_message));
+		return;
+	}
+}
+
+/*
+ * rpma_log_default_function -- default logging function used to log a message
+ * to syslog and/or stderr
+ *
+ * The message is started with prefix composed from file, line, func parameters
+ * followed by string pointed by format. If format includes format specifiers
+ * (subsequences beginning with %), the additional arguments following format
+ * are formatted and inserted in the message.
+ *
+ * ASSUMPTIONS:
+ * - level >= RPMA_LOG_LEVEL_FATAL && level <= RPMA_LOG_LEVEL_DEBUG
+ * - level <= Rpma_log_threshold[RPMA_LOG_THRESHOLD_PRIMARY]
+ * - file == NULL || (file != NULL && function != NULL)
+ */
+void
+rpma_log_default_function(rpma_log_level level, const char *file_name,
+	const int line_no, const char *function_name,
+	const char *message_format, ...)
+{
+	char file_info_buffer[256] = "";
+	const char *file_info = file_info_buffer;
+	char message[1024] = "";
+	const char file_info_error[] = "[file info error]: ";
+
+	va_list arg;
+	va_start(arg, message_format);
+	if (vsnprintf(message, sizeof(message), message_format, arg) < 0) {
+		va_end(arg);
+		return;
+	}
+	va_end(arg);
+
+	if (file_name) {
+		/* extract base_file_name */
+		const char *base_file_name = strrchr(file_name, '/');
+		if (!base_file_name)
+			base_file_name = file_name;
+		else
+			/* skip '/' */
+			base_file_name++;
+
+		if (snprintf(file_info_buffer, sizeof(file_info_buffer),
+				"%s: %4d: %s: ", base_file_name, line_no,
+				function_name) < 0) {
+			file_info = file_info_error;
+		}
+	}
+
+	/* assumed: level <= Rpma_log_threshold[RPMA_LOG_THRESHOLD_PRIMARY] */
+	syslog(rpma_log_level_syslog_severity[level], "%s*%s*: %s",
+		file_info, rpma_log_level_names[level], message);
+
+	if (level <= Rpma_log_threshold[RPMA_LOG_THRESHOLD_SECONDARY]) {
+		char times_tamp[45] = "";
+		get_timestamp_prefix(times_tamp, sizeof(times_tamp));
+		(void) fprintf(stderr, "%s%s*%s*: %s", times_tamp, file_info,
+			rpma_log_level_names[level], message);
+	}
+}
+
+/*
+ * rpma_log_default_init -- open a connection to the system logger
+ */
+void
+rpma_log_default_init(void)
+{
+	openlog("rpma", LOG_PID, LOG_LOCAL7);
+}
+
+
+/*
+ * rpma_log_default_fini -- close the descriptor being used to write to
+ * the system logger
+ */
+void
+rpma_log_default_fini(void)
+{
+	closelog();
+}

--- a/src/log_default.h
+++ b/src/log_default.h
@@ -1,0 +1,21 @@
+/* SPDX-License-Identifier: BSD-3-Clause */
+/* Copyright 2020, Intel Corporation */
+
+/*
+ * log_default.h -- the default logging function definitions
+ */
+
+#ifndef LIBRPMA_LOG_DEFAULT_H
+#define LIBRPMA_LOG_DEFAULT_H
+
+#include "librpma_log.h"
+
+void rpma_log_default_function(rpma_log_level level, const char *file_name,
+	const int line_no, const char *function_name,
+	const char *message_format, ...);
+
+void rpma_log_default_init(void);
+
+void rpma_log_default_fini(void);
+
+#endif /* LIBRPMA_LOG_DEFAULT_H */

--- a/src/log_internal.h
+++ b/src/log_internal.h
@@ -10,69 +10,48 @@
 
 #include "librpma_log.h"
 
+/* pointer to the logging function */
+extern log_function *Rpma_log_function;
+
+/* threshold levels */
+extern rpma_log_level Rpma_log_threshold[RPMA_LOG_THRESHOLD_MAX];
+
+void rpma_log_init();
+
+void rpma_log_fini();
+
+#define RPMA_LOG(level, format, ...) \
+	if (level <= Rpma_log_threshold[RPMA_LOG_THRESHOLD_PRIMARY] && \
+			NULL != Rpma_log_function) { \
+		Rpma_log_function(level, __FILE__, __LINE__, __func__, \
+				format, ##__VA_ARGS__); \
+	}
+
 /*
  * Set of macros that should be used as the primary API for logging.
  * Direct call to rpma_log shall be used only in exceptional, corner cases.
  */
 #define RPMA_LOG_NOTICE(format, ...) \
-	rpma_log(RPMA_LOG_LEVEL_NOTICE, __FILE__, __LINE__, __func__, \
-		format "\n", ##__VA_ARGS__)
+	RPMA_LOG(RPMA_LOG_LEVEL_NOTICE, format "\n", ##__VA_ARGS__)
 
 #define RPMA_LOG_WARNING(format, ...) \
-	rpma_log(RPMA_LOG_LEVEL_WARNING, __FILE__, __LINE__, __func__, \
-		format "\n", ##__VA_ARGS__)
+	RPMA_LOG(RPMA_LOG_LEVEL_WARNING, format "\n", ##__VA_ARGS__)
 
 #define RPMA_LOG_ERROR(format, ...) \
-	rpma_log(RPMA_LOG_LEVEL_ERROR, __FILE__, __LINE__, __func__, \
-		format "\n", ##__VA_ARGS__)
+	RPMA_LOG(RPMA_LOG_LEVEL_ERROR, format "\n", ##__VA_ARGS__)
 
 #define RPMA_LOG_FATAL(format, ...) \
-	rpma_log(RPMA_LOG_LEVEL_FATAL, __FILE__, __LINE__, __func__, \
-		format "\n", ##__VA_ARGS__)
-
-#define RPMA_PRINTF(format, ...) \
-	rpma_log(RPMA_LOG_LEVEL_INFO, NULL, -1, NULL, format, ##__VA_ARGS__)
+	RPMA_LOG(RPMA_LOG_LEVEL_FATAL, format "\n", ##__VA_ARGS__)
 
 /*
- * rpma_log - call either the default or a custom log function.
- *
- * The default log function write messages to syslog and to stderr.
- * The message flow can be controlled with help of threshold setters function:
- * rpma_log_syslog_set_threshold and rpma_log_stderr_set_threshold.
- * Threshold set to RPMA_LOG_DISABLED disable particular message destination
- * (syslog/stderr).
- *
- * All log messages are redirected to a custom log function if it is provided
- * by rmpa_log_init() function. No messages are produced to syslog and stderr.
- * A custom log function receives all log messages and it is not affected by
- * the thresholds described above.
- *
- * Parameters are as follow:
- * level - log level.
- * file_name - name of the current source file. NULL value indicate that there
- * is also neither line_no nor function name provided.
- * line_no - current source line number.
- * function_name - current source function name. Must not be NULL if file_name
- * is given.
- * message_format - printf() like message string.
- *
- * ASSUMPTIONS
- * - file_name == NULL || function_name != NULL
- * - format != NULL
- */
-__attribute__((__format__(__printf__, 5, 6)))
-void rpma_log(rpma_log_level level, const char *file_name, const int line_no,
-	const char *function_name, const char *message_format, ...);
-
-/*
- * Default thresholds for logging levels
+ * Default levels of the logging thresholds
  */
 #ifdef DEBUG
-#define RPMA_LOG_LEVEL_SYSLOG_DEFAULT RPMA_LOG_LEVEL_DEBUG
-#define RPMA_LOG_LEVEL_STDERR_DEFAULT RPMA_LOG_LEVEL_WARNING
+#define RPMA_LOG_THRESHOLD_PRIMARY_DEFAULT RPMA_LOG_LEVEL_DEBUG
+#define RPMA_LOG_THRESHOLD_SECONDARY_DEFAULT RPMA_LOG_LEVEL_WARNING
 #else
-#define RPMA_LOG_LEVEL_SYSLOG_DEFAULT RPMA_LOG_LEVEL_WARNING
-#define RPMA_LOG_LEVEL_STDERR_DEFAULT RPMA_LOG_DISABLED
+#define RPMA_LOG_THRESHOLD_PRIMARY_DEFAULT RPMA_LOG_LEVEL_WARNING
+#define RPMA_LOG_THRESHOLD_SECONDARY_DEFAULT RPMA_LOG_DISABLED
 #endif
 
 #endif /* LIBRPMA_LOG_INTERNAL_H */

--- a/tests/integration/example-01-connection/CMakeLists.txt
+++ b/tests/integration/example-01-connection/CMakeLists.txt
@@ -19,6 +19,8 @@ build_test_src(NAME ${TARGET} SRCS
 	${LIBRPMA_SOURCE_DIR}/ep.c
 	${LIBRPMA_SOURCE_DIR}/info.c
 	${LIBRPMA_SOURCE_DIR}/librpma.c
+	${LIBRPMA_SOURCE_DIR}/log.c
+	${LIBRPMA_SOURCE_DIR}/log_default.c
 	${LIBRPMA_SOURCE_DIR}/mr.c
 	${LIBRPMA_SOURCE_DIR}/peer.c
 	${LIBRPMA_SOURCE_DIR}/private_data.c

--- a/tests/integration/example-02-read-to-volatile/CMakeLists.txt
+++ b/tests/integration/example-02-read-to-volatile/CMakeLists.txt
@@ -19,6 +19,8 @@ build_test_src(NAME ${TARGET} SRCS
 	${LIBRPMA_SOURCE_DIR}/ep.c
 	${LIBRPMA_SOURCE_DIR}/info.c
 	${LIBRPMA_SOURCE_DIR}/librpma.c
+	${LIBRPMA_SOURCE_DIR}/log.c
+	${LIBRPMA_SOURCE_DIR}/log_default.c
 	${LIBRPMA_SOURCE_DIR}/mr.c
 	${LIBRPMA_SOURCE_DIR}/peer.c
 	${LIBRPMA_SOURCE_DIR}/private_data.c


### PR DESCRIPTION
The split recognizes three separate parts of the mechanism:
- the core logging (src/log.c) mechanism which has to call as soon as
possible the configured logging function taking into account the primary
threshold. It also holds the primary and the secondary threshold values
which are available for writing and reading via the default and the
user-provided logging functions.
- the default logging implementation (src/log_default.c) which
implements logging to syslog and/or stderr. syslog logging is controlled
via the primary logging threshold whereas stderr logging is controlled
via the secondary logging threshold. The syslog connection is opened via
the library constructor and closed on deconstructor.
- the initialization of the logging module is triggered via the main
library constructor (src/librpma.c) which calls the rpma_log_init()
function which sets the default logging function and calls its
initializer which opens the connection to the syslog. The deconstruction
works accordingly.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/pmem/rpma/245)
<!-- Reviewable:end -->
