### PR TITLE
common: fix installing txt2man in /usr

### DIFF
--- a/utils/docker/images/install-txt2man.sh
+++ b/utils/docker/images/install-txt2man.sh
@@ -17,6 +17,6 @@ cd txt2man
 git checkout txt2man-1.7.0
 
 make -j$(nproc)
-sudo make -j$(nproc) install
+sudo make -j$(nproc) install prefix=/usr
 cd ..
 rm -r txt2man


### PR DESCRIPTION
Install src2man and txt2man in /usr instead of /usr/local.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/pmem/rpma/383)
<!-- Reviewable:end -->
