### PR TITLE
common: fix running check-ms-license.pl in check-headers.sh ultimately

### DIFF
--- a/utils/check_license/check-headers.sh
+++ b/utils/check_license/check-headers.sh
@@ -5,6 +5,7 @@
 # check-headers.sh - check copyright and license in source files
 
 SELF=$0
+DIR=$(pwd)/$(dirname $SELF)
 
 function usage() {
 	echo "Usage: $SELF <source_root_path> <license_tag> [-h|-v|-a]"
@@ -187,7 +188,7 @@ s/.*Copyright \([0-9]\+\),.*/\1-\1/' $src_path`
 done
 rm -f $TMP $TMP2 $TEMPFILE
 
-$(dirname $SELF)/check-ms-license.pl $FILES
+$DIR/check-ms-license.pl $FILES
 
 # check if error found
 if [ $RV -eq 0 ]; then


### PR DESCRIPTION
This is a fix of b4ce4ab.
The b4ce4ab commit has not fixed the issue:

```
../utils/check_license/check-headers.sh: line 190: ../utils/check_license/check-ms-license.pl: No such file or directory
```

because the c17026a commit was also merged just before it.
c17026a changes the current directory and makes b4ce4ab does not work.

This patch fixes it ultimately.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/pmem/rpma/402)
<!-- Reviewable:end -->
