### PR TITLE
rpma: remove rpma_peer_cfg_descriptor

### DIFF
--- a/doc/manuals_3.txt
+++ b/doc/manuals_3.txt
@@ -41,6 +41,7 @@ rpma_mr_remote_get_size.3
 rpma_peer_cfg_delete.3
 rpma_peer_cfg_from_descriptor.3
 rpma_peer_cfg_get_descriptor.3
+rpma_peer_cfg_get_descriptor_size.3
 rpma_peer_cfg_get_direct_write_to_pmem.3
 rpma_peer_cfg_new.3
 rpma_peer_cfg_set_direct_write_to_pmem.3

--- a/examples/05-flush-to-persistent/client.c
+++ b/examples/05-flush-to-persistent/client.c
@@ -201,7 +201,8 @@ main(int argc, char *argv[])
 	 * descriptor and apply it to the current connection.
 	 */
 	struct common_data *dst_data = pdata.ptr;
-	ret = rpma_peer_cfg_from_descriptor(&dst_data->pcfg_desc, &pcfg);
+	ret = rpma_peer_cfg_from_descriptor(dst_data->pcfg_desc,
+				dst_data->pcfg_desc_size, &pcfg);
 	if (ret)
 		goto err_mr_dereg;
 	ret = rpma_peer_cfg_get_direct_write_to_pmem(pcfg,

--- a/examples/common/common-conn.h
+++ b/examples/common/common-conn.h
@@ -19,9 +19,10 @@
 #endif
 
 struct common_data {
-	rpma_peer_cfg_descriptor pcfg_desc;
-	rpma_mr_descriptor mr_desc;
 	size_t data_offset;
+	rpma_mr_descriptor mr_desc;
+	size_t pcfg_desc_size;
+	char pcfg_desc[];
 };
 
 #define KILOBYTE 1024

--- a/src/include/librpma.h
+++ b/src/include/librpma.h
@@ -181,13 +181,6 @@ int rpma_peer_cfg_set_direct_write_to_pmem(struct rpma_peer_cfg *pcfg,
 int rpma_peer_cfg_get_direct_write_to_pmem(struct rpma_peer_cfg *pcfg,
 		bool *supported);
 
-/* The number of bytes required to store a peer descriptor */
-#define RPMA_PEER_CFG_DESCRIPTOR_SIZE 1
-
-typedef struct {
-	uint8_t data[RPMA_PEER_CFG_DESCRIPTOR_SIZE];
-} rpma_peer_cfg_descriptor;
-
 /** 3
  * rpma_peer_cfg_get_descriptor - get a descriptor of a peer configuration
  *
@@ -203,8 +196,27 @@ typedef struct {
  *
  * - RPMA_E_INVAL - pcfg or desc are NULL
  */
-int rpma_peer_cfg_get_descriptor(struct rpma_peer_cfg *pcfg,
-		rpma_peer_cfg_descriptor *desc);
+int rpma_peer_cfg_get_descriptor(struct rpma_peer_cfg *pcfg, void *desc);
+
+/** 3
+ * rpma_peer_cfg_get_descriptor_size -- get size of the peer configuration
+ * descriptor
+ *
+ * SYNOPSIS
+ *
+ *	#include <librpma.h>
+ *
+ *	int rpma_peer_cfg_get_descriptor_size(struct rpma_peer_cfg *pcfg,
+ *                                            size_t *desc_size);
+ *
+ * ERRORS
+ * rpma_peer_cfg_get_descriptor() can fail with the following error:
+ *
+ * - RPMA_E_INVAL - pcfg or desc_size is NULL
+ */
+int
+rpma_peer_cfg_get_descriptor_size(struct rpma_peer_cfg *pcfg,
+					size_t *desc_size);
 
 /** 3
  * rpma_peer_cfg_from_descriptor - create a peer configuration from a descriptor
@@ -213,7 +225,7 @@ int rpma_peer_cfg_get_descriptor(struct rpma_peer_cfg *pcfg,
  *
  *	#include <librpma.h>
  *
- *	int rpma_peer_cfg_from_descriptor(rpma_peer_cfg_descriptor *desc,
+ *	int rpma_peer_cfg_from_descriptor(void *desc, size_t desc_size,
  *			struct rpma_peer_cfg **pcfg_ptr);
  *
  * ERRORS
@@ -222,7 +234,7 @@ int rpma_peer_cfg_get_descriptor(struct rpma_peer_cfg *pcfg,
  * - RPMA_E_INVAL - desc or pcfg_ptr are NULL
  * - RPMA_E_NOMEM - out of memory
  */
-int rpma_peer_cfg_from_descriptor(rpma_peer_cfg_descriptor *desc,
+int rpma_peer_cfg_from_descriptor(void *desc, size_t desc_size,
 		struct rpma_peer_cfg **pcfg_ptr);
 
 /* peer */

--- a/src/librpma.map
+++ b/src/librpma.map
@@ -51,6 +51,7 @@ LIBRPMA_1.0 {
 		rpma_peer_cfg_delete;
 		rpma_peer_cfg_from_descriptor;
 		rpma_peer_cfg_get_descriptor;
+		rpma_peer_cfg_get_descriptor_size;
 		rpma_peer_cfg_get_direct_write_to_pmem;
 		rpma_peer_cfg_new;
 		rpma_peer_cfg_set_direct_write_to_pmem;

--- a/src/peer_cfg.c
+++ b/src/peer_cfg.c
@@ -94,15 +94,27 @@ rpma_peer_cfg_get_direct_write_to_pmem(struct rpma_peer_cfg *pcfg,
  * rpma_peer_cfg_get_descriptor -- get a descriptor of a peer configuration
  */
 int
-rpma_peer_cfg_get_descriptor(struct rpma_peer_cfg *pcfg,
-		rpma_peer_cfg_descriptor *desc)
+rpma_peer_cfg_get_descriptor(struct rpma_peer_cfg *pcfg, void *desc)
 {
 	if (pcfg == NULL || desc == NULL)
 		return RPMA_E_INVAL;
 
-	char *buff = (char *)desc;
+	*((uint8_t *)desc) = (uint8_t)pcfg->direct_write_to_pmem;
 
-	*((uint8_t *)buff) = (uint8_t)pcfg->direct_write_to_pmem;
+	return 0;
+}
+
+/*
+ * rpma_peer_cfg_get_descriptor_size -- get size of the peer configuration
+ * descriptor
+ */
+int
+rpma_peer_cfg_get_descriptor_size(struct rpma_peer_cfg *pcfg, size_t *desc_size)
+{
+	if (pcfg == NULL || desc_size == NULL)
+		return RPMA_E_INVAL;
+
+	*desc_size = sizeof(uint8_t);
 
 	return 0;
 }
@@ -112,25 +124,28 @@ rpma_peer_cfg_get_descriptor(struct rpma_peer_cfg *pcfg,
  * from a descriptor
  */
 int
-rpma_peer_cfg_from_descriptor(rpma_peer_cfg_descriptor *desc,
+rpma_peer_cfg_from_descriptor(void *desc, size_t desc_size,
 		struct rpma_peer_cfg **pcfg_ptr)
 {
 	if (desc == NULL || pcfg_ptr == NULL)
 		return RPMA_E_INVAL;
 
-	char *buff = (char *)desc;
-
-	uint8_t direct_write_to_pmem = *(uint8_t *)buff;
+	if (desc_size < sizeof(uint8_t)) {
+		RPMA_LOG_ERROR(
+			"incorrect size of the descriptor: %i bytes (should be at least %i bytes)",
+			desc_size, sizeof(uint8_t));
+		return RPMA_E_INVAL;
+	}
 
 	struct rpma_peer_cfg *cfg = malloc(sizeof(struct rpma_peer_cfg));
 	if (cfg == NULL)
 		return RPMA_E_NOMEM;
 
-	cfg->direct_write_to_pmem = direct_write_to_pmem;
+	cfg->direct_write_to_pmem = *(uint8_t *)desc;
 	*pcfg_ptr = cfg;
 
 	RPMA_LOG_INFO("new rpma_peer_cfg(direct_write_to_pmem=%s)",
-			SUPPORTED2STR(direct_write_to_pmem));
+			SUPPORTED2STR(cfg->direct_write_to_pmem));
 
 	return 0;
 }

--- a/tests/unit/peer_cfg/peer_cfg-common.h
+++ b/tests/unit/peer_cfg/peer_cfg-common.h
@@ -14,6 +14,9 @@
 
 #define MOCK_PEER_PCFG_PTR	((struct rpma_peer_cfg **)0xA1D1)
 #define MOCK_PEER_PCFG		((struct rpma_peer_cfg *)0xA1D2)
+#define MOCK_DESC		((void *)0xA1D3)
+#define MOCK_DESC_SIZE		((size_t)1)
+#define MOCK_WRONG_DESC_SIZE	((size_t)0)
 #define MOCK_SUPPORTED		false
 
 /*


### PR DESCRIPTION
Missing:
- [x] UTs for `rpma_peer_cfg_get_descriptor_size()`
- [x] fix the 05 example

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/pmem/rpma/407)
<!-- Reviewable:end -->
