### PR TITLE
common: remove snprintf from get_timestamp_prefix [WIP]

### DIFF
--- a/src/log_default.c
+++ b/src/log_default.c
@@ -33,10 +33,41 @@ static const int rpma_log_level_syslog_severity[] = {
 };
 
 /*
+ * ltoa:  convert n to characters in 6 digits string with base 10
+ */
+static void
+ltoa(long n, char *buf)
+{
+	char *tail = buf;
+	int i = 0;
+	do { /* generate digits in reverse order */
+		*tail++ = n % 10 + '0';   /* get next digit */
+		i++; /* count all digits */
+	} while ((n /= 10) > 0); /* delete it */
+
+	while (i < 6) {
+		*tail++ = '0'; /* update to 6 digits size */
+		i++;
+	}
+
+	*tail++ = '.'; /* leading dot */
+	*tail-- = '\0';
+
+	/* reverse string */
+	char *head = buf;
+	char tmp;
+	while (head < tail) {
+		tmp = *head;
+		*head++ = *tail;
+		*tail-- = tmp;
+	}
+}
+
+/*
  * get_timestamp_prefix -- provide actual time in a readable string
  *
  * ASSUMPTIONS:
- * - buf != NULL && buf_size >= 16
+ * - buf != NULL && buf_size >= 30
  */
 static void
 get_timestamp_prefix(char *buf, size_t buf_size)
@@ -47,7 +78,6 @@ get_timestamp_prefix(char *buf, size_t buf_size)
 	long usec;
 
 	const char error_message[] = "[time error] ";
-
 	if (clock_gettime(CLOCK_REALTIME, &ts) ||
 	    (NULL == (info = localtime(&ts.tv_sec)))) {
 		memcpy(buf, error_message, sizeof(error_message));
@@ -55,15 +85,18 @@ get_timestamp_prefix(char *buf, size_t buf_size)
 	}
 
 	usec = ts.tv_nsec / 1000;
-	if (!strftime(date, sizeof(date), "%Y-%m-%d %H:%M:%S", info)) {
-		memcpy(buf, error_message, sizeof(error_message));
+	*buf++ = '[';
+	if (!strftime(buf, sizeof(date), "%Y-%m-%d %H:%M:%S", info)) {
+		memcpy(buf - 1, error_message, sizeof(error_message));
 		return;
 	}
 
-	if (snprintf(buf, buf_size, "[%s.%06ld] ", date, usec) < 0) {
-		memcpy(buf, error_message, sizeof(error_message));
-		return;
-	}
+	/*
+	 * 19 characters added by strftime
+	 * "1970-01-01 00:00:00"
+	 */
+	ltoa(usec, buf + 19);
+	strcat(buf, "] ");
 }
 
 /*

--- a/tests/unit/log_default/function.c
+++ b/tests/unit/log_default/function.c
@@ -72,7 +72,6 @@ typedef struct {
 	int clock_gettime_error;
 	int localtime_error;
 	int strftime_error;
-	int snprintf_error;
 
 	rpma_log_level secondary;
 
@@ -210,23 +209,16 @@ static struct tm Tm = MOCK_TIME_OF_DAY;
 		will_return(__wrap_localtime, &Timespec); \
 		will_return(__wrap_localtime, &Tm); \
 		will_return(__wrap_strftime, MOCK_STRFTIME_ERROR); \
-	} else if ((x)->snprintf_error) { \
-		will_return(__wrap_clock_gettime, &Timespec); \
-		will_return(__wrap_localtime, &Timespec); \
-		will_return(__wrap_localtime, &Tm); \
-		will_return(__wrap_strftime, MOCK_STRFTIME_SUCCESS); \
-		will_return(__wrap_snprintf, MOCK_STDIO_ERROR); \
 	} else { \
 		will_return(__wrap_clock_gettime, &Timespec); \
 		will_return(__wrap_localtime, &Timespec); \
 		will_return(__wrap_localtime, &Tm); \
 		will_return(__wrap_strftime, MOCK_STRFTIME_SUCCESS); \
-		will_return(__wrap_snprintf, MOCK_OK); \
 	}
 
 #define MOCK_TIME_STR_EXPECTED(x) \
 	(((x)->clock_gettime_error || (x)->localtime_error || \
-			(x)->strftime_error || (x)->snprintf_error) ? \
+			(x)->strftime_error) ? \
 			MOCK_TIME_ERROR_STR : MOCK_TIME_STR)
 
 /*
@@ -294,31 +286,27 @@ function__stderr_no_path(void **config_ptr)
  * test configurations
  */
 static mock_config config_no_stderr = {
-	0, 0, 0, 0, RPMA_LOG_DISABLED, MOCK_FILE_NAME
+	0, 0, 0, RPMA_LOG_DISABLED, MOCK_FILE_NAME
 };
 
 static mock_config config_no_stderr_path_absolute = {
-	0, 0, 0, 0, RPMA_LOG_DISABLED, MOCK_FILE_NAME_ABSOLUTE
+	0, 0, 0, RPMA_LOG_DISABLED, MOCK_FILE_NAME_ABSOLUTE
 };
 
 static mock_config config_no_error = {
-	0, 0, 0, 0, RPMA_LOG_LEVEL_DEBUG, MOCK_FILE_NAME
+	0, 0, 0, RPMA_LOG_LEVEL_DEBUG, MOCK_FILE_NAME
 };
 
 static mock_config config_gettime_error = {
-	1, 0, 0, 0, RPMA_LOG_LEVEL_DEBUG, MOCK_FILE_NAME
+	1, 0, 0, RPMA_LOG_LEVEL_DEBUG, MOCK_FILE_NAME
 };
 
 static mock_config config_localtime_error = {
-	0, 1, 0, 0, RPMA_LOG_LEVEL_DEBUG, MOCK_FILE_NAME
+	0, 1, 0, RPMA_LOG_LEVEL_DEBUG, MOCK_FILE_NAME
 };
 
 static mock_config config_strftime_error = {
-	0, 0, 1, 0, RPMA_LOG_LEVEL_DEBUG, MOCK_FILE_NAME
-};
-
-static mock_config config_snprintf_error = {
-	0, 0, 0, 1, RPMA_LOG_LEVEL_DEBUG, MOCK_FILE_NAME
+	0, 0, 1, RPMA_LOG_LEVEL_DEBUG, MOCK_FILE_NAME
 };
 
 int
@@ -354,10 +342,6 @@ main(int argc, char *argv[])
 		{"function__stderr_path_strftime_error",
 			function__stderr_path,
 			setup_thresholds, NULL, &config_strftime_error},
-		{"function__stderr_path_snprintf_error",
-			function__stderr_path,
-			setup_thresholds, NULL, &config_snprintf_error},
-
 		/* stderr tests - positive */
 		cmocka_unit_test_prestate_setup_teardown(
 			function__stderr_path,


### PR DESCRIPTION
I propose to remove snprintf from get_timestamp_prefix 
simple ltoa should do what is needed to convert number to 6 digits string

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/pmem/rpma/305)
<!-- Reviewable:end -->
