### PR TITLE
common: obsolete enum removed

### DIFF
--- a/src/include/librpma.h
+++ b/src/include/librpma.h
@@ -119,11 +119,6 @@ int rpma_utils_ibv_context_is_odp_capable(struct ibv_context *dev,
 
 struct rpma_peer_cfg;
 
-enum rpma_on_off_type {
-	RPMA_OFF,
-	RPMA_ON
-};
-
 /** 3
  * rpma_peer_cfg_new - create a new peer configuration object
  *


### PR DESCRIPTION
rpma_on_off_type has been replaced by bool type

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/pmem/rpma/427)
<!-- Reviewable:end -->
