### PR TITLE
examples: fix more '__builtin_strncpy specified bound 1024' errors

### DIFF
--- a/examples/03-read-to-persistent/client.c
+++ b/examples/03-read-to-persistent/client.c
@@ -39,7 +39,7 @@ static inline void
 write_hello_str(struct hello_t *hello, enum lang_t lang)
 {
 	hello->lang = lang;
-	strncpy(hello->str, hello_str[hello->lang], KILOBYTE);
+	strncpy(hello->str, hello_str[hello->lang], KILOBYTE - 1);
 }
 
 static void

--- a/examples/05-flush-to-persistent/client.c
+++ b/examples/05-flush-to-persistent/client.c
@@ -42,7 +42,7 @@ static inline void
 write_hello_str(struct hello_t *hello, enum lang_t lang)
 {
 	hello->lang = lang;
-	strncpy(hello->str, hello_str[hello->lang], KILOBYTE);
+	strncpy(hello->str, hello_str[hello->lang], KILOBYTE - 1);
 }
 
 static void


### PR DESCRIPTION
Fix the rest of:
"error: '__builtin_strncpy' specified bound 1024 equals\
 destination size [-Werror=stringop-truncation]"
errors.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/pmem/rpma/322)
<!-- Reviewable:end -->
