### PR TITLE
examples: fix non null terminated string

### DIFF
--- a/examples/06-multiple-connections/client.c
+++ b/examples/06-multiple-connections/client.c
@@ -87,7 +87,8 @@ main(int argc, char *argv[])
 	/* pick a name */
 	srand(seed % UINT_MAX);
 	const char *name = Names[(long unsigned int)rand() % NAMES_NUM];
-	(void) strncpy((char *)mr_ptr, name, MAX_NAME_SIZE);
+	(void) strncpy((char *)mr_ptr, name, (MAX_NAME_SIZE - 1));
+	((char *)mr_ptr)[MAX_NAME_SIZE - 1] = '\0';
 	printf("My names is: %s\n", (char *)mr_ptr);
 
 	/* register the memory */


### PR DESCRIPTION
Forced by the static analyzer which has pointed out
that strncpy *theoretically* may not null-terminate the output string.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/pmem/rpma/371)
<!-- Reviewable:end -->
