### PR TITLE
rpma: fix 'missing braces around initializer' warning

### DIFF
--- a/src/rpma.c
+++ b/src/rpma.c
@@ -85,7 +85,7 @@ rpma_utils_ibv_context_is_odp_capable(struct ibv_context *dev,
 	*is_odp_capable = 0;
 
 	/* query an RDMA device's attributes */
-	struct ibv_device_attr_ex attr = {0};
+	struct ibv_device_attr_ex attr = {{{0}}};
 	Rpma_provider_error = ibv_query_device_ex(dev, NULL /* input */,
 			&attr);
 	if (Rpma_provider_error)


### PR DESCRIPTION


<!-- Reviewable:start -->
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/pmem/rpma/270)
<!-- Reviewable:end -->
