### PR TITLE
rpma: remove flags from rpma_recv()

### DIFF
--- a/src/conn.c
+++ b/src/conn.c
@@ -393,14 +393,14 @@ rpma_send(struct rpma_conn *conn,
 int
 rpma_recv(struct rpma_conn *conn,
     struct rpma_mr_local *dst, size_t offset, size_t len,
-    int flags, void *op_context)
+    void *op_context)
 {
-	if (conn == NULL || dst == NULL || flags == 0)
+	if (conn == NULL || dst == NULL)
 		return RPMA_E_INVAL;
 
 	return rpma_mr_recv(conn->id->qp,
 			dst, offset, len,
-			flags, op_context);
+			op_context);
 }
 
 /*

--- a/src/conn_req.c
+++ b/src/conn_req.c
@@ -483,7 +483,7 @@ rpma_conn_req_delete(struct rpma_conn_req **req_ptr)
 int
 rpma_conn_req_recv(struct rpma_conn_req *req,
     struct rpma_mr_local *dst, size_t offset, size_t len,
-    int flags, void *op_context)
+    void *op_context)
 {
 	return RPMA_E_NOSUPP;
 }

--- a/src/include/librpma.h
+++ b/src/include/librpma.h
@@ -824,7 +824,7 @@ int rpma_send(struct rpma_conn *conn,
  *
  *	int rpma_recv(struct rpma_conn *conn,
  *		struct rpma_mr_local *dst, size_t offset, size_t len,
- *		int flags, void *op_context);
+ *		void *op_context);
  *
  * DESCRIPTION
  * Initialize the receive operation which prepares a buffer for a message
@@ -847,12 +847,11 @@ int rpma_send(struct rpma_conn *conn,
  * rpma_recv() can fail with the following errors:
  *
  * - RPMA_E_INVAL - conn or src is NULL
- * - RPMA_E_INVAL - flags are not set
  * - RPMA_E_PROVIDER - ibv_post_recv(3) failed
  */
 int rpma_recv(struct rpma_conn *conn,
     struct rpma_mr_local *dst, size_t offset, size_t len,
-    int flags, void *op_context);
+    void *op_context);
 
 /* completion handling */
 

--- a/src/include/librpma.h
+++ b/src/include/librpma.h
@@ -544,7 +544,7 @@ int rpma_conn_req_connect(struct rpma_conn_req **req_ptr,
  *
  *	int rpma_conn_req_recv(struct rpma_conn_req *req,
  *		struct rpma_mr_local *dst, size_t offset, size_t len,
- *		int flags, void *op_context);
+ *		void *op_context);
  *
  * DESCRIPTION
  * Initialize the receive operation. It prepares a buffer for a message
@@ -556,12 +556,11 @@ int rpma_conn_req_connect(struct rpma_conn_req **req_ptr,
  * rpma_conn_req_recv() can fail with the following errors:
  *
  * - RPMA_E_INVAL - req or src or op_context is NULL
- * - RPMA_E_INVAL - flags are not set
  * - RPMA_E_PROVIDER - ibv_post_recv(3) failed
  */
 int rpma_conn_req_recv(struct rpma_conn_req *req,
     struct rpma_mr_local *dst, size_t offset, size_t len,
-    int flags, void *op_context);
+    void *op_context);
 
 /* server-side setup */
 

--- a/src/mr.c
+++ b/src/mr.c
@@ -216,7 +216,7 @@ rpma_mr_send(struct ibv_qp *qp,
 int
 rpma_mr_recv(struct ibv_qp *qp,
 	struct rpma_mr_local *dst,  size_t offset,
-	size_t len, int flags, void *op_context)
+	size_t len, void *op_context)
 {
 	return RPMA_E_NOSUPP;
 }

--- a/src/mr.h
+++ b/src/mr.h
@@ -55,7 +55,7 @@ int rpma_mr_send(struct ibv_qp *qp,
 
 /*
  * ASSUMPTIONS
- * - qp != NULL && dst != NULL && flags != 0
+ * - qp != NULL && dst != NULL
  *
  * ERRORS
  * rpma_mr_recv() can fail with the following error:
@@ -64,6 +64,6 @@ int rpma_mr_send(struct ibv_qp *qp,
  */
 int rpma_mr_recv(struct ibv_qp *qp,
 	struct rpma_mr_local *dst,  size_t offset,
-	size_t len, int flags, void *op_context);
+	size_t len, void *op_context);
 
 #endif /* LIBRPMA_MR_H */

--- a/tests/unit/common/mocks-rpma-mr.c
+++ b/tests/unit/common/mocks-rpma-mr.c
@@ -128,17 +128,15 @@ rpma_mr_send(struct ibv_qp *qp,
 int
 rpma_mr_recv(struct ibv_qp *qp,
 	struct rpma_mr_local *dst,  size_t offset,
-	size_t len, int flags, void *op_context)
+	size_t len, void *op_context)
 {
 	assert_non_null(qp);
 	assert_non_null(dst);
-	assert_int_not_equal(flags, 0);
 
 	check_expected_ptr(qp);
 	check_expected_ptr(dst);
 	check_expected(offset);
 	check_expected(len);
-	check_expected(flags);
 	check_expected_ptr(op_context);
 
 	return mock_type(int);

--- a/tests/unit/conn/conn-recv.c
+++ b/tests/unit/conn/conn-recv.c
@@ -20,7 +20,7 @@ recv__conn_NULL(void **unused)
 {
 	/* run test */
 	int ret = rpma_recv(NULL, MOCK_RPMA_MR_LOCAL, MOCK_LOCAL_OFFSET,
-			MOCK_LEN, MOCK_FLAGS, MOCK_OP_CONTEXT);
+			MOCK_LEN, MOCK_OP_CONTEXT);
 
 	/* verify the results */
 	assert_int_equal(ret, RPMA_E_INVAL);
@@ -34,36 +34,21 @@ recv__dst_NULL(void **unused)
 {
 	/* run test */
 	int ret = rpma_recv(MOCK_CONN, NULL, MOCK_LOCAL_OFFSET,
-			MOCK_LEN, MOCK_FLAGS, MOCK_OP_CONTEXT);
+			MOCK_LEN, MOCK_OP_CONTEXT);
 
 	/* verify the results */
 	assert_int_equal(ret, RPMA_E_INVAL);
 }
 
 /*
- * recv__flags_0 - flags == 0 is invalid
+ * recv__conn_dst_src_NULL - NULL conn and dst are invalid
  */
 static void
-recv__flags_0(void **unused)
-{
-	/* run test */
-	int ret = rpma_recv(MOCK_CONN, MOCK_RPMA_MR_LOCAL, MOCK_LOCAL_OFFSET,
-			MOCK_LEN, 0, MOCK_OP_CONTEXT);
-
-	/* verify the results */
-	assert_int_equal(ret, RPMA_E_INVAL);
-}
-
-/*
- * recv__conn_dst_src_NULL_flags_0 - NULL conn, dst
- * and flags == 0 are invalid
- */
-static void
-recv__conn_dst_src_NULL_flags_0(void **unused)
+recv__conn_dst_src_NULL(void **unused)
 {
 	/* run test */
 	int ret = rpma_recv(NULL, NULL, MOCK_LOCAL_OFFSET,
-			MOCK_LEN, 0, MOCK_OP_CONTEXT);
+			MOCK_LEN, MOCK_OP_CONTEXT);
 
 	/* verify the results */
 	assert_int_equal(ret, RPMA_E_INVAL);
@@ -82,13 +67,12 @@ recv__success(void **cstate_ptr)
 	expect_value(rpma_mr_recv, dst, MOCK_RPMA_MR_LOCAL);
 	expect_value(rpma_mr_recv, offset, MOCK_LOCAL_OFFSET);
 	expect_value(rpma_mr_recv, len, MOCK_LEN);
-	expect_value(rpma_mr_recv, flags, MOCK_FLAGS);
 	expect_value(rpma_mr_recv, op_context, MOCK_OP_CONTEXT);
 	will_return(rpma_mr_recv, MOCK_OK);
 
 	/* run test */
 	int ret = rpma_recv(cstate->conn, MOCK_RPMA_MR_LOCAL, MOCK_LOCAL_OFFSET,
-			MOCK_LEN, MOCK_FLAGS, MOCK_OP_CONTEXT);
+			MOCK_LEN, MOCK_OP_CONTEXT);
 
 	/* verify the results */
 	assert_int_equal(ret, MOCK_OK);
@@ -110,8 +94,7 @@ static const struct CMUnitTest tests_recv[] = {
 	/* rpma_recv() unit tests */
 	cmocka_unit_test(recv__conn_NULL),
 	cmocka_unit_test(recv__dst_NULL),
-	cmocka_unit_test(recv__flags_0),
-	cmocka_unit_test(recv__conn_dst_src_NULL_flags_0),
+	cmocka_unit_test(recv__conn_dst_src_NULL),
 	cmocka_unit_test_setup_teardown(recv__success,
 		setup__conn_new, teardown__conn_delete),
 	cmocka_unit_test(NULL)


### PR DESCRIPTION
Remove the 'flags' argument from rpma_recv(),
because the 'ibv_recv_wr' structure has no receive flags.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/pmem/rpma/327)
<!-- Reviewable:end -->
