### PR TITLE
common: Do not use valgiring by default

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -54,7 +54,7 @@ option(USE_ASAN "enable AddressSanitizer (debugging)" OFF)
 option(USE_UBSAN "enable UndefinedBehaviorSanitizer (debugging)" OFF)
 
 option(TESTS_USE_FORCED_PMEM "run tests with PMEM_IS_PMEM_FORCE=1" OFF)
-option(TESTS_USE_VALGRIND "enable tests with valgrind (if found)" ON)
+option(TESTS_USE_VALGRIND "enable tests with valgrind (if found)" OFF)
 option(TESTS_LONG "enable long running tests" OFF)
 option(TESTS_USE_FAULT_INJECTION "run tests with fault injection" OFF)
 


### PR DESCRIPTION
As there is no valgrind tests yet so, to avoid cmake warning when valgrind is
not found, this option should be off by default

```
CMake Warning at tests/cmake/ctest_helpers.cmake:55 (message):
  Valgrind not found.  Valgrind tests will not be performed.
Call Stack (most recent call first):
  tests/CMakeLists.txt:28 (find_packages)
```

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/pmem/rpma/405)
<!-- Reviewable:end -->
