### PR TITLE
common: redundant error message removed

### DIFF
--- a/examples/08-messages-ping-pong/client.c
+++ b/examples/08-messages-ping-pong/client.c
@@ -123,10 +123,7 @@ main(int argc, char *argv[])
 			} else if (cmpl.op_status != IBV_WC_SUCCESS) {
 
 				(void) fprintf(stderr,
-					"operation %d failed: %s\n",
-					cmpl.op,
-					ibv_wc_status_str(cmpl.op_status));
-
+					"Shutting down the client due to the unsuccessful completion of an operation.\n");
 				ret = -1;
 				break;
 			}


### PR DESCRIPTION
Librpma already provide WARNING when the result is != IBV_WC_SUCCESS
Here a high level message is only needed.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/pmem/rpma/360)
<!-- Reviewable:end -->
