### PR TITLE
rpma: fix generating rpma_log_set_threshold.3.md by 'make doc'

### DIFF
--- a/src/include/librpma.h
+++ b/src/include/librpma.h
@@ -1398,6 +1398,9 @@ typedef enum {
  *
  *	#include <librpma.h>
  *
+ *	int rpma_log_set_threshold(rpma_threshold threshold,
+ *			rpma_log_level level);
+ *
  *	typedef enum {
  *		RPMA_LOG_DISABLED,
  *		RPMA_LOG_LEVEL_FATAL,
@@ -1413,9 +1416,6 @@ typedef enum {
  *		RPMA_LOG_THRESHOLD_AUX,
  *		RPMA_LOG_THRESHOLD_MAX
  *	} rpma_log_threshold;
- *
- *	int rpma_log_set_threshold(rpma_threshold threshold,
- *			rpma_log_level level);
  *
  * DESCRIPTION
  * rpma_log_set_threshold() sets the logging threshold level.


### PR DESCRIPTION
It is workaround for the following src2man issue:

```
$ make doc
src2man: errors found in the "/home/ldorau/work/rpma/\
  src/include/librpma.h" file:
gawk: cmd. line:145: (FILENAME=- FNR=22) fatal: invalid regexp:\
  Unmatched ( or \(: /\<rpma_log_set_threshold(rpma_threshold\>/
Built target doc
```

and rpma_log_set_threshold.3.md is corrupted.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/pmem/rpma/437)
<!-- Reviewable:end -->
