### PR TITLE
common: remove redundant 'make doc' test

### DIFF
--- a/utils/docker/run-build.sh
+++ b/utils/docker/run-build.sh
@@ -88,7 +88,6 @@ cmake .. -DCMAKE_BUILD_TYPE=Debug \
 	-DDEVELOPER_MODE=1
 
 make -j$(nproc)
-make -j$(nproc) doc
 ctest --output-on-failure
 sudo_password -S make -j$(nproc) install
 
@@ -140,7 +139,6 @@ cmake .. -DCMAKE_BUILD_TYPE=Release \
 	-DDEVELOPER_MODE=1
 
 make -j$(nproc)
-make -j$(nproc) doc
 ctest --output-on-failure
 # Do not install the library from sources here,
 # because it will be installed from the packages below.


### PR DESCRIPTION
The 'all' target depends on the 'doc' target,
so the 'doc' target is already run during the 'all' target.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/pmem/rpma/387)
<!-- Reviewable:end -->
