### PR TITLE
rpma: include string.h for strerror()

### DIFF
--- a/src/log_internal.h
+++ b/src/log_internal.h
@@ -8,6 +8,7 @@
 #ifndef LIBRPMA_LOG_INTERNAL_H
 #define LIBRPMA_LOG_INTERNAL_H
 
+#include <string.h>
 #include "librpma_log.h"
 
 /* pointer to the logging function */


### PR DESCRIPTION
It fixes the following error:
```
In file included from /rpma/src/conn.c:14:0:
/rpma/src/conn.c: In function 'rpma_conn_new':
/rpma/src/log_internal.h:57:49: error: implicit declaration of function 'strerror' [-Werror=implicit-function-declaration]
  RPMA_LOG_ERROR(f " failed: %s", ##__VA_ARGS__, strerror(e));
                                                 ^
```

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/pmem/rpma/351)
<!-- Reviewable:end -->
