### PR TITLE
examples: fix error: macro "LOG_HDR_SIGNATURE" is not used

### DIFF
--- a/examples/07-atomic-write/server.c
+++ b/examples/07-atomic-write/server.c
@@ -23,7 +23,9 @@
 
 #include "common-conn.h"
 
+#ifdef USE_LIBPMEM
 #define LOG_HDR_SIGNATURE "LOG"
+#endif
 #define LOG_SIGNATURE_SIZE 8
 #define LOG_DATA_SIZE 1024
 


### PR DESCRIPTION
Fix the following compilation error:
```
[100%] Building C object examples/CMakeFiles/example-07-atomic-write-server.dir/07-atomic-write/server.c.o
/rpma/examples/07-atomic-write/server.c:26:0: error: macro "LOG_HDR_SIGNATURE" is not used [-Werror=unused-macros]
 #define LOG_HDR_SIGNATURE "LOG"
```

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/pmem/rpma/343)
<!-- Reviewable:end -->
