### PR TITLE
common: fix running check-ms-license.pl in check-headers.sh

### DIFF
--- a/utils/check_license/check-headers.sh
+++ b/utils/check_license/check-headers.sh
@@ -181,7 +181,7 @@ s/.*Copyright \([0-9]\+\),.*/\1-\1/' $src_path`
 done
 rm -f $TMP $TMP2 $TEMPFILE
 
-$(dirname "$0")/check-ms-license.pl $FILES
+$(dirname $SELF)/check-ms-license.pl $FILES
 
 # check if error found
 if [ $RV -eq 0 ]; then


### PR DESCRIPTION
$0 has to be replaced with $SELF (set at the beginning to $0),
because there were several 'shift' commands
and $0 can be something else than it was initially.

It fixes the following error existing on master:
```
../utils/check_license/check-headers.sh: line 190: ../utils/check_license/check-ms-license.pl: No such file or directory
```

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/pmem/rpma/374)
<!-- Reviewable:end -->
