### PR TITLE
common: add missing FindLIBPROTOBUFC.cmake

### DIFF
--- a/cmake/FindLIBPROTOBUFC.cmake
+++ b/cmake/FindLIBPROTOBUFC.cmake
@@ -1,0 +1,20 @@
+#
+# SPDX-License-Identifier: BSD-3-Clause
+# Copyright 2020, Intel Corporation
+#
+
+message(STATUS "Checking for module 'libprotobuf-c' w/o PkgConfig")
+
+find_library(LIBPROTOBUFC_LIBRARY NAMES libprotobuf-c.so libprotobuf-c protobuf-c)
+set(LIBPROTOBUFC_LIBRARIES ${LIBPROTOBUFC_LIBRARY})
+
+if(LIBPROTOBUFC_LIBRARY)
+	message(STATUS "  Found libprotobuf-c w/o PkgConfig")
+else()
+	set(MSG_NOT_FOUND "libprotobuf-c NOT found (set CMAKE_PREFIX_PATH to point the location)")
+	if(LIBPROTOBUFC_FIND_REQUIRED)
+		message(FATAL_ERROR ${MSG_NOT_FOUND})
+	else()
+		message(WARNING ${MSG_NOT_FOUND})
+	endif()
+endif()


### PR DESCRIPTION
Add missing FindLIBPROTOBUFC.cmake.
If there is no 'libprotobuf-c' pkgconfig file found,
the following CMake error is printed:

```
-- Checking for module 'libprotobuf-c'
--   No package 'libprotobuf-c' found
CMake Error at CMakeLists.txt:26 (find_package):
  By not providing "FindLIBPROTOBUFC.cmake" in CMAKE_MODULE_PATH this project
  has asked CMake to find a package configuration file provided by
  "LIBPROTOBUFC", but CMake did not find one.
```

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/pmem/rpma/413)
<!-- Reviewable:end -->
