### PR TITLE
examples: fix 07-atomic-write example on SoftRoCE

### DIFF
--- a/examples/07-atomic-write/server.c
+++ b/examples/07-atomic-write/server.c
@@ -25,7 +25,7 @@
 
 #define LOG_HDR_SIGNATURE "LOG"
 #define LOG_SIGNATURE_SIZE 8
-#define LOG_DATA_SIZE 100000 /* 100k */
+#define LOG_DATA_SIZE 1024
 
 /* defined log structure */
 struct log {


### PR DESCRIPTION
When LOG_DATA_SIZE==100000 `ibv_reg_mr()` is called with length==200016
and it fails on SoftRoCE. Decrease LOG_DATA_SIZE to 1024 to fix it.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/pmem/rpma/336)
<!-- Reviewable:end -->
