### PR TITLE
common: require Perl v5.10 instead of v5.16

### DIFF
--- a/tests/match
+++ b/tests/match
@@ -54,7 +54,7 @@
 use strict;
 use Getopt::Std;
 use Encode;
-use v5.16;
+use v5.10;
 
 select STDERR;
 binmode(STDOUT, ":utf8");

--- a/utils/check_whitespace
+++ b/utils/check_whitespace
@@ -14,7 +14,7 @@ use warnings;
 use File::Basename;
 use File::Find;
 use Encode;
-use v5.16;
+use v5.10;
 
 my $Me = $0;
 $Me =~ s,.*/,,;


### PR DESCRIPTION
This change is required to support building librpma on CentOS-6.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/pmem/rpma/365)
<!-- Reviewable:end -->
