### PR TITLE
common: add missing cases to rpma_err_2str() + replace RPMA_E_NO_NEXT with RPMA_E_NO_EVENT

### DIFF
--- a/examples/06-multiple-connections/server.c
+++ b/examples/06-multiple-connections/server.c
@@ -318,7 +318,7 @@ client_handle_connection_event(struct custom_event *ce)
 	enum rpma_conn_event event;
 	int ret = rpma_conn_next_event(clnt->conn, &event);
 	if (ret) {
-		if (ret == RPMA_E_NO_NEXT)
+		if (ret == RPMA_E_NO_EVENT)
 			return;
 
 		(void) rpma_conn_disconnect(clnt->conn);

--- a/src/conn.c
+++ b/src/conn.c
@@ -144,7 +144,7 @@ rpma_conn_next_event(struct rpma_conn *conn, enum rpma_conn_event *event)
 	struct rdma_cm_event *edata = NULL;
 	if (rdma_get_cm_event(conn->evch, &edata)) {
 		if (errno == ENODATA)
-			return RPMA_E_NO_NEXT;
+			return RPMA_E_NO_EVENT;
 
 		Rpma_provider_error = errno;
 		RPMA_LOG_ERROR_WITH_ERRNO(Rpma_provider_error,

--- a/src/ep.c
+++ b/src/ep.c
@@ -176,7 +176,7 @@ rpma_ep_next_conn_req(const struct rpma_ep *ep, const struct rpma_conn_cfg *cfg,
 	/* get an event */
 	if (rdma_get_cm_event(ep->evch, &event)) {
 		if (errno == ENODATA)
-			return RPMA_E_NO_NEXT;
+			return RPMA_E_NO_EVENT;
 
 		Rpma_provider_error = errno;
 		RPMA_LOG_ERROR_WITH_ERRNO(Rpma_provider_error,

--- a/src/include/librpma.h
+++ b/src/include/librpma.h
@@ -29,7 +29,7 @@
 #define RPMA_E_PROVIDER			(-100002) /* Provider error occurred */
 #define RPMA_E_NOMEM			(-100003) /* Out of memory */
 #define RPMA_E_INVAL			(-100004) /* Invalid argument */
-#define RPMA_E_NO_COMPLETION		(-100005) /* No completion available */
+#define RPMA_E_NO_COMPLETION		(-100005) /* No next completion available */
 #define RPMA_E_NO_NEXT			(-100006) /* No next event available */
 
 /* picking up an RDMA-capable device */

--- a/src/include/librpma.h
+++ b/src/include/librpma.h
@@ -29,8 +29,8 @@
 #define RPMA_E_PROVIDER			(-100002) /* Provider error occurred */
 #define RPMA_E_NOMEM			(-100003) /* Out of memory */
 #define RPMA_E_INVAL			(-100004) /* Invalid argument */
-#define RPMA_E_NO_COMPLETION		(-100005) /* No next completion available */
-#define RPMA_E_NO_NEXT			(-100006) /* No next event available */
+#define RPMA_E_NO_COMPLETION	(-100005) /* No next completion available */
+#define RPMA_E_NO_EVENT			(-100006) /* No next event available */
 
 /* picking up an RDMA-capable device */
 
@@ -1355,7 +1355,7 @@ int rpma_ep_get_fd(const struct rpma_ep *ep, int *fd);
  * - RPMA_E_INVAL - obtained an event different than a connection request
  * - RPMA_E_PROVIDER - rdma_get_cm_event(3) failed
  * - RPMA_E_NOMEM - out of memory
- * - RPMA_E_NO_NEXT - no next connection request available
+ * - RPMA_E_NO_EVENT - no next connection request available
  */
 int rpma_ep_next_conn_req(const struct rpma_ep *ep,
 		const struct rpma_conn_cfg *cfg,

--- a/src/rpma_err.c
+++ b/src/rpma_err.c
@@ -48,7 +48,7 @@ rpma_err_2str(int ret)
 		return "Invalid argument";
 	case RPMA_E_NO_COMPLETION:
 		return "No next completion available";
-	case RPMA_E_NO_NEXT:
+	case RPMA_E_NO_EVENT:
 		return "No next event available";
 	case RPMA_E_UNKNOWN:
 	default:

--- a/src/rpma_err.c
+++ b/src/rpma_err.c
@@ -46,6 +46,10 @@ rpma_err_2str(int ret)
 		return "Out of memory";
 	case RPMA_E_INVAL:
 		return "Invalid argument";
+	case RPMA_E_NO_COMPLETION:
+		return "No next completion available";
+	case RPMA_E_NO_NEXT:
+		return "No next event available";
 	case RPMA_E_UNKNOWN:
 	default:
 		return "Unknown error";

--- a/tests/unit/conn/conn-next-event.c
+++ b/tests/unit/conn/conn-next-event.c
@@ -95,7 +95,7 @@ next_event__get_cm_event_ENODATA(void **cstate_ptr)
 	int ret = rpma_conn_next_event(cstate->conn, &c_event);
 
 	/* verify the results */
-	assert_int_equal(ret, RPMA_E_NO_NEXT);
+	assert_int_equal(ret, RPMA_E_NO_EVENT);
 	assert_int_equal(c_event, RPMA_CONN_UNDEFINED);
 }
 

--- a/tests/unit/ep/ep-next_conn_req.c
+++ b/tests/unit/ep/ep-next_conn_req.c
@@ -98,7 +98,7 @@ next_conn_req__get_cm_event_ENODATA(void **estate_ptr)
 	int ret = rpma_ep_next_conn_req(estate->ep, NULL, &req);
 
 	/* verify the results */
-	assert_int_equal(ret, RPMA_E_NO_NEXT);
+	assert_int_equal(ret, RPMA_E_NO_EVENT);
 	assert_null(req);
 }
 

--- a/tests/unit/error/error.c
+++ b/tests/unit/error/error.c
@@ -90,7 +90,7 @@ err_2str__E_NO_COMPLETION(void **unused)
 static void
 err_2str__E_NO_NEXT(void **unused)
 {
-	assert_string_equal(rpma_err_2str(RPMA_E_NO_NEXT),
+	assert_string_equal(rpma_err_2str(RPMA_E_NO_EVENT),
 				"No next event available");
 }
 

--- a/tests/unit/error/error.c
+++ b/tests/unit/error/error.c
@@ -53,7 +53,7 @@ static void
 err_2str__E_PROVIDER(void **unused)
 {
 	assert_string_equal(rpma_err_2str(RPMA_E_PROVIDER),
-	"Provider error occurred");
+				"Provider error occurred");
 }
 
 /*
@@ -75,6 +75,26 @@ err_2str__E_INVAL(void **unused)
 }
 
 /*
+ * err_2str__E_NO_COMPLETION - sanity test for rpma_err_2str()
+ */
+static void
+err_2str__E_NO_COMPLETION(void **unused)
+{
+	assert_string_equal(rpma_err_2str(RPMA_E_NO_COMPLETION),
+				"No next completion available");
+}
+
+/*
+ * err_2str__E_NO_NEXT - sanity test for rpma_err_2str()
+ */
+static void
+err_2str__E_NO_NEXT(void **unused)
+{
+	assert_string_equal(rpma_err_2str(RPMA_E_NO_NEXT),
+				"No next event available");
+}
+
+/*
  * err_2str__E_UNKOWN - sanity test for rpma_err_2str()
  */
 static void
@@ -93,6 +113,8 @@ main(int argc, char *argv[])
 		cmocka_unit_test(err_2str__E_PROVIDER),
 		cmocka_unit_test(err_2str__E_NOMEM),
 		cmocka_unit_test(err_2str__E_INVAL),
+		cmocka_unit_test(err_2str__E_NO_COMPLETION),
+		cmocka_unit_test(err_2str__E_NO_NEXT),
 		cmocka_unit_test(err_2str__E_UNKNOWN),
 	};
 


### PR DESCRIPTION


<!-- Reviewable:start -->
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/pmem/rpma/465)
<!-- Reviewable:end -->
