### PR TITLE
common: fix checking SPDX tag for files other then *.[ch]

### DIFF
--- a/utils/check_license/check-headers.sh
+++ b/utils/check_license/check-headers.sh
@@ -116,7 +116,7 @@ for file in $FILES ; do
 			echo "error: wrong format of SPDX tag in the file: $src_path" >&2
 			RV=1
 		fi
-	elif [[ $file == *.cmake ]] || [[ $file == *.sh ]]; then
+	elif [[ $file != LICENSE ]]; then
 		if ! grep -q -e "# SPDX-License-Identifier: $LICENSE" $src_path; then
 			echo "error: wrong format of SPDX tag in the file: $src_path" >&2
 			RV=1


### PR DESCRIPTION
Apart from the *.[ch] files there are only scripts in our repo now,
so all of them should have the same SPDX tag:
# SPDX-License-Identifier: $LICENSE

Only the LICENSE file has a different SPDX tag:
SPDX-License-Identifier: $LICENSE