### PR TITLE
Unify stderr and syslog messages

### DIFF
--- a/src/log_default.c
+++ b/src/log_default.c
@@ -123,7 +123,6 @@ rpma_log_default_function(enum rpma_log_level level, const char *file_name,
 	syslog(rpma_log_level_syslog_severity[level], "%s%s%s",
 		rpma_log_level_names[level], file_info, message);
 
-
 	if (level <= Rpma_log_threshold[RPMA_LOG_THRESHOLD_AUX]) {
 		char times_tamp[45] = "";
 		get_timestamp_prefix(times_tamp, sizeof(times_tamp));

--- a/src/log_default.c
+++ b/src/log_default.c
@@ -10,6 +10,7 @@
 #include <syslog.h>
 #include <time.h>
 #include <string.h>
+#include <unistd.h>
 
 #include "log_default.h"
 #include "log_internal.h"
@@ -65,7 +66,7 @@ get_timestamp_prefix(char *buf, size_t buf_size)
 	}
 
 	/* it cannot fail - please see the note above */
-	(void) snprintf(buf, buf_size, "[%s.%06ld] ", date, usec);
+	(void) snprintf(buf, buf_size, "%s.%06ld ", date, usec);
 	if (strnlen(buf, buf_size) == buf_size)
 		memcpy(buf, error_message, sizeof(error_message));
 }
@@ -120,13 +121,14 @@ rpma_log_default_function(enum rpma_log_level level, const char *file_name,
 
 	/* assumed: level <= Rpma_log_threshold[RPMA_LOG_THRESHOLD] */
 	syslog(rpma_log_level_syslog_severity[level], "%s%s%s",
-		rpma_log_level_names[level], file_info,  message);
+		rpma_log_level_names[level], file_info, message);
+
 
 	if (level <= Rpma_log_threshold[RPMA_LOG_THRESHOLD_AUX]) {
 		char times_tamp[45] = "";
 		get_timestamp_prefix(times_tamp, sizeof(times_tamp));
-		(void) fprintf(stderr, "%s%s%s%s", times_tamp,
-			rpma_log_level_names[level],  file_info, message);
+		(void) fprintf(stderr, "%s[%d] %s%s%s", times_tamp, getpid(),
+			rpma_log_level_names[level], file_info, message);
 	}
 }
 

--- a/src/log_default.c
+++ b/src/log_default.c
@@ -60,7 +60,7 @@ get_timestamp_prefix(char *buf, size_t buf_size)
 	}
 
 	usec = ts.tv_nsec / 1000;
-	if (!strftime(date, sizeof(date), "%Y-%m-%d %H:%M:%S", info)) {
+	if (!strftime(date, sizeof(date), "%b %d %H:%M:%S", info)) {
 		memcpy(buf, error_message, sizeof(error_message));
 		return;
 	}

--- a/tests/unit/common/mocks-getpid.c
+++ b/tests/unit/common/mocks-getpid.c
@@ -16,10 +16,11 @@
  */
 bool enabled__wrap_getpid = false;
 
-/*
- * __wrap_getpid -- getpid() mock
- */
 __pid_t __real_getpid(void);
+
+/*
+ * __wrap_getpid -- mock of getpid()
+ */
 __pid_t
 __wrap_getpid()
 {

--- a/tests/unit/common/mocks-getpid.c
+++ b/tests/unit/common/mocks-getpid.c
@@ -1,0 +1,19 @@
+// SPDX-License-Identifier: BSD-3-Clause
+/* Copyright 2020, Intel Corporation */
+
+/*
+ * mocks-getpid.c -- getpid mock
+ */
+
+#include "cmocka_headers.h"
+#include "mocks-getpid.h"
+
+/*
+ * __wrap_getpid -- getpid() mock
+ */
+__pid_t
+__wrap_getpid()
+{
+	int ret = mock_type(int);
+	return ret;
+}

--- a/tests/unit/common/mocks-getpid.c
+++ b/tests/unit/common/mocks-getpid.c
@@ -11,7 +11,7 @@
 #include "mocks-getpid.h"
 
 /*
- * grtpid shall be mocked only during tests otherwise ctest with COVERAGE=1
+ * getpid() shall be mocked only during tests otherwise ctest with COVERAGE=1
  * does not work properly
  */
 bool enabled__wrap_getpid = false;

--- a/tests/unit/common/mocks-getpid.c
+++ b/tests/unit/common/mocks-getpid.c
@@ -5,15 +5,27 @@
  * mocks-getpid.c -- getpid mock
  */
 
+#include <unistd.h>
+
 #include "cmocka_headers.h"
 #include "mocks-getpid.h"
 
 /*
+ * grtpid shall be mocked only during tests otherwise ctest with COVERAGE=1
+ * does not work properly
+ */
+bool enabled__wrap_getpid = false;
+
+/*
  * __wrap_getpid -- getpid() mock
  */
+__pid_t __real_getpid(void);
 __pid_t
 __wrap_getpid()
 {
+	if (!enabled__wrap_getpid)
+		return __real_getpid();
+
 	int ret = mock_type(int);
 	return ret;
 }

--- a/tests/unit/common/mocks-getpid.h
+++ b/tests/unit/common/mocks-getpid.h
@@ -8,12 +8,8 @@
 #ifndef MOCKS_GETPID_H
 #define MOCKS_GETPID_H
 
-#include <unistd.h>
+#include <stdbool.h>
 
-/*
- * __wrap_getpid -- getpid() mock
- */
-__pid_t
-__wrap_getpid();
+extern bool enabled__wrap_getpid;
 
 #endif /* MOCKS_GETPID_H */

--- a/tests/unit/common/mocks-getpid.h
+++ b/tests/unit/common/mocks-getpid.h
@@ -1,0 +1,19 @@
+/* SPDX-License-Identifier: BSD-3-Clause */
+/* Copyright 2020, Intel Corporation */
+
+/*
+ * mocks-getpid.h -- the getpid mock's header
+ */
+
+#ifndef MOCKS_GETPID_H
+#define MOCKS_GETPID_H
+
+#include <unistd.h>
+
+/*
+ * __wrap_getpid -- getpid() mock
+ */
+__pid_t
+__wrap_getpid();
+
+#endif /* MOCKS_GETPID_H */

--- a/tests/unit/log_default/CMakeLists.txt
+++ b/tests/unit/log_default/CMakeLists.txt
@@ -23,7 +23,7 @@ function(build_log_default name)
 
 		set_target_properties(log_default-${name} PROPERTIES
 			LINK_FLAGS
-			"-Wl,--wrap=vsnprintf,--wrap=snprintf,--wrap=fprintf,--wrap=clock_gettime,--wrap=localtime,--wrap=strftime")
+			"-Wl,--wrap=vsnprintf,--wrap=snprintf,--wrap=fprintf,--wrap=clock_gettime,--wrap=localtime,--wrap=strftime,--wrap=getpid")
 
 	add_test_generic(NAME log_default-${name} TRACERS none)
 endfunction()

--- a/tests/unit/log_default/CMakeLists.txt
+++ b/tests/unit/log_default/CMakeLists.txt
@@ -19,6 +19,7 @@ function(build_log_default name)
 		${TEST_UNIT_COMMON_DIR}/mocks-stdio.c
 		${TEST_UNIT_COMMON_DIR}/mocks-syslog.c
 		${TEST_UNIT_COMMON_DIR}/mocks-time.c
+		${TEST_UNIT_COMMON_DIR}/mocks-getpid.c
 		${LIBRPMA_SOURCE_DIR}/log_default.c)
 
 		set_target_properties(log_default-${name} PROPERTIES

--- a/tests/unit/log_default/function.c
+++ b/tests/unit/log_default/function.c
@@ -80,6 +80,15 @@ typedef struct {
 } mock_config;
 
 /*
+ * __wrap_localtime -- localtime() mock
+ */
+__pid_t
+__wrap_getpid()
+{
+	return 123456;
+}
+
+/*
  * setup_thresholds -- setup logging thresholds
  */
 int
@@ -186,7 +195,7 @@ function__syslog(void **config_ptr)
 
 #define MOCK_TIME_OF_DAY {00, 00, 00, 1, 0, 70, 0, 365, 0}
 #define MOCK_TIME_OF_DAY_STR "1970-01-01 00:00:00"
-#define MOCK_TIME_STR "[" MOCK_TIME_OF_DAY_STR ".000000] "
+#define MOCK_TIME_STR MOCK_TIME_OF_DAY_STR ".000000 "
 #define MOCK_TIME_ERROR_STR "[time error] "
 
 static struct timespec Timespec = {0};
@@ -243,6 +252,7 @@ function__stderr_path(void **config_ptr)
 	/* construct the resulting fprintf message */
 	char msg[MOCK_BUFF_LEN] = "";
 	strcat(msg, MOCK_TIME_STR_EXPECTED(config));
+	strcat(msg, "[123456] ");
 	strcat(msg, rpma_log_level_names[MOCK_LOG_LEVEL]);
 	strcat(msg, MOCK_FILE_NAME ": " STR(MOCK_LINE_NUMBER) ": "
 		MOCK_FUNCTION_NAME ": " MOCK_MESSAGE);
@@ -274,6 +284,7 @@ function__stderr_no_path(void **config_ptr)
 		/* construct the resulting fprintf message */
 		char msg[MOCK_BUFF_LEN] = "";
 		strcat(msg, MOCK_TIME_STR_EXPECTED(config));
+		strcat(msg, "[123456] ");
 		strcat(msg, rpma_log_level_names[MOCK_LOG_LEVEL]);
 		strcat(msg, MOCK_MESSAGE);
 		will_return(__wrap_fprintf, MOCK_VALIDATE);

--- a/tests/unit/log_default/function.c
+++ b/tests/unit/log_default/function.c
@@ -185,7 +185,7 @@ function__syslog(void **config_ptr)
 }
 
 #define MOCK_TIME_OF_DAY {00, 00, 00, 1, 0, 70, 0, 365, 0}
-#define MOCK_TIME_OF_DAY_STR "1970-01-01 00:00:00"
+#define MOCK_TIME_OF_DAY_STR "Jan 01 00:00:00"
 #define MOCK_TIME_STR MOCK_TIME_OF_DAY_STR ".000000 "
 #define MOCK_TIME_ERROR_STR "[time error] "
 #define MOCK_GETPID 123456

--- a/tests/unit/log_default/function.c
+++ b/tests/unit/log_default/function.c
@@ -32,6 +32,7 @@
 #include "log_internal.h"
 #include "mocks-stdio.h"
 #include "mocks-time.h"
+#include "mocks-getpid.h"
 #include "test-common.h"
 
 #define STR_HELPER(x) #x
@@ -253,10 +254,16 @@ function__stderr_path(void **config_ptr)
 	will_return(__wrap_fprintf, MOCK_VALIDATE);
 	expect_string(__wrap_fprintf, fprintf_output, msg);
 
+	/* enable getpid mock only for test execution */
+	enabled__wrap_getpid = true;
+
 	/* run test */
 	rpma_log_default_function(MOCK_LOG_LEVEL, config->path,
 			MOCK_LINE_NUMBER, MOCK_FUNCTION_NAME, "%s",
 			MOCK_MESSAGE);
+
+	/* disable getpid mock after test execution */
+	enabled__wrap_getpid = false;
 }
 
 /*
@@ -285,9 +292,15 @@ function__stderr_no_path(void **config_ptr)
 		will_return(__wrap_fprintf, MOCK_VALIDATE);
 		expect_string(__wrap_fprintf, fprintf_output, msg);
 
+		/* enable getpid mock only for test execution */
+		enabled__wrap_getpid = true;
+
 		/* run test */
 		rpma_log_default_function(MOCK_LOG_LEVEL, NULL, 0, NULL, "%s",
 				MOCK_MESSAGE);
+
+		/* disable getpid mock after test execution */
+		enabled__wrap_getpid = false;
 	}
 }
 

--- a/tests/unit/log_default/function.c
+++ b/tests/unit/log_default/function.c
@@ -189,7 +189,7 @@ function__syslog(void **config_ptr)
 #define MOCK_TIME_STR MOCK_TIME_OF_DAY_STR ".000000 "
 #define MOCK_TIME_ERROR_STR "[time error] "
 #define MOCK_PID 123456
-#define MOCK_PID_AS_STR STR(MOCK_PID)
+#define MOCK_PID_AS_STR "["STR(MOCK_PID)"] "
 
 static struct timespec Timespec = {0};
 static struct tm Tm = MOCK_TIME_OF_DAY;
@@ -246,7 +246,7 @@ function__stderr_path(void **config_ptr)
 	/* construct the resulting fprintf message */
 	char msg[MOCK_BUFF_LEN] = "";
 	strcat(msg, MOCK_TIME_STR_EXPECTED(config));
-	strcat(msg, "["MOCK_PID_AS_STR"] ");
+	strcat(msg, MOCK_PID_AS_STR);
 	strcat(msg, rpma_log_level_names[MOCK_LOG_LEVEL]);
 	strcat(msg, MOCK_FILE_NAME ": " STR(MOCK_LINE_NUMBER) ": "
 		MOCK_FUNCTION_NAME ": " MOCK_MESSAGE);
@@ -279,7 +279,7 @@ function__stderr_no_path(void **config_ptr)
 		/* construct the resulting fprintf message */
 		char msg[MOCK_BUFF_LEN] = "";
 		strcat(msg, MOCK_TIME_STR_EXPECTED(config));
-		strcat(msg, "["MOCK_PID_AS_STR"] ");
+		strcat(msg, MOCK_PID_AS_STR);
 		strcat(msg, rpma_log_level_names[MOCK_LOG_LEVEL]);
 		strcat(msg, MOCK_MESSAGE);
 		will_return(__wrap_fprintf, MOCK_VALIDATE);

--- a/tests/unit/log_default/function.c
+++ b/tests/unit/log_default/function.c
@@ -80,15 +80,6 @@ typedef struct {
 } mock_config;
 
 /*
- * __wrap_localtime -- localtime() mock
- */
-__pid_t
-__wrap_getpid()
-{
-	return 123456;
-}
-
-/*
  * setup_thresholds -- setup logging thresholds
  */
 int
@@ -197,6 +188,10 @@ function__syslog(void **config_ptr)
 #define MOCK_TIME_OF_DAY_STR "1970-01-01 00:00:00"
 #define MOCK_TIME_STR MOCK_TIME_OF_DAY_STR ".000000 "
 #define MOCK_TIME_ERROR_STR "[time error] "
+#define MOCK_GETPID 123456
+// #define STR_HELPER(x) #x
+// #define STR(x) STR_HELPER(x)
+#define MOCK_PID_AS_STR STR(MOCK_GETPID)
 
 static struct timespec Timespec = {0};
 static struct tm Tm = MOCK_TIME_OF_DAY;
@@ -248,11 +243,12 @@ function__stderr_path(void **config_ptr)
 	will_return(__wrap_snprintf, MOCK_OK);
 	will_return(syslog, MOCK_PASSTHROUGH);
 	MOCK_GET_TIMESTAMP_CONFIGURE(config);
+	will_return(__wrap_getpid, MOCK_GETPID);
 
 	/* construct the resulting fprintf message */
 	char msg[MOCK_BUFF_LEN] = "";
 	strcat(msg, MOCK_TIME_STR_EXPECTED(config));
-	strcat(msg, "[123456] ");
+	strcat(msg, "["MOCK_PID_AS_STR"] ");
 	strcat(msg, rpma_log_level_names[MOCK_LOG_LEVEL]);
 	strcat(msg, MOCK_FILE_NAME ": " STR(MOCK_LINE_NUMBER) ": "
 		MOCK_FUNCTION_NAME ": " MOCK_MESSAGE);
@@ -280,11 +276,12 @@ function__stderr_no_path(void **config_ptr)
 		will_return(__wrap_vsnprintf, MOCK_OK);
 		will_return(syslog, MOCK_PASSTHROUGH);
 		MOCK_GET_TIMESTAMP_CONFIGURE(config);
+		will_return(__wrap_getpid, MOCK_GETPID);
 
 		/* construct the resulting fprintf message */
 		char msg[MOCK_BUFF_LEN] = "";
 		strcat(msg, MOCK_TIME_STR_EXPECTED(config));
-		strcat(msg, "[123456] ");
+		strcat(msg, "["MOCK_PID_AS_STR"] ");
 		strcat(msg, rpma_log_level_names[MOCK_LOG_LEVEL]);
 		strcat(msg, MOCK_MESSAGE);
 		will_return(__wrap_fprintf, MOCK_VALIDATE);

--- a/tests/unit/log_default/function.c
+++ b/tests/unit/log_default/function.c
@@ -188,10 +188,8 @@ function__syslog(void **config_ptr)
 #define MOCK_TIME_OF_DAY_STR "Jan 01 00:00:00"
 #define MOCK_TIME_STR MOCK_TIME_OF_DAY_STR ".000000 "
 #define MOCK_TIME_ERROR_STR "[time error] "
-#define MOCK_GETPID 123456
-// #define STR_HELPER(x) #x
-// #define STR(x) STR_HELPER(x)
-#define MOCK_PID_AS_STR STR(MOCK_GETPID)
+#define MOCK_PID 123456
+#define MOCK_PID_AS_STR STR(MOCK_PID)
 
 static struct timespec Timespec = {0};
 static struct tm Tm = MOCK_TIME_OF_DAY;
@@ -243,7 +241,7 @@ function__stderr_path(void **config_ptr)
 	will_return(__wrap_snprintf, MOCK_OK);
 	will_return(syslog, MOCK_PASSTHROUGH);
 	MOCK_GET_TIMESTAMP_CONFIGURE(config);
-	will_return(__wrap_getpid, MOCK_GETPID);
+	will_return(__wrap_getpid, MOCK_PID);
 
 	/* construct the resulting fprintf message */
 	char msg[MOCK_BUFF_LEN] = "";
@@ -276,7 +274,7 @@ function__stderr_no_path(void **config_ptr)
 		will_return(__wrap_vsnprintf, MOCK_OK);
 		will_return(syslog, MOCK_PASSTHROUGH);
 		MOCK_GET_TIMESTAMP_CONFIGURE(config);
-		will_return(__wrap_getpid, MOCK_GETPID);
+		will_return(__wrap_getpid, MOCK_PID);
 
 		/* construct the resulting fprintf message */
 		char msg[MOCK_BUFF_LEN] = "";

--- a/tests/unit/log_default/function.c
+++ b/tests/unit/log_default/function.c
@@ -254,7 +254,7 @@ function__stderr_path(void **config_ptr)
 	will_return(__wrap_fprintf, MOCK_VALIDATE);
 	expect_string(__wrap_fprintf, fprintf_output, msg);
 
-	/* enable getpid mock only for test execution */
+	/* enable getpid()'s mock only for test execution */
 	enabled__wrap_getpid = true;
 
 	/* run test */
@@ -262,7 +262,7 @@ function__stderr_path(void **config_ptr)
 			MOCK_LINE_NUMBER, MOCK_FUNCTION_NAME, "%s",
 			MOCK_MESSAGE);
 
-	/* disable getpid mock after test execution */
+	/* disable getpid()'s mock after test execution */
 	enabled__wrap_getpid = false;
 }
 
@@ -292,14 +292,14 @@ function__stderr_no_path(void **config_ptr)
 		will_return(__wrap_fprintf, MOCK_VALIDATE);
 		expect_string(__wrap_fprintf, fprintf_output, msg);
 
-		/* enable getpid mock only for test execution */
+		/* enable getpid()'s mock only for test execution */
 		enabled__wrap_getpid = true;
 
 		/* run test */
 		rpma_log_default_function(MOCK_LOG_LEVEL, NULL, 0, NULL, "%s",
 				MOCK_MESSAGE);
 
-		/* disable getpid mock after test execution */
+		/* disable getpid()'s mock after test execution */
 		enabled__wrap_getpid = false;
 	}
 }

--- a/tests/unit/log_default/init-fini.c
+++ b/tests/unit/log_default/init-fini.c
@@ -10,7 +10,6 @@
 #include "cmocka_headers.h"
 #include "log_default.h"
 
-
 /*
  * init__normal -- happy day scenario
  */

--- a/tests/unit/log_default/init-fini.c
+++ b/tests/unit/log_default/init-fini.c
@@ -10,14 +10,6 @@
 #include "cmocka_headers.h"
 #include "log_default.h"
 
-/*
- * __wrap_localtime -- localtime() mock
- */
-__pid_t
-__wrap_getpid()
-{
-	return 123456;
-}
 
 /*
  * init__normal -- happy day scenario

--- a/tests/unit/log_default/init-fini.c
+++ b/tests/unit/log_default/init-fini.c
@@ -11,6 +11,15 @@
 #include "log_default.h"
 
 /*
+ * __wrap_localtime -- localtime() mock
+ */
+__pid_t
+__wrap_getpid()
+{
+	return 123456;
+}
+
+/*
  * init__normal -- happy day scenario
  */
 void


### PR DESCRIPTION
- add procid to stderr message (instead of user-defined prefix)
- adjust stderr time format to follow syslog one

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/pmem/rpma/447)
<!-- Reviewable:end -->
