### PR TITLE
examples: make sure the server's process is finished

### DIFF
--- a/examples/run-all-on-SoftRoCE.sh
+++ b/examples/run-all-on-SoftRoCE.sh
@@ -63,6 +63,16 @@ function run_example() {
 		N_FAILED=$(($N_FAILED + 1))
 		FAILED="$FAILED$EXAMPLE\n"
 	fi
+
+	# make sure the server's process is finished
+	ARGS="server $IP_ADDRESS $PORT"
+	PID=$(ps aux | grep -e "$ARGS" | grep -v -e "grep -e $ARGS" | awk '{print $2}')
+	if [ "$PID" != "" ]; then
+		kill $PID
+		sleep 1
+		kill -9 $PID 2>/dev/null
+	fi
+
 	echo
 }
 


### PR DESCRIPTION
While running 'make test_softroce' the '07-atomic-write' example
fails always with the following error now:

`*ERROR*: rdma_bind_addr() failed: Address already in use`

Make sure the server's process is finished,
before starting a new one.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/pmem/rpma/333)
<!-- Reviewable:end -->
