### PR TITLE
common: add pandoc package to Ubuntu 19.10 Docker image

### DIFF
--- a/utils/docker/images/Dockerfile.fedora-31
+++ b/utils/docker/images/Dockerfile.fedora-31
@@ -40,12 +40,12 @@ ENV RPMA_DEPS "\
 	groff \
 	graphviz \
 	libunwind-devel \
+	pandoc \
 	rdma-core-devel"
 #	txt2man is installed from git repo now
 
 # doc update deps
 ENV DOC_UPDATE_DEPS "\
-	pandoc \
 	hub"
 
 # Install all required packages

--- a/utils/docker/images/Dockerfile.ubuntu-19.10
+++ b/utils/docker/images/Dockerfile.ubuntu-19.10
@@ -43,7 +43,8 @@ ENV RPMA_DEPS "\
 	graphviz \
 	libibverbs-dev \
 	librdmacm-dev \
-	libunwind-dev"
+	libunwind-dev \
+	pandoc"
 #	txt2man is installed from git repo now
 
 # Install all required packages


### PR DESCRIPTION
Add pandoc package to Ubuntu 19.10 Docker image,
to enable generation of Markdown documentation:

```
CMake Warning at doc/CMakeLists.txt:13 (message):
  pandoc not found - Markdown documentation will not be generated
```

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/pmem/rpma/473)
<!-- Reviewable:end -->
