### PR TITLE
common: fix librpma pkg-config file

### DIFF
--- a/cmake/librpma.pc.in
+++ b/cmake/librpma.pc.in
@@ -1,9 +1,10 @@
 prefix=@CMAKE_INSTALL_PREFIX@
 includedir=${prefix}/@CMAKE_INSTALL_INCLUDEDIR@
+libdir=${prefix}/@CMAKE_INSTALL_LIBDIR@
 
 Name: librpma
 Description: librpma - library to simplify accessing persistent memory devices on remote hosts over RDMA
 Version: @VERSION@
 URL: https://github.com/pmem/rpma
-Requires: libibverbs >= @LIBIBVERBS_REQUIRED_VERSION@ librdmacm >= @LIBRDMACM_REQUIRED_VERSION@
 Cflags: -I${includedir}
+Libs: -L${libdir} -lrpma -libverbs -lrdmacm


### PR DESCRIPTION
Fix librpma pkg-config file:
1) do not require pkg-config files of libibverbs and librdmacm,
   because older versions of them do not provide pkg-config files
2) add the link flags specific to this package and other required
   libraries that don't support pkg-config.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/pmem/rpma/361)
<!-- Reviewable:end -->
