### PR TITLE
common: fix checking file extensions in check-headers.h

### DIFF
--- a/utils/check_license/check-headers.sh
+++ b/utils/check_license/check-headers.sh
@@ -106,17 +106,17 @@ for file in $FILES ; do
 	if ! grep -q "SPDX-License-Identifier: $LICENSE" $src_path; then
 		echo "error: no $LICENSE SPDX tag in file: $src_path" >&2
 		RV=1
-	elif [[ $(echo $file) =~ ".cmake" ]] || [[ $(echo $file) =~ ".sh" ]]; then
+	elif [[ $file == *.cmake ]] || [[ $file == *.sh ]]; then
 		if ! grep -q -e "# SPDX-License-Identifier: $LICENSE" $src_path; then
 			echo "error: wrong format of SPDX tag in the file: $src_path" >&2
 			RV=1
 		fi
-	elif [[ $(echo $file) =~ ".c" ]]; then
+	elif [[ $file == *.c ]]; then
 		if ! grep -q -e "\/\/ SPDX-License-Identifier: $LICENSE" $src_path; then
 			echo "error: wrong format of SPDX tag in the file: $src_path" >&2
 			RV=1
 		fi
-	elif [[ $(echo $file) =~ ".h" ]]; then
+	elif [[ $file == *.h ]]; then
 		if ! grep -q -e "\/\* SPDX-License-Identifier: $LICENSE \*\/" $src_path; then
 			echo "error: wrong format of SPDX tag in the file: $src_path" >&2
 			RV=1

--- a/utils/check_license/check-headers.sh
+++ b/utils/check_license/check-headers.sh
@@ -106,11 +106,6 @@ for file in $FILES ; do
 	if ! grep -q "SPDX-License-Identifier: $LICENSE" $src_path; then
 		echo "error: no $LICENSE SPDX tag in file: $src_path" >&2
 		RV=1
-	elif [[ $file == *.cmake ]] || [[ $file == *.sh ]]; then
-		if ! grep -q -e "# SPDX-License-Identifier: $LICENSE" $src_path; then
-			echo "error: wrong format of SPDX tag in the file: $src_path" >&2
-			RV=1
-		fi
 	elif [[ $file == *.c ]]; then
 		if ! grep -q -e "\/\/ SPDX-License-Identifier: $LICENSE" $src_path; then
 			echo "error: wrong format of SPDX tag in the file: $src_path" >&2
@@ -118,6 +113,11 @@ for file in $FILES ; do
 		fi
 	elif [[ $file == *.h ]]; then
 		if ! grep -q -e "\/\* SPDX-License-Identifier: $LICENSE \*\/" $src_path; then
+			echo "error: wrong format of SPDX tag in the file: $src_path" >&2
+			RV=1
+		fi
+	elif [[ $file == *.cmake ]] || [[ $file == *.sh ]]; then
+		if ! grep -q -e "# SPDX-License-Identifier: $LICENSE" $src_path; then
 			echo "error: wrong format of SPDX tag in the file: $src_path" >&2
 			RV=1
 		fi


### PR DESCRIPTION
The condition `[[ $(echo $file) =~ ".c" ]]` matches also all `*.c*` files
(for example all `*.cmake` or `Dockerfile.centos`) what is incorrect,
so let's fix checking all file extensions.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/pmem/rpma/281)
<!-- Reviewable:end -->
