### PR TITLE
rpma: op_context is not mandatory for rpma_recv

### DIFF
--- a/src/include/librpma.h
+++ b/src/include/librpma.h
@@ -844,7 +844,7 @@ int rpma_send(struct rpma_conn *conn,
  * ERRORS
  * rpma_recv() can fail with the following errors:
  *
- * - RPMA_E_INVAL - conn or src or op_context is NULL
+ * - RPMA_E_INVAL - conn or src is NULL
  * - RPMA_E_INVAL - flags are not set
  * - RPMA_E_PROVIDER - ibv_post_recv(3) failed
  */


### PR DESCRIPTION


<!-- Reviewable:start -->
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/pmem/rpma/310)
<!-- Reviewable:end -->
