### PR TITLE
examples: fix defining ON_STR

### DIFF
--- a/examples/05-flush-to-persistent/server.c
+++ b/examples/05-flush-to-persistent/server.c
@@ -21,7 +21,9 @@
 #define USAGE_STR "usage: %s <server_address> <port>\n"
 #endif /* USE_LIBPMEM */
 
+#ifdef USE_LIBPMEM
 #define ON_STR "on"
+#endif /* USE_LIBPMEM */
 
 #include "common-conn.h"
 


### PR DESCRIPTION
'ON_STR' should be defined only
if 'USE_LIBPMEM' had been already defined before.

It fixes the following error:
```
/rpma/examples/05-flush-to-persistent/server.c:24: error: macro "ON_STR" is not used [-Werror=unused-macros]
 #define ON_STR "on"
```

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/pmem/rpma/394)
<!-- Reviewable:end -->
