### PR TITLE
common: fix error: unknown option: '-C' of the 'git' command

### DIFF
--- a/utils/check_license/check-headers.sh
+++ b/utils/check_license/check-headers.sh
@@ -34,7 +34,13 @@ if [ "$1" == "-h" -o "$1" == "--help" ]; then
 	exit 0
 fi
 
-export GIT="git -C ${SOURCE_ROOT}"
+#
+# "git -C ${SOURCE_ROOT}" is not supported on CentOS-6 and CentOS-7,
+# so let's do it using the 'cd' command.
+# Leave 'export GIT="git"' for consistency with the PMDK's version.
+#
+cd ${SOURCE_ROOT}
+export GIT="git"
 $GIT rev-parse || exit 1
 
 if [ -f $SOURCE_ROOT/.git/shallow ]; then


### PR DESCRIPTION
This fix is required to support CentOS-7 and CentOS-6.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/pmem/rpma/364)
<!-- Reviewable:end -->
