### PR TITLE
rpma: avoid silent shutdown in case of unknown comunication event

### DIFF
--- a/src/conn.c
+++ b/src/conn.c
@@ -183,6 +183,20 @@ rpma_conn_next_event(struct rpma_conn *conn, enum rpma_conn_event *event)
 			*event = RPMA_CONN_CLOSED;
 			break;
 		default:
+/*
+ * XXX
+ * rdma_event_str() to be added
+ * to provide more information about unexpected event.
+ * e.g.:
+ * RPMA_LOG_WARNING("%s (%s)",
+ *	rpma_utils_conn_event_2str(*event),
+ *	cm_erdma_event_str( cm_event));
+ *
+ * Note: This modification will cause several UT to be updated
+ */
+			RPMA_LOG_WARNING("%s: %d",
+					rpma_utils_conn_event_2str(*event),
+					cm_event);
 			return RPMA_E_UNKNOWN;
 	}
 

--- a/src/rpma.c
+++ b/src/rpma.c
@@ -130,6 +130,6 @@ rpma_utils_conn_event_2str(enum rpma_conn_event conn_event)
 	case RPMA_CONN_LOST:
 		return "Connection lost";
 	default:
-		return "Unknown connection event";
+		return "Unsupported connection event";
 	}
 }

--- a/tests/unit/utils/utils-conn_event_2str.c
+++ b/tests/unit/utils/utils-conn_event_2str.c
@@ -16,7 +16,7 @@ static void
 conn_event_2str__CONN_UNDEFINED(void **unused)
 {
 	assert_string_equal(rpma_utils_conn_event_2str(RPMA_CONN_UNDEFINED),
-	"Undefined connection event");
+		"Undefined connection event");
 }
 
 /*
@@ -27,7 +27,7 @@ static void
 conn_event_2str__CONN_ESTABLISHED(void **unused)
 {
 	assert_string_equal(rpma_utils_conn_event_2str(RPMA_CONN_ESTABLISHED),
-	"Connection established");
+		"Connection established");
 }
 
 /*
@@ -38,7 +38,7 @@ static void
 conn_event_2str__CONN_CLOSED(void **unused)
 {
 	assert_string_equal(rpma_utils_conn_event_2str(RPMA_CONN_CLOSED),
-	"Connection closed");
+		"Connection closed");
 }
 
 /*
@@ -49,7 +49,7 @@ static void
 conn_event_2str__CONN_LOST(void **unused)
 {
 	assert_string_equal(rpma_utils_conn_event_2str(RPMA_CONN_LOST),
-	"Connection lost");
+		"Connection lost");
 }
 
 /*
@@ -60,7 +60,7 @@ static void
 conn_event_2str__CONN_UNSUPPORTED(void **unused)
 {
 	assert_string_equal(rpma_utils_conn_event_2str(RPMA_E_UNKNOWN),
-	"Unsupported connection event");
+		"Unsupported connection event");
 }
 
 int

--- a/tests/unit/utils/utils-conn_event_2str.c
+++ b/tests/unit/utils/utils-conn_event_2str.c
@@ -53,14 +53,14 @@ conn_event_2str__CONN_LOST(void **unused)
 }
 
 /*
- * conn_event_2str__CONN_UNKOWN - sanity test for
+ * conn_event_2str__CONN_UNSUPPORTED - sanity test for
  * rpma_utils_conn_event_2str()
  */
 static void
-conn_event_2str__CONN_UNKNOWN(void **unused)
+conn_event_2str__CONN_UNSUPPORTED(void **unused)
 {
 	assert_string_equal(rpma_utils_conn_event_2str(RPMA_E_UNKNOWN),
-	"Unknown connection event");
+	"Unsupported connection event");
 }
 
 int
@@ -72,7 +72,7 @@ main(int argc, char *argv[])
 		cmocka_unit_test(conn_event_2str__CONN_ESTABLISHED),
 		cmocka_unit_test(conn_event_2str__CONN_CLOSED),
 		cmocka_unit_test(conn_event_2str__CONN_LOST),
-		cmocka_unit_test(conn_event_2str__CONN_UNKNOWN),
+		cmocka_unit_test(conn_event_2str__CONN_UNSUPPORTED),
 	};
 
 	return cmocka_run_group_tests(tests, NULL, NULL);


### PR DESCRIPTION
There is no message when connection could not be properly established on a client side  (server close it just after accepting)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/pmem/rpma/415)
<!-- Reviewable:end -->
