### PR TITLE
examples: link with -lrt for clock_gettime() for glibc < v2.17

### DIFF
--- a/cmake/functions.cmake
+++ b/cmake/functions.cmake
@@ -210,3 +210,16 @@ function(check_signature_rdma_getaddrinfo var)
 		message(NOTICE "-- Performing Test RDMA_GETADDRINFO_NEW_SIGNATURE - Failed")
 	endif()
 endfunction()
+
+# clock_gettime() requires linking with -lrt for glibc versions before 2.17
+function(check_if_librt_is_required)
+	set(MINIMUM_GLIBC_VERSION "2.17")
+	execute_process(COMMAND ldd --version
+		OUTPUT_VARIABLE LDD_OUTPUT
+		OUTPUT_STRIP_TRAILING_WHITESPACE
+		ERROR_QUIET)
+	string(REGEX MATCH "[0-9][.][0-9]+" LDD_VERSION "${LDD_OUTPUT}")
+	if(${LDD_VERSION} VERSION_LESS ${MINIMUM_GLIBC_VERSION})
+		set(LIBRT_LIBRARIES "rt" PARENT_SCOPE) # librt
+	endif()
+endfunction()

--- a/examples/01-connection/CMakeLists.txt
+++ b/examples/01-connection/CMakeLists.txt
@@ -10,6 +10,10 @@ set(CMAKE_MODULE_PATH ${CMAKE_MODULE_PATH}
 	${CMAKE_SOURCE_DIR}/../cmake
 	${CMAKE_SOURCE_DIR}/../../cmake)
 
+include(${CMAKE_SOURCE_DIR}/../../cmake/functions.cmake)
+# set LIBRT_LIBRARIES if linking with librt is required
+check_if_librt_is_required()
+
 find_package(PkgConfig QUIET)
 
 if(PKG_CONFIG_FOUND)
@@ -25,7 +29,7 @@ function(add_example name)
 	set(srcs ${ARGN})
 	add_executable(${name} ${srcs})
 	target_include_directories(${name} PUBLIC ${LIBRPMA_INCLUDE_DIRS})
-	target_link_libraries(${name} rpma)
+	target_link_libraries(${name} rpma ${LIBRT_LIBRARIES})
 endfunction()
 
 add_example(server server.c)

--- a/examples/02-read-to-volatile/CMakeLists.txt
+++ b/examples/02-read-to-volatile/CMakeLists.txt
@@ -10,6 +10,10 @@ set(CMAKE_MODULE_PATH ${CMAKE_MODULE_PATH}
 	${CMAKE_SOURCE_DIR}/../cmake
 	${CMAKE_SOURCE_DIR}/../../cmake)
 
+include(${CMAKE_SOURCE_DIR}/../../cmake/functions.cmake)
+# set LIBRT_LIBRARIES if linking with librt is required
+check_if_librt_is_required()
+
 find_package(PkgConfig QUIET)
 
 if(PKG_CONFIG_FOUND)
@@ -28,7 +32,7 @@ function(add_example name)
 		PUBLIC
 			${LIBRPMA_INCLUDE_DIRS}
 			../common)
-	target_link_libraries(example-${name} rpma)
+	target_link_libraries(example-${name} rpma ${LIBRT_LIBRARIES})
 endfunction()
 
 add_example(server server.c ../common/common-conn.c)

--- a/examples/03-read-to-persistent/CMakeLists.txt
+++ b/examples/03-read-to-persistent/CMakeLists.txt
@@ -10,6 +10,10 @@ set(CMAKE_MODULE_PATH ${CMAKE_MODULE_PATH}
 	${CMAKE_SOURCE_DIR}/../cmake
 	${CMAKE_SOURCE_DIR}/../../cmake)
 
+include(${CMAKE_SOURCE_DIR}/../../cmake/functions.cmake)
+# set LIBRT_LIBRARIES if linking with librt is required
+check_if_librt_is_required()
+
 set(LIBPMEM_REQUIRED_VERSION 1.6)
 
 find_package(PkgConfig QUIET)
@@ -34,7 +38,7 @@ function(add_example name)
 		PRIVATE
 			${LIBRPMA_INCLUDE_DIRS}
 			../common)
-	target_link_libraries(example-${name} rpma)
+	target_link_libraries(example-${name} rpma ${LIBRT_LIBRARIES})
 
 	if(LIBPMEM_FOUND)
 		target_include_directories(example-${name}

--- a/examples/04-write-to-persistent/CMakeLists.txt
+++ b/examples/04-write-to-persistent/CMakeLists.txt
@@ -10,6 +10,10 @@ set(CMAKE_MODULE_PATH ${CMAKE_MODULE_PATH}
 	${CMAKE_SOURCE_DIR}/../cmake
 	${CMAKE_SOURCE_DIR}/../../cmake)
 
+include(${CMAKE_SOURCE_DIR}/../../cmake/functions.cmake)
+# set LIBRT_LIBRARIES if linking with librt is required
+check_if_librt_is_required()
+
 set(LIBPMEM_REQUIRED_VERSION 1.6)
 
 find_package(PkgConfig QUIET)
@@ -34,7 +38,7 @@ function(add_example name)
 		PRIVATE
 			${LIBRPMA_INCLUDE_DIRS}
 			../common)
-	target_link_libraries(example-${name} rpma)
+	target_link_libraries(example-${name} rpma ${LIBRT_LIBRARIES})
 
 	if(LIBPMEM_FOUND)
 		target_include_directories(example-${name}

--- a/examples/05-flush-to-persistent/CMakeLists.txt
+++ b/examples/05-flush-to-persistent/CMakeLists.txt
@@ -10,6 +10,10 @@ set(CMAKE_MODULE_PATH ${CMAKE_MODULE_PATH}
 	${CMAKE_SOURCE_DIR}/../cmake
 	${CMAKE_SOURCE_DIR}/../../cmake)
 
+include(${CMAKE_SOURCE_DIR}/../../cmake/functions.cmake)
+# set LIBRT_LIBRARIES if linking with librt is required
+check_if_librt_is_required()
+
 set(LIBPMEM_REQUIRED_VERSION 1.6)
 
 find_package(PkgConfig QUIET)
@@ -34,7 +38,7 @@ function(add_example name)
 		PRIVATE
 			${LIBRPMA_INCLUDE_DIRS}
 			../common)
-	target_link_libraries(example-${name} rpma)
+	target_link_libraries(example-${name} rpma ${LIBRT_LIBRARIES})
 
 	if(LIBPMEM_FOUND)
 		target_include_directories(example-${name}

--- a/examples/06-multiple-connections/CMakeLists.txt
+++ b/examples/06-multiple-connections/CMakeLists.txt
@@ -10,6 +10,10 @@ set(CMAKE_MODULE_PATH ${CMAKE_MODULE_PATH}
 	${CMAKE_SOURCE_DIR}/../cmake
 	${CMAKE_SOURCE_DIR}/../../cmake)
 
+include(${CMAKE_SOURCE_DIR}/../../cmake/functions.cmake)
+# set LIBRT_LIBRARIES if linking with librt is required
+check_if_librt_is_required()
+
 set(LIBPMEM_REQUIRED_VERSION 1.6)
 
 set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -std=gnu99")
@@ -36,7 +40,7 @@ function(add_example name)
 		PRIVATE
 			${LIBRPMA_INCLUDE_DIRS}
 			../common)
-	target_link_libraries(example-${name} rpma)
+	target_link_libraries(example-${name} rpma ${LIBRT_LIBRARIES})
 
 	if(LIBPMEM_FOUND)
 		target_include_directories(example-${name}

--- a/examples/07-atomic-write/CMakeLists.txt
+++ b/examples/07-atomic-write/CMakeLists.txt
@@ -10,6 +10,10 @@ set(CMAKE_MODULE_PATH ${CMAKE_MODULE_PATH}
 	${CMAKE_SOURCE_DIR}/../cmake
 	${CMAKE_SOURCE_DIR}/../../cmake)
 
+include(${CMAKE_SOURCE_DIR}/../../cmake/functions.cmake)
+# set LIBRT_LIBRARIES if linking with librt is required
+check_if_librt_is_required()
+
 set(LIBPMEM_REQUIRED_VERSION 1.6)
 
 set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -std=gnu99")
@@ -36,7 +40,7 @@ function(add_example name)
 		PRIVATE
 			${LIBRPMA_INCLUDE_DIRS}
 			../common)
-	target_link_libraries(example-${name} rpma)
+	target_link_libraries(example-${name} rpma ${LIBRT_LIBRARIES})
 
 	if(LIBPMEM_FOUND)
 		target_include_directories(example-${name}

--- a/examples/08-messages-ping-pong/CMakeLists.txt
+++ b/examples/08-messages-ping-pong/CMakeLists.txt
@@ -10,6 +10,10 @@ set(CMAKE_MODULE_PATH ${CMAKE_MODULE_PATH}
 	${CMAKE_SOURCE_DIR}/../cmake
 	${CMAKE_SOURCE_DIR}/../../cmake)
 
+include(${CMAKE_SOURCE_DIR}/../../cmake/functions.cmake)
+# set LIBRT_LIBRARIES if linking with librt is required
+check_if_librt_is_required()
+
 find_package(PkgConfig QUIET)
 
 if(PKG_CONFIG_FOUND)
@@ -33,7 +37,7 @@ function(add_example name)
 			${LIBRPMA_INCLUDE_DIRS}
 			${LIBIBVERBS_INCLUDE_DIRS}
 			../common)
-	target_link_libraries(example-${name} rpma ${LIBIBVERBS_LIBRARIES})
+	target_link_libraries(example-${name} rpma ${LIBIBVERBS_LIBRARIES} ${LIBRT_LIBRARIES})
 endfunction()
 
 add_example(server server.c ../common/common-conn.c)

--- a/examples/09-flush-to-persistent-GPSPM/CMakeLists.txt
+++ b/examples/09-flush-to-persistent-GPSPM/CMakeLists.txt
@@ -10,6 +10,10 @@ set(CMAKE_MODULE_PATH ${CMAKE_MODULE_PATH}
 	${CMAKE_SOURCE_DIR}/../cmake
 	${CMAKE_SOURCE_DIR}/../../cmake)
 
+include(${CMAKE_SOURCE_DIR}/../../cmake/functions.cmake)
+# set LIBRT_LIBRARIES if linking with librt is required
+check_if_librt_is_required()
+
 set(LIBPMEM_REQUIRED_VERSION 1.6)
 
 find_package(PkgConfig QUIET)
@@ -38,7 +42,7 @@ function(add_example name)
 		PRIVATE
 			${LIBRPMA_INCLUDE_DIRS}
 			../common)
-	target_link_libraries(example-${name} rpma)
+	target_link_libraries(example-${name} rpma ${LIBRT_LIBRARIES})
 
 	if(LIBPMEM_FOUND)
 		target_include_directories(example-${name}

--- a/examples/CMakeLists.txt
+++ b/examples/CMakeLists.txt
@@ -17,6 +17,10 @@ add_flag(-DDEBUG DEBUG)
 
 add_flag("-U_FORTIFY_SOURCE -D_FORTIFY_SOURCE=2" RELEASE)
 
+include(${CMAKE_SOURCE_DIR}/cmake/functions.cmake)
+# set LIBRT_LIBRARIES if linking with librt is required
+check_if_librt_is_required()
+
 if(USE_ASAN)
 	add_sanitizer_flag(address)
 endif()
@@ -69,7 +73,7 @@ function(add_example)
 	set_target_properties(${target} PROPERTIES
 		OUTPUT_NAME ${EXAMPLE_BIN}
 		RUNTIME_OUTPUT_DIRECTORY ${EXAMPLE_NAME})
-	target_link_libraries(${target} ${LIBRPMA_LIBRARIES})
+	target_link_libraries(${target} ${LIBRPMA_LIBRARIES} ${LIBRT_LIBRARIES})
 	target_include_directories(${target} PRIVATE common
 		${LIBRPMA_SOURCE_DIR})
 

--- a/examples/template-example/CMakeLists.txt
+++ b/examples/template-example/CMakeLists.txt
@@ -10,6 +10,10 @@ set(CMAKE_MODULE_PATH ${CMAKE_MODULE_PATH}
 	${CMAKE_SOURCE_DIR}/../cmake
 	${CMAKE_SOURCE_DIR}/../../cmake)
 
+include(${CMAKE_SOURCE_DIR}/../../cmake/functions.cmake)
+# set LIBRT_LIBRARIES if linking with librt is required
+check_if_librt_is_required()
+
 find_package(PkgConfig QUIET)
 
 if(PKG_CONFIG_FOUND)
@@ -23,5 +27,5 @@ link_directories(${LIBRPMA_LIBRARY_DIRS})
 
 add_executable(template-example template-example.c)
 target_include_directories(template-example PUBLIC ${LIBRPMA_INCLUDE_DIRS} .)
-target_link_libraries(template-example rpma ${CMAKE_THREAD_LIBS_INIT})
+target_link_libraries(template-example rpma ${CMAKE_THREAD_LIBS_INIT} ${LIBRT_LIBRARIES})
 


### PR DESCRIPTION
clock_gettime() requires linking with -lrt
for glibc versions before 2.17

See: https://man7.org/linux/man-pages/man2/clock_gettime.2.html

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/pmem/rpma/440)
<!-- Reviewable:end -->
