### PR TITLE
common: log module refactor

### DIFF
--- a/examples/log/log-example.c
+++ b/examples/log/log-example.c
@@ -51,9 +51,9 @@ main(int argc, char *argv[])
 	 * log messages to be produced to syslog as well as stderr
 	 */
 	printf("Let's write messages to stderr and syslog\n");
-	rpma_log_set_threshold(RPMA_LOG_THRESHOLD_PRIMARY,
+	rpma_log_set_threshold(RPMA_LOG_THRESHOLD,
 			RPMA_LOG_LEVEL_DEBUG);
-	rpma_log_set_threshold(RPMA_LOG_THRESHOLD_SECONDARY,
+	rpma_log_set_threshold(RPMA_LOG_THRESHOLD_AUX,
 			RPMA_LOG_LEVEL_DEBUG);
 	log_worker_is_doing_something();
 	printf(
@@ -66,7 +66,7 @@ main(int argc, char *argv[])
 	printf(
 		"Let's use custom log function to write messages to stderr\nNo message should be written to syslog\n");
 	log_worker_is_doing_something();
-	rpma_log_set_function(RPMA_LOG_DEFAULT_FUNCTION);
+	rpma_log_set_function(RPMA_LOG_USE_DEFAULT_FUNCTION);
 
 	return 0;
 }

--- a/src/include/librpma_log.h
+++ b/src/include/librpma_log.h
@@ -40,78 +40,14 @@ typedef enum {
 	 * the main threshold level - the logging messages above this level
 	 * won't trigger the logging functions
 	 */
-	RPMA_LOG_THRESHOLD_PRIMARY,
+	RPMA_LOG_THRESHOLD,
 	/*
 	 * the auxiliary threshold level - may or may not be used by
 	 * the logging function
 	 */
-	RPMA_LOG_THRESHOLD_SECONDARY,
+	RPMA_LOG_THRESHOLD_AUX,
 	RPMA_LOG_THRESHOLD_MAX
-} rpma_threshold;
-
-/*
- * the type used for defining logging functions
- */
-typedef void log_function(
-	/* the log level of the message */
-	rpma_log_level level,
-	/* name of the source file where the message coming from */
-	const char *file_name,
-	/* the source file line where the message coming from */
-	const int line_no,
-	/* the function name where the message coming from */
-	const char *function_name,
-	/* printf(3)-like format string of the message */
-	const char *message_format,
-	/* additional arguments of the message format string */
-	...);
-
-#define RPMA_LOG_DEFAULT_FUNCTION (NULL)
-
-/** 3
- * rpma_log_set_function - set the log function
- *
- * SYNOPSIS
- *
- * #include <librpma_log.h>
- *
- * typedef void log_function(
- *	rpma_log_level level,
- *	const char *file_name,
- *	const int line_no,
- *	const char *function_name,
- *	const char *message_format,
- *	...);
- *
- * void rpma_log_set_function(log_function *log_function);
- *
- * DESCRIPTION
- * rpma_log_set_function() allows choosing the function which will get all
- * the generated logging messages. The log_function can be either
- * RPMA_LOG_DEFAULT_FUNCTION which will use the default logging function
- * (built into the library) or a pointer to user-defined function.
- *
- * The initial value of the logging function is RPMA_LOG_DEFAULT_FUNCTION.
- * This function writes messages to syslog(3) and to stderr(3). Where syslog(3)
- * is the primary destination (RPMA_LOG_THRESHOLD_PRIMARY applies) whereas
- * stderr(3) is the secondary destination (RPMA_LOG_THRESHOLD_SECONDARY
- * applies).
- *
- * Parameters of a user-defined log function are as follow:
- * - level - the log level of the message
- * - file_name - name of the source file where the message coming from.
- * It could be set to NULL and in such case neither line_no nor function_name
- * are provided.
- * - line_no - the source file line where the message coming from
- * - function_name - the function name where the message coming from
- * - message_format - printf(3)-like format string of the message
- * - ... - additional arguments of the message format string
- *
- * NOTE
- * The logging messages on the levels above the RPMA_LOG_THRESHOLD_PRIMARY
- * level won't trigger the logging function.
- */
-void rpma_log_set_function(log_function *log_function);
+} rpma_log_threshold;
 
 /** 3
  * rpma_log_set_threshold - set the logging threshold level
@@ -133,20 +69,20 @@ void rpma_log_set_function(log_function *log_function);
  * } rpma_log_level;
  *
  * typedef enum {
- *	RPMA_LOG_THRESHOLD_PRIMARY,
- *	RPMA_LOG_THRESHOLD_SECONDARY,
+ *	RPMA_LOG_THRESHOLD,
+ *	RPMA_LOG_THRESHOLD_AUX,
  *	RPMA_LOG_THRESHOLD_MAX
- * } rpma_threshold;
+ * } rpma_log_threshold;
  *
  * DESCRIPTION
  * rpma_log_set_threshold() sets the logging threshold level.
  *
  * Available thresholds are:
- * - RPMA_LOG_THRESHOLD_PRIMARY - the main threshold used to filter out
+ * - RPMA_LOG_THRESHOLD - the main threshold used to filter out
  * undesired logging messages. Messages on a higher level than the primary
  * threshold level are ignored. RPMA_LOG_DISABLED shall be used to suppress
  * logging. The default value is RPMA_LOG_WARNING.
- * - RPMA_LOG_THRESHOLD_SECONDARY - the auxiliary threshold intended for use
+ * - RPMA_LOG_THRESHOLD_AUX - the auxiliary threshold intended for use
  * inside the logging function (please see rpma_log_get_threshold(3)).
  * The logging function may or may not take this threshold into consideration.
  * The default value is RPMA_LOG_DISABLED.
@@ -163,17 +99,23 @@ void rpma_log_set_function(log_function *log_function);
  * - RPMA_LOG_LEVEL_INFO - massive info e.g. every write operation indication
  * - RPMA_LOG_LEVEL_DEBUG - debug info e.g. write operation dump
  *
+ * THE DEFAULT LOGGING FUNCTION
+ * The default logging function writes messages to syslog(3) and to stderr(3),
+ * where syslog(3) is the primary destination
+ * (RPMA_LOG_THRESHOLD applies) whereas stderr(3) is the secondary
+ * destination (RPMA_LOG_THRESHOLD_AUX applies).
+ *
  * RETURN VALUE
  * rpma_log_syslog_set_threshold() function returns 0 on success or error code
  * on failure.
  *
  * ERRORS
  * rpma_log_set_threshold() can fail with the following errors:
- * - RPMA_E_INVAL - threshold is not RPMA_LOG_THRESHOLD_PRIMARY nor
- * RPMA_LOG_THRESHOLD_SECONDARY
+ * - RPMA_E_INVAL - threshold is not RPMA_LOG_THRESHOLD nor
+ * RPMA_LOG_THRESHOLD_AUX
  * - RPMA_E_INVAL - level is not a value defined by rpma_log_level type
  */
-int rpma_log_set_threshold(rpma_threshold threshold, rpma_log_level level);
+int rpma_log_set_threshold(rpma_log_threshold threshold, rpma_log_level level);
 
 /** 3
  * rpma_log_get_threshold - get the logging threshold level
@@ -194,10 +136,73 @@ int rpma_log_set_threshold(rpma_threshold threshold, rpma_log_level level);
  *
  * ERRORS
  * rpma_log_get_threshold() can fail with the following errors:
- * - RPMA_E_INVAL - threshold is not RPMA_LOG_THRESHOLD_PRIMARY nor
- * RPMA_LOG_THRESHOLD_SECONDARY
- * - RPMA_E_INVAL - level is NULL
+ * - RPMA_E_INVAL - threshold is not RPMA_LOG_THRESHOLD nor
+ * RPMA_LOG_THRESHOLD_AUX
+ * - RPMA_E_INVAL - *level is NULL
  */
-int rpma_log_get_threshold(rpma_threshold threshold, rpma_log_level *level);
+int rpma_log_get_threshold(rpma_log_threshold threshold, rpma_log_level *level);
+
+/*
+ * the type used for defining logging functions
+ */
+typedef void log_function(
+	/* the log level of the message */
+	rpma_log_level level,
+	/* name of the source file where the message coming from */
+	const char *file_name,
+	/* the source file line where the message coming from */
+	const int line_no,
+	/* the function name where the message coming from */
+	const char *function_name,
+	/* printf(3)-like format string of the message */
+	const char *message_format,
+	/* additional arguments of the message format string */
+	...);
+
+#define RPMA_LOG_USE_DEFAULT_FUNCTION (NULL)
+
+/** 3
+ * rpma_log_set_function - set the log function
+ *
+ * SYNOPSIS
+ *
+ * #include <librpma_log.h>
+ *
+ * typedef void log_function(
+ *	rpma_log_level level,
+ *	const char *file_name,
+ *	const int line_no,
+ *	const char *function_name,
+ *	const char *message_format,
+ *	...);
+ *
+ * void rpma_log_set_function(log_function *log_function);
+ *
+ * DESCRIPTION
+ * rpma_log_set_function() allows choosing the function which will get all
+ * the generated logging messages. The log_function can be either
+ * RPMA_LOG_USE_DEFAULT_FUNCTION which will use the default logging function
+ * (built into the library) or a pointer to user-defined function.
+ *
+ * Parameters of a user-defined log function are as follow:
+ * - level - the log level of the message
+ * - file_name - name of the source file where the message coming from.
+ * It could be set to NULL and in such case neither line_no nor function_name
+ * are provided.
+ * - line_no - the source file line where the message coming from
+ * - function_name - the function name where the message coming from
+ * - message_format - printf(3)-like format string of the message
+ * - ... - additional arguments of the message format string
+ *
+ * THE DEFAULT LOGGING FUNCTION
+ * The initial value of the logging function is RPMA_LOG_USE_DEFAULT_FUNCTION.
+ * This function writes messages to syslog(3) (the primary destination) and to
+ * stderr(3) (the secondary destination).
+ *
+ * NOTE
+ * The logging messages on the levels above the RPMA_LOG_THRESHOLD
+ * level won't trigger the logging function.
+ */
+void rpma_log_set_function(log_function *log_function);
 
 #endif /* LIBRPMA_LOG_H */

--- a/src/log.c
+++ b/src/log.c
@@ -16,6 +16,17 @@
 #include "log_internal.h"
 
 /*
+ * Default levels of the logging thresholds
+ */
+#ifdef DEBUG
+#define RPMA_LOG_THRESHOLD_DEFAULT RPMA_LOG_LEVEL_DEBUG
+#define RPMA_LOG_THRESHOLD_AUX_DEFAULT RPMA_LOG_LEVEL_WARNING
+#else
+#define RPMA_LOG_THRESHOLD_DEFAULT RPMA_LOG_LEVEL_WARNING
+#define RPMA_LOG_THRESHOLD_AUX_DEFAULT RPMA_LOG_DISABLED
+#endif
+
+/*
  * Rpma_log_function -- pointer to the logging function.
  * By default it is rpma_log_default_function() but could be a user logging
  * function provided via rpma_log_set().
@@ -24,8 +35,8 @@ log_function *Rpma_log_function;
 
 /* threshold levels */
 rpma_log_level Rpma_log_threshold[] = {
-		RPMA_LOG_THRESHOLD_PRIMARY_DEFAULT,
-		RPMA_LOG_THRESHOLD_SECONDARY_DEFAULT
+		RPMA_LOG_THRESHOLD_DEFAULT,
+		RPMA_LOG_THRESHOLD_AUX_DEFAULT
 };
 
 /*
@@ -36,7 +47,7 @@ rpma_log_init()
 {
 	/* enable the default logging function */
 	rpma_log_default_init();
-	rpma_log_set_function(RPMA_LOG_DEFAULT_FUNCTION);
+	rpma_log_set_function(RPMA_LOG_USE_DEFAULT_FUNCTION);
 }
 
 /*
@@ -45,6 +56,11 @@ rpma_log_init()
 void
 rpma_log_fini()
 {
+	/*
+	 * NULL-ed function pointer turns off the logging. No matter if
+	 * the previous value was the default logging function or a user
+	 * logging function.
+	 */
 	Rpma_log_function = NULL;
 
 	/* cleanup the default logging function */
@@ -60,7 +76,7 @@ rpma_log_fini()
 void
 rpma_log_set_function(log_function *log_function)
 {
-	if (log_function == RPMA_LOG_DEFAULT_FUNCTION)
+	if (log_function == RPMA_LOG_USE_DEFAULT_FUNCTION)
 		Rpma_log_function = rpma_log_default_function;
 	else
 		Rpma_log_function = log_function;
@@ -70,10 +86,10 @@ rpma_log_set_function(log_function *log_function)
  * rpma_log_set_threshold -- set the log level threshold
  */
 int
-rpma_log_set_threshold(rpma_threshold threshold, rpma_log_level level)
+rpma_log_set_threshold(rpma_log_threshold threshold, rpma_log_level level)
 {
-	if (threshold != RPMA_LOG_THRESHOLD_PRIMARY &&
-			threshold != RPMA_LOG_THRESHOLD_SECONDARY)
+	if (threshold != RPMA_LOG_THRESHOLD &&
+			threshold != RPMA_LOG_THRESHOLD_AUX)
 		return RPMA_E_INVAL;
 
 	if (level < RPMA_LOG_DISABLED || level > RPMA_LOG_LEVEL_DEBUG)
@@ -88,10 +104,10 @@ rpma_log_set_threshold(rpma_threshold threshold, rpma_log_level level)
  * rpma_log_get_threshold -- get the log level threshold
  */
 int
-rpma_log_get_threshold(rpma_threshold threshold, rpma_log_level *level)
+rpma_log_get_threshold(rpma_log_threshold threshold, rpma_log_level *level)
 {
-	if (threshold != RPMA_LOG_THRESHOLD_PRIMARY &&
-			threshold != RPMA_LOG_THRESHOLD_SECONDARY)
+	if (threshold != RPMA_LOG_THRESHOLD &&
+			threshold != RPMA_LOG_THRESHOLD_AUX)
 		return RPMA_E_INVAL;
 
 	if (level == NULL)

--- a/src/log_default.c
+++ b/src/log_default.c
@@ -77,7 +77,7 @@ get_timestamp_prefix(char *buf, size_t buf_size)
  *
  * ASSUMPTIONS:
  * - level >= RPMA_LOG_LEVEL_FATAL && level <= RPMA_LOG_LEVEL_DEBUG
- * - level <= Rpma_log_threshold[RPMA_LOG_THRESHOLD_PRIMARY]
+ * - level <= Rpma_log_threshold[RPMA_LOG_THRESHOLD]
  * - file == NULL || (file != NULL && function != NULL)
  */
 void
@@ -114,11 +114,11 @@ rpma_log_default_function(rpma_log_level level, const char *file_name,
 		}
 	}
 
-	/* assumed: level <= Rpma_log_threshold[RPMA_LOG_THRESHOLD_PRIMARY] */
+	/* assumed: level <= Rpma_log_threshold[RPMA_LOG_THRESHOLD] */
 	syslog(rpma_log_level_syslog_severity[level], "%s*%s*: %s",
 		file_info, rpma_log_level_names[level], message);
 
-	if (level <= Rpma_log_threshold[RPMA_LOG_THRESHOLD_SECONDARY]) {
+	if (level <= Rpma_log_threshold[RPMA_LOG_THRESHOLD_AUX]) {
 		char times_tamp[45] = "";
 		get_timestamp_prefix(times_tamp, sizeof(times_tamp));
 		(void) fprintf(stderr, "%s%s*%s*: %s", times_tamp, file_info,

--- a/src/log_internal.h
+++ b/src/log_internal.h
@@ -21,7 +21,7 @@ void rpma_log_init();
 void rpma_log_fini();
 
 #define RPMA_LOG(level, format, ...) \
-	if (level <= Rpma_log_threshold[RPMA_LOG_THRESHOLD_PRIMARY] && \
+	if (level <= Rpma_log_threshold[RPMA_LOG_THRESHOLD] && \
 			NULL != Rpma_log_function) { \
 		Rpma_log_function(level, __FILE__, __LINE__, __func__, \
 				format, ##__VA_ARGS__); \
@@ -42,16 +42,5 @@ void rpma_log_fini();
 
 #define RPMA_LOG_FATAL(format, ...) \
 	RPMA_LOG(RPMA_LOG_LEVEL_FATAL, format "\n", ##__VA_ARGS__)
-
-/*
- * Default levels of the logging thresholds
- */
-#ifdef DEBUG
-#define RPMA_LOG_THRESHOLD_PRIMARY_DEFAULT RPMA_LOG_LEVEL_DEBUG
-#define RPMA_LOG_THRESHOLD_SECONDARY_DEFAULT RPMA_LOG_LEVEL_WARNING
-#else
-#define RPMA_LOG_THRESHOLD_PRIMARY_DEFAULT RPMA_LOG_LEVEL_WARNING
-#define RPMA_LOG_THRESHOLD_SECONDARY_DEFAULT RPMA_LOG_DISABLED
-#endif
 
 #endif /* LIBRPMA_LOG_INTERNAL_H */

--- a/tests/unit/log/CMakeLists.txt
+++ b/tests/unit/log/CMakeLists.txt
@@ -5,14 +5,25 @@
 
 include(../../cmake/ctest_helpers.cmake)
 
-function(build_log name)
-	build_test_src(UNIT NAME log-${name} SRCS
+function(add_test_log name)
+	if ("${ARGV1}" STREQUAL "DEBUG")
+		set(test log-${name}-DEBUG)
+	else()
+		set(test log-${name})
+	endif()
+
+	build_test_src(UNIT NAME ${test} SRCS
 		${name}.c
 		${TEST_UNIT_COMMON_DIR}/mocks-rpma-log_default.c
 		${LIBRPMA_SOURCE_DIR}/log.c)
 
-	add_test_generic(NAME log-${name} TRACERS none)
+	if ("${ARGV1}" STREQUAL "DEBUG")
+		target_compile_definitions(${test} PRIVATE DEBUG)
+	endif()
+
+	add_test_generic(NAME ${test} TRACERS none)
 endfunction()
 
-build_log(init-fini)
-build_log(macros)
+add_test_log(init-fini)
+add_test_log(init-fini DEBUG)
+add_test_log(macros)

--- a/tests/unit/log/init-fini.c
+++ b/tests/unit/log/init-fini.c
@@ -12,6 +12,17 @@
 #include "log_default.h"
 
 /*
+ * Default levels of the logging thresholds
+ */
+#ifdef DEBUG
+#define RPMA_LOG_THRESHOLD_DEFAULT RPMA_LOG_LEVEL_DEBUG
+#define RPMA_LOG_THRESHOLD_AUX_DEFAULT RPMA_LOG_LEVEL_WARNING
+#else
+#define RPMA_LOG_THRESHOLD_DEFAULT RPMA_LOG_LEVEL_WARNING
+#define RPMA_LOG_THRESHOLD_AUX_DEFAULT RPMA_LOG_DISABLED
+#endif
+
+/*
  * init_fini__lifecycle -- happy day scenario
  */
 static void
@@ -19,10 +30,10 @@ init_fini__lifecycle(void **unused)
 {
 	/* verify the initial state of the module */
 	assert_null(Rpma_log_function);
-	assert_int_equal(Rpma_log_threshold[RPMA_LOG_THRESHOLD_PRIMARY],
-			RPMA_LOG_THRESHOLD_PRIMARY_DEFAULT);
-	assert_int_equal(Rpma_log_threshold[RPMA_LOG_THRESHOLD_SECONDARY],
-			RPMA_LOG_THRESHOLD_SECONDARY_DEFAULT);
+	assert_int_equal(Rpma_log_threshold[RPMA_LOG_THRESHOLD],
+			RPMA_LOG_THRESHOLD_DEFAULT);
+	assert_int_equal(Rpma_log_threshold[RPMA_LOG_THRESHOLD_AUX],
+			RPMA_LOG_THRESHOLD_AUX_DEFAULT);
 
 	/* configure mocks, run test & verify the results */
 	expect_function_call(rpma_log_default_init);

--- a/tests/unit/log/macros.c
+++ b/tests/unit/log/macros.c
@@ -45,7 +45,7 @@ int
 setup_threshold(void **level_ptr)
 {
 	rpma_log_level level = **(rpma_log_level **)level_ptr;
-	rpma_log_set_threshold(RPMA_LOG_THRESHOLD_PRIMARY, level);
+	rpma_log_set_threshold(RPMA_LOG_THRESHOLD, level);
 
 	return 0;
 }
@@ -77,7 +77,7 @@ log__all(void **level_ptr)
 		 * The secondary threshold should not affect the macros
 		 * behaviour.
 		 */
-		rpma_log_set_threshold(RPMA_LOG_THRESHOLD_SECONDARY, secondary);
+		rpma_log_set_threshold(RPMA_LOG_THRESHOLD_AUX, secondary);
 
 		if (RPMA_LOG_LEVEL_NOTICE <= primary) {
 			MOCK_CONFIGURE_LOG_FUNC(RPMA_LOG_LEVEL_NOTICE);


### PR DESCRIPTION
- reorganize librpma_log.h (thresholds first since they will probably
used more often)
- rename RPMA_LOG_DEFAULT_FUNCTION to RPMA_LOG_USE_DEFAULT_FUNCTION
- misc comments and changes to documentation

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/pmem/rpma/260)
<!-- Reviewable:end -->
