### PR TITLE
common: add 'rpm-build' package to Fedora docker image

### DIFF
--- a/utils/docker/images/Dockerfile.fedora-31
+++ b/utils/docker/images/Dockerfile.fedora-31
@@ -24,6 +24,7 @@ ENV BASE_DEPS "\
 	make \
 	patch \
 	pkg-config \
+	rpm-build \
 	which"
 
 ENV EXAMPLES_DEPS "\


### PR DESCRIPTION
Add 'rpm-build' package to Fedora docker image.
It will be required to make rpm packages.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/pmem/rpma/291)
<!-- Reviewable:end -->
