### PR TITLE
common: remove hardcoded timeout from info.c module

### DIFF
--- a/src/conn_req.c
+++ b/src/conn_req.c
@@ -366,12 +366,12 @@ rpma_conn_req_new(struct rpma_peer *peer, const char *addr, const char *port,
 	}
 
 	/* resolve address */
-	ret = rpma_info_resolve_addr(info, id);
+	ret = rpma_info_resolve_addr(info, id, RPMA_DEFAULT_TIMEOUT_MS);
 	if (ret)
 		goto err_destroy_id;
 
 	/* resolve route */
-	if (rdma_resolve_route(id, RPMA_DEFAULT_TIMEOUT)) {
+	if (rdma_resolve_route(id, RPMA_DEFAULT_TIMEOUT_MS)) {
 		Rpma_provider_error = errno;
 		RPMA_LOG_ERROR_WITH_ERRNO(Rpma_provider_error,
 			"rdma_resolve_route(timeout_ms="

--- a/src/conn_req.h
+++ b/src/conn_req.h
@@ -12,8 +12,6 @@
 
 #include <rdma/rdma_cma.h>
 
-#define RPMA_DEFAULT_TIMEOUT 1000 /* ms */
-
 /*
  * For the simplicity sake, it is assumed all CQ/SQ/RQ sizes are equal.
  * XXX Later on, it should be configurable on a per-connection basis.

--- a/src/include/librpma.h
+++ b/src/include/librpma.h
@@ -32,6 +32,8 @@
 
 /* picking up an RDMA-capable device */
 
+#define RPMA_DEFAULT_TIMEOUT_MS 1000
+
 /* pick a type of an ibv_context to lookup for */
 enum rpma_util_ibv_context_type {
 	RPMA_UTIL_IBV_CONTEXT_LOCAL, /* lookup for a local device */

--- a/src/info.c
+++ b/src/info.c
@@ -98,23 +98,29 @@ rpma_info_delete(struct rpma_info **info_ptr)
 
 /*
  * rpma_info_resolve_addr -- resolve the CM ID's destination address
+ *
+ * XXX (id != NULL && info != NULL) conditions are unnecessarily checked in
+ * this function whereas this can be done via assumptions mechanism.
+ *
+ * ASSUMPTIONS
+ * - timeout_ms > 0
  */
 int
-rpma_info_resolve_addr(const struct rpma_info *info, struct rdma_cm_id *id)
+rpma_info_resolve_addr(const struct rpma_info *info, struct rdma_cm_id *id,
+		int timeout_ms)
 {
 	if (id == NULL || info == NULL)
 		return RPMA_E_INVAL;
 
-
 	int ret = rdma_resolve_addr(id, info->rai->ai_src_addr,
-			info->rai->ai_dst_addr, RPMA_DEFAULT_TIMEOUT);
+			info->rai->ai_dst_addr, timeout_ms);
 	if (ret) {
 		Rpma_provider_error = errno;
 		RPMA_LOG_ERROR_WITH_ERRNO(Rpma_provider_error,
-			"rdma_resolve_addr(src_addr=%s, dst_addr=%s, timeout_ms=%u)",
+			"rdma_resolve_addr(src_addr=%s, dst_addr=%s, timeout_ms=%d)",
 			info->rai->ai_src_canonname,
 			info->rai->ai_dst_canonname,
-			RPMA_DEFAULT_TIMEOUT);
+			timeout_ms);
 		return RPMA_E_PROVIDER;
 	}
 

--- a/src/info.h
+++ b/src/info.h
@@ -49,7 +49,8 @@ int rpma_info_delete(struct rpma_info **info);
  * - RPMA_E_INVAL - id or info is NULL
  * - RPMA_E_PROVIDER - resolving the destination address failed
  */
-int rpma_info_resolve_addr(const struct rpma_info *info, struct rdma_cm_id *id);
+int rpma_info_resolve_addr(const struct rpma_info *info, struct rdma_cm_id *id,
+		int timeout_ms);
 
 /*
  * rpma_info_bind_addr -- bind the CM ID to the local address

--- a/src/rpma.c
+++ b/src/rpma.c
@@ -56,7 +56,8 @@ rpma_utils_get_ibv_context(const char *addr,
 		if (ret)
 			goto err_destroy_id;
 	} else {
-		ret = rpma_info_resolve_addr(info, temp_id);
+		ret = rpma_info_resolve_addr(info, temp_id,
+				RPMA_DEFAULT_TIMEOUT_MS);
 		if (ret)
 			goto err_destroy_id;
 	}

--- a/tests/unit/common/mocks-rdma_cm.c
+++ b/tests/unit/common/mocks-rdma_cm.c
@@ -169,7 +169,7 @@ int
 rdma_resolve_route(struct rdma_cm_id *id, int timeout_ms)
 {
 	check_expected(id);
-	assert_int_equal(timeout_ms, RPMA_DEFAULT_TIMEOUT);
+	assert_int_equal(timeout_ms, RPMA_DEFAULT_TIMEOUT_MS);
 
 	errno = mock_type(int);
 	if (errno)

--- a/tests/unit/common/mocks-rpma-info.c
+++ b/tests/unit/common/mocks-rpma-info.c
@@ -55,10 +55,12 @@ rpma_info_delete(struct rpma_info **info_ptr)
  * rpma_info_resolve_addr -- mock of rpma_info_resolve_addr
  */
 int
-rpma_info_resolve_addr(const struct rpma_info *info, struct rdma_cm_id *id)
+rpma_info_resolve_addr(const struct rpma_info *info, struct rdma_cm_id *id,
+		int timeout_ms)
 {
 	assert_int_equal(info, MOCK_INFO);
 	check_expected(id);
+	check_expected(timeout_ms);
 
 	int ret = mock_type(int);
 	if (ret == RPMA_E_PROVIDER)

--- a/tests/unit/common/test-common.h
+++ b/tests/unit/common/test-common.h
@@ -10,6 +10,7 @@
 
 #define MOCK_IP_ADDRESS		"127.0.0.1"
 #define MOCK_PORT		"1234" /* a random port number */
+#define MOCK_TIMEOUT_MS		5678
 
 /* random values */
 #define MOCK_PEER		(struct rpma_peer *)0xFEEF

--- a/tests/unit/conn_req/conn_req-common.c
+++ b/tests/unit/conn_req/conn_req-common.c
@@ -91,6 +91,8 @@ setup__conn_req_new(void **cstate_ptr)
 	will_return(rpma_info_new, MOCK_INFO);
 	will_return(rdma_create_id, &cstate.id);
 	expect_value(rpma_info_resolve_addr, id, &cstate.id);
+	expect_value(rpma_info_resolve_addr, timeout_ms,
+			RPMA_DEFAULT_TIMEOUT_MS);
 	will_return(rpma_info_resolve_addr, MOCK_OK);
 	will_return(rdma_resolve_route, MOCK_OK);
 	will_return(ibv_create_comp_channel, MOCK_COMP_CHANNEL);

--- a/tests/unit/conn_req/conn_req-new.c
+++ b/tests/unit/conn_req/conn_req-new.c
@@ -149,6 +149,8 @@ new__resolve_addr_E_PROVIDER_EAGAIN(void **unused)
 	will_return(rpma_info_new, MOCK_INFO);
 	will_return(rdma_create_id, &id);
 	expect_value(rpma_info_resolve_addr, id, &id);
+	expect_value(rpma_info_resolve_addr, timeout_ms,
+			RPMA_DEFAULT_TIMEOUT_MS);
 	will_return(rpma_info_resolve_addr, RPMA_E_PROVIDER);
 	will_return(rpma_info_resolve_addr, EAGAIN);
 	will_return(rdma_destroy_id, MOCK_OK);
@@ -177,6 +179,8 @@ new__resolve_route_EAGAIN(void **unused)
 	will_return(rpma_info_new, MOCK_INFO);
 	will_return(rdma_create_id, &id);
 	expect_value(rpma_info_resolve_addr, id, &id);
+	expect_value(rpma_info_resolve_addr, timeout_ms,
+				RPMA_DEFAULT_TIMEOUT_MS);
 	will_return(rpma_info_resolve_addr, MOCK_OK);
 	will_return(rdma_resolve_route, EAGAIN);
 	will_return(rdma_destroy_id, MOCK_OK);
@@ -206,6 +210,8 @@ new__create_comp_channel_EAGAIN(void **unused)
 	will_return(rpma_info_new, MOCK_INFO);
 	will_return(rdma_create_id, &id);
 	expect_value(rpma_info_resolve_addr, id, &id);
+	expect_value(rpma_info_resolve_addr, timeout_ms,
+				RPMA_DEFAULT_TIMEOUT_MS);
 	will_return(rpma_info_resolve_addr, MOCK_OK);
 	will_return(rdma_resolve_route, MOCK_OK);
 	will_return(ibv_create_comp_channel, NULL);
@@ -236,6 +242,8 @@ new__create_cq_EAGAIN(void **unused)
 	will_return(rpma_info_new, MOCK_INFO);
 	will_return(rdma_create_id, &id);
 	expect_value(rpma_info_resolve_addr, id, &id);
+	expect_value(rpma_info_resolve_addr, timeout_ms,
+				RPMA_DEFAULT_TIMEOUT_MS);
 	will_return(rpma_info_resolve_addr, MOCK_OK);
 	will_return(rdma_resolve_route, MOCK_OK);
 	will_return(ibv_create_comp_channel, MOCK_COMP_CHANNEL);
@@ -269,6 +277,8 @@ new__peer_create_qp_E_PROVIDER_EAGAIN(void **unused)
 	will_return(rpma_info_new, MOCK_INFO);
 	will_return(rdma_create_id, &id);
 	expect_value(rpma_info_resolve_addr, id, &id);
+	expect_value(rpma_info_resolve_addr, timeout_ms,
+				RPMA_DEFAULT_TIMEOUT_MS);
 	will_return(rpma_info_resolve_addr, MOCK_OK);
 	will_return(rdma_resolve_route, MOCK_OK);
 	will_return(ibv_create_comp_channel, MOCK_COMP_CHANNEL);
@@ -305,6 +315,8 @@ new__malloc_ENOMEM(void **unused)
 	will_return(rpma_info_new, MOCK_INFO);
 	will_return(rdma_create_id, &id);
 	expect_value(rpma_info_resolve_addr, id, &id);
+	expect_value(rpma_info_resolve_addr, timeout_ms,
+				RPMA_DEFAULT_TIMEOUT_MS);
 	will_return(rpma_info_resolve_addr, MOCK_OK);
 	will_return(rdma_resolve_route, MOCK_OK);
 	will_return(ibv_create_comp_channel, MOCK_COMP_CHANNEL);
@@ -342,6 +354,8 @@ new__malloc_ENOMEM_subsequent_EAGAIN(void **unused)
 	will_return(rpma_info_new, MOCK_INFO);
 	will_return(rdma_create_id, &id);
 	expect_value(rpma_info_resolve_addr, id, &id);
+	expect_value(rpma_info_resolve_addr, timeout_ms,
+				RPMA_DEFAULT_TIMEOUT_MS);
 	will_return(rpma_info_resolve_addr, MOCK_OK);
 	will_return(rdma_resolve_route, MOCK_OK);
 	will_return(ibv_create_comp_channel, MOCK_COMP_CHANNEL);

--- a/tests/unit/info/info-resolve_addr.c
+++ b/tests/unit/info/info-resolve_addr.c
@@ -28,7 +28,8 @@ resolve_addr__id_NULL(void **info_state_ptr)
 	struct info_state *istate = *info_state_ptr;
 
 	/* run test */
-	int ret = rpma_info_resolve_addr(istate->info, NULL);
+	int ret = rpma_info_resolve_addr(istate->info, NULL,
+			RPMA_DEFAULT_TIMEOUT_MS);
 
 	/* verify the result */
 	assert_int_equal(ret, RPMA_E_INVAL);
@@ -42,7 +43,7 @@ resolve_addr__info_NULL(void **unused)
 {
 	/* run test */
 	struct rdma_cm_id cmid = {0};
-	int ret = rpma_info_resolve_addr(NULL, &cmid);
+	int ret = rpma_info_resolve_addr(NULL, &cmid, RPMA_DEFAULT_TIMEOUT_MS);
 
 	/* verify the result */
 	assert_int_equal(ret, RPMA_E_INVAL);
@@ -56,7 +57,7 @@ static void
 resolve_addr__id_info_NULL(void **unused)
 {
 	/* run test */
-	int ret = rpma_info_resolve_addr(NULL, NULL);
+	int ret = rpma_info_resolve_addr(NULL, NULL, RPMA_DEFAULT_TIMEOUT_MS);
 
 	/* verify the result */
 	assert_int_equal(ret, RPMA_E_INVAL);
@@ -76,11 +77,12 @@ resolve_addr__resolve_addr_EAGAIN(void **info_state_ptr)
 	expect_value(rdma_resolve_addr, id, &cmid);
 	expect_value(rdma_resolve_addr, src_addr, MOCK_SRC_ADDR);
 	expect_value(rdma_resolve_addr, dst_addr, MOCK_DST_ADDR);
-	expect_value(rdma_resolve_addr, timeout_ms, RPMA_DEFAULT_TIMEOUT);
+	expect_value(rdma_resolve_addr, timeout_ms, RPMA_DEFAULT_TIMEOUT_MS);
 	will_return(rdma_resolve_addr, EAGAIN);
 
 	/* run test */
-	int ret = rpma_info_resolve_addr(istate->info, &cmid);
+	int ret = rpma_info_resolve_addr(istate->info, &cmid,
+			RPMA_DEFAULT_TIMEOUT_MS);
 
 	/* verify the result */
 	assert_int_equal(ret, RPMA_E_PROVIDER);
@@ -101,11 +103,12 @@ resolve_addr__success(void **info_state_ptr)
 	expect_value(rdma_resolve_addr, id, &cmid);
 	expect_value(rdma_resolve_addr, src_addr, MOCK_SRC_ADDR);
 	expect_value(rdma_resolve_addr, dst_addr, MOCK_DST_ADDR);
-	expect_value(rdma_resolve_addr, timeout_ms, RPMA_DEFAULT_TIMEOUT);
+	expect_value(rdma_resolve_addr, timeout_ms, RPMA_DEFAULT_TIMEOUT_MS);
 	will_return(rdma_resolve_addr, MOCK_OK);
 
 	/* run test */
-	int ret = rpma_info_resolve_addr(istate->info, &cmid);
+	int ret = rpma_info_resolve_addr(istate->info, &cmid,
+			RPMA_DEFAULT_TIMEOUT_MS);
 
 	/* verify the result */
 	assert_int_equal(ret, MOCK_OK);

--- a/tests/unit/utils/utils-common.c
+++ b/tests/unit/utils/utils-common.c
@@ -97,10 +97,12 @@ rpma_info_bind_addr(const struct rpma_info *info, struct rdma_cm_id *id)
  * rpma_info_resolve_addr -- mock of rpma_info_resolve_addr
  */
 int
-rpma_info_resolve_addr(const struct rpma_info *info, struct rdma_cm_id *id)
+rpma_info_resolve_addr(const struct rpma_info *info, struct rdma_cm_id *id,
+		int timeout_ms)
 {
 	check_expected(info);
 	check_expected(id);
+	assert_int_equal(timeout_ms, RPMA_DEFAULT_TIMEOUT_MS);
 
 	int ret = mock_type(int);
 	if (ret)


### PR DESCRIPTION
This one of many steps leading to allow configuring various aspects of the library behaviour.

TODO:
- [x] tests

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/pmem/rpma/313)
<!-- Reviewable:end -->
