### PR TITLE
rpma: remove const where related RDMA resources might be modified

### DIFF
--- a/examples/common/common-conn.c
+++ b/examples/common/common-conn.c
@@ -57,7 +57,7 @@ common_peer_via_address(const char *addr, enum rpma_util_ibv_context_type type,
  * addr:port
  */
 int
-client_connect(const struct rpma_peer *peer, const char *addr, const char *port,
+client_connect(struct rpma_peer *peer, const char *addr, const char *port,
 		struct rpma_conn_private_data *pdata,
 		struct rpma_conn **conn_ptr)
 {

--- a/examples/common/common-conn.h
+++ b/examples/common/common-conn.h
@@ -51,7 +51,7 @@ int common_peer_via_address(const char *addr,
 		common_peer_via_address(addr, RPMA_UTIL_IBV_CONTEXT_LOCAL, \
 				peer_ptr)
 
-int client_connect(const struct rpma_peer *peer, const char *addr,
+int client_connect(struct rpma_peer *peer, const char *addr,
 		const char *port, struct rpma_conn_private_data *pdata,
 		struct rpma_conn **conn_ptr);
 

--- a/src/conn.c
+++ b/src/conn.c
@@ -41,7 +41,7 @@ struct rpma_conn {
  * ID has any outstanding (unacknowledged) events.
  */
 int
-rpma_conn_new(const struct rpma_peer *peer, struct rdma_cm_id *id,
+rpma_conn_new(struct rpma_peer *peer, struct rdma_cm_id *id,
 		struct ibv_cq *cq, struct rpma_conn **conn_ptr)
 {
 	if (peer == NULL || id == NULL || cq == NULL || conn_ptr == NULL)
@@ -210,7 +210,7 @@ rpma_conn_get_private_data(const struct rpma_conn *conn,
  * rpma_conn_disconnect -- disconnect the connection
  */
 int
-rpma_conn_disconnect(const struct rpma_conn *conn)
+rpma_conn_disconnect(struct rpma_conn *conn)
 {
 	if (conn == NULL)
 		return RPMA_E_INVAL;
@@ -293,8 +293,8 @@ err_destroy_event_channel:
  * rpma_read -- initiate the read operation
  */
 int
-rpma_read(const struct rpma_conn *conn,
-	const struct rpma_mr_local *dst, size_t dst_offset,
+rpma_read(struct rpma_conn *conn,
+	struct rpma_mr_local *dst, size_t dst_offset,
 	const struct rpma_mr_remote *src,  size_t src_offset,
 	size_t len, int flags, const void *op_context)
 {
@@ -311,8 +311,8 @@ rpma_read(const struct rpma_conn *conn,
  * rpma_write -- initiate the write operation
  */
 int
-rpma_write(const struct rpma_conn *conn,
-	const struct rpma_mr_remote *dst, size_t dst_offset,
+rpma_write(struct rpma_conn *conn,
+	struct rpma_mr_remote *dst, size_t dst_offset,
 	const struct rpma_mr_local *src,  size_t src_offset,
 	size_t len, int flags, const void *op_context)
 {
@@ -329,8 +329,8 @@ rpma_write(const struct rpma_conn *conn,
  * rpma_write_atomic -- initiate the atomic write operation
  */
 int
-rpma_write_atomic(const struct rpma_conn *conn,
-	const struct rpma_mr_remote *dst, size_t dst_offset,
+rpma_write_atomic(struct rpma_conn *conn,
+	struct rpma_mr_remote *dst, size_t dst_offset,
 	const struct rpma_mr_local *src,  size_t src_offset,
 	int flags, const void *op_context)
 {
@@ -350,8 +350,8 @@ rpma_write_atomic(const struct rpma_conn *conn,
  * rpma_flush -- initiate the flush operation
  */
 int
-rpma_flush(const struct rpma_conn *conn,
-	const struct rpma_mr_remote *dst, size_t dst_offset, size_t len,
+rpma_flush(struct rpma_conn *conn,
+	struct rpma_mr_remote *dst, size_t dst_offset, size_t len,
 	enum rpma_flush_type type, int flags, const void *op_context)
 {
 	if (conn == NULL || dst == NULL || flags == 0)
@@ -391,7 +391,7 @@ rpma_flush(const struct rpma_conn *conn,
  * rpma_send -- initiate the send operation
  */
 int
-rpma_send(const struct rpma_conn *conn,
+rpma_send(struct rpma_conn *conn,
     const struct rpma_mr_local *src, size_t offset, size_t len,
     int flags, const void *op_context)
 {
@@ -407,8 +407,8 @@ rpma_send(const struct rpma_conn *conn,
  * rpma_recv -- initiate the receive operation
  */
 int
-rpma_recv(const struct rpma_conn *conn,
-    const struct rpma_mr_local *dst, size_t offset, size_t len,
+rpma_recv(struct rpma_conn *conn,
+    struct rpma_mr_local *dst, size_t offset, size_t len,
     const void *op_context)
 {
 	if (conn == NULL || dst == NULL)
@@ -438,7 +438,7 @@ rpma_conn_get_completion_fd(const struct rpma_conn *conn, int *fd)
  * rpma_conn_prepare_completions -- wait for completions
  */
 int
-rpma_conn_prepare_completions(const struct rpma_conn *conn)
+rpma_conn_prepare_completions(struct rpma_conn *conn)
 {
 	if (conn == NULL)
 		return RPMA_E_INVAL;
@@ -472,7 +472,7 @@ rpma_conn_prepare_completions(const struct rpma_conn *conn)
  * rpma_conn_next_completion -- receive an operation completion
  */
 int
-rpma_conn_next_completion(const struct rpma_conn *conn,
+rpma_conn_next_completion(struct rpma_conn *conn,
 		struct rpma_completion *cmpl)
 {
 	if (conn == NULL || cmpl == NULL)

--- a/src/conn.h
+++ b/src/conn.h
@@ -21,7 +21,7 @@
  *                     fail
  * - RPMA_E_NOMEM - out of memory
  */
-int rpma_conn_new(const struct rpma_peer *peer, struct rdma_cm_id *id,
+int rpma_conn_new(struct rpma_peer *peer, struct rdma_cm_id *id,
 		struct ibv_cq *cq, struct rpma_conn **conn_ptr);
 
 /*

--- a/src/conn_req.c
+++ b/src/conn_req.c
@@ -34,7 +34,7 @@ struct rpma_conn_req {
 	struct rpma_conn_private_data data;
 
 	/* a parent RPMA peer of this request - needed for derivative objects */
-	const struct rpma_peer *peer;
+	struct rpma_peer *peer;
 
 	/* completion event channel - copy for convenience */
 	struct ibv_comp_channel *channel;
@@ -48,7 +48,7 @@ struct rpma_conn_req {
  * - peer != NULL && id != NULL && cfg != NULL && req_ptr != NULL
  */
 static int
-rpma_conn_req_from_id(const struct rpma_peer *peer, struct rdma_cm_id *id,
+rpma_conn_req_from_id(struct rpma_peer *peer, struct rdma_cm_id *id,
 		const struct rpma_conn_cfg *cfg, struct rpma_conn_req **req_ptr)
 {
 	int ret = 0;
@@ -296,7 +296,7 @@ rpma_conn_req_destroy(struct rpma_conn_req *req)
  * cfg != NULL
  */
 int
-rpma_conn_req_from_cm_event(const struct rpma_peer *peer,
+rpma_conn_req_from_cm_event(struct rpma_peer *peer,
 		struct rdma_cm_event *edata, const struct rpma_conn_cfg *cfg,
 		struct rpma_conn_req **req_ptr)
 {
@@ -330,7 +330,7 @@ rpma_conn_req_from_cm_event(const struct rpma_peer *peer,
  * the prepared ID into rpma_conn_req_from_id.
  */
 int
-rpma_conn_req_new(const struct rpma_peer *peer, const char *addr,
+rpma_conn_req_new(struct rpma_peer *peer, const char *addr,
 		const char *port, const struct rpma_conn_cfg *cfg,
 		struct rpma_conn_req **req_ptr)
 {
@@ -469,8 +469,8 @@ rpma_conn_req_delete(struct rpma_conn_req **req_ptr)
  * rpma_conn_req_recv -- initiate the receive operation
  */
 int
-rpma_conn_req_recv(const struct rpma_conn_req *req,
-    const struct rpma_mr_local *dst, size_t offset, size_t len,
+rpma_conn_req_recv(struct rpma_conn_req *req,
+    struct rpma_mr_local *dst, size_t offset, size_t len,
     const void *op_context)
 {
 	if (req == NULL || dst == NULL)

--- a/src/conn_req.h
+++ b/src/conn_req.h
@@ -21,7 +21,7 @@
  * - RPMA_E_PROVIDER - ibv_create_cq(3) or rdma_create_qp(3) failed
  * - RPMA_E_NOMEM - out of memory
  */
-int rpma_conn_req_from_cm_event(const struct rpma_peer *peer,
+int rpma_conn_req_from_cm_event(struct rpma_peer *peer,
 		struct rdma_cm_event *event, const struct rpma_conn_cfg *cfg,
 		struct rpma_conn_req **req_ptr);
 

--- a/src/ep.c
+++ b/src/ep.c
@@ -16,7 +16,7 @@
 
 struct rpma_ep {
 	/* parent peer object */
-	const struct rpma_peer *peer;
+	struct rpma_peer *peer;
 	/* CM ID dedicated to listening for incoming connections */
 	struct rdma_cm_id *id;
 	/* event channel of the CM ID */
@@ -36,7 +36,7 @@ struct rpma_ep {
  * channel and the CM ID.
  */
 int
-rpma_ep_listen(const struct rpma_peer *peer, const char *addr, const char *port,
+rpma_ep_listen(struct rpma_peer *peer, const char *addr, const char *port,
 		struct rpma_ep **ep_ptr)
 {
 	if (peer == NULL || addr == NULL || port == NULL || ep_ptr == NULL)
@@ -152,7 +152,7 @@ rpma_ep_get_fd(const struct rpma_ep *ep, int *fd)
  * If succeeds it returns a newly created object.
  */
 int
-rpma_ep_next_conn_req(const struct rpma_ep *ep, const struct rpma_conn_cfg *cfg,
+rpma_ep_next_conn_req(struct rpma_ep *ep, const struct rpma_conn_cfg *cfg,
 		struct rpma_conn_req **req_ptr)
 {
 	if (ep == NULL || req_ptr == NULL)

--- a/src/flush.c
+++ b/src/flush.c
@@ -18,11 +18,11 @@
 #include "log_internal.h"
 #include "mr.h"
 
-static int rpma_flush_apm_new(const struct rpma_peer *peer,
+static int rpma_flush_apm_new(struct rpma_peer *peer,
 		struct rpma_flush *flush);
 static int rpma_flush_apm_delete(struct rpma_flush *flush);
 static int rpma_flush_apm_do(struct ibv_qp *qp, struct rpma_flush *flush,
-	const struct rpma_mr_remote *dst, size_t dst_offset, size_t len,
+	struct rpma_mr_remote *dst, size_t dst_offset, size_t len,
 	enum rpma_flush_type type, int flags, const void *op_context);
 
 typedef int (*rpma_flush_delete_func)(struct rpma_flush *flush);
@@ -49,7 +49,7 @@ struct flush_apm {
  * rpma_flush_apm_new -- allocate a RAW buffer and register it
  */
 static int
-rpma_flush_apm_new(const struct rpma_peer *peer, struct rpma_flush *flush)
+rpma_flush_apm_new(struct rpma_peer *peer, struct rpma_flush *flush)
 {
 	/* a memory registration has to be page-aligned */
 	long pagesize = sysconf(_SC_PAGESIZE);
@@ -115,7 +115,7 @@ rpma_flush_apm_delete(struct rpma_flush *flush)
  */
 static int
 rpma_flush_apm_do(struct ibv_qp *qp, struct rpma_flush *flush,
-	const struct rpma_mr_remote *dst, size_t dst_offset, size_t len,
+	struct rpma_mr_remote *dst, size_t dst_offset, size_t len,
 	enum rpma_flush_type type, int flags, const void *op_context)
 {
 	struct rpma_flush_internal *flush_internal =
@@ -133,7 +133,7 @@ rpma_flush_apm_do(struct ibv_qp *qp, struct rpma_flush *flush,
  * rpma_flush_new -- peak a flush implementation and return the flushing object
  */
 int
-rpma_flush_new(const struct rpma_peer *peer, struct rpma_flush **flush_ptr)
+rpma_flush_new(struct rpma_peer *peer, struct rpma_flush **flush_ptr)
 {
 	struct rpma_flush *flush = malloc(sizeof(struct rpma_flush_internal));
 	if (!flush)

--- a/src/flush.h
+++ b/src/flush.h
@@ -13,7 +13,7 @@
 struct rpma_flush;
 
 typedef int (*rpma_flush_func)(struct ibv_qp *qp, struct rpma_flush *flush,
-	const struct rpma_mr_remote *dst, size_t dst_offset, size_t len,
+	struct rpma_mr_remote *dst, size_t dst_offset, size_t len,
 	enum rpma_flush_type type, int flags, const void *op_context);
 
 struct rpma_flush {
@@ -27,7 +27,7 @@ struct rpma_flush {
  * - RPMA_E_NOMEM - out of memory
  * - RPMA_E_PROVIDER - sysconf() or ibv_reg_mr() failed
  */
-int rpma_flush_new(const struct rpma_peer *peer, struct rpma_flush **flush_ptr);
+int rpma_flush_new(struct rpma_peer *peer, struct rpma_flush **flush_ptr);
 
 /*
  * ERRORS

--- a/src/include/librpma.h
+++ b/src/include/librpma.h
@@ -333,7 +333,7 @@ int rpma_peer_cfg_set_direct_write_to_pmem(struct rpma_peer_cfg *pcfg,
  *
  *	#include <librpma.h>
  *
- *	const struct rpma_peer_cfg;
+ *	struct rpma_peer_cfg;
  *	int rpma_peer_cfg_get_direct_write_to_pmem(
  *			const struct rpma_peer_cfg *pcfg, bool *supported);
  *
@@ -360,7 +360,7 @@ int rpma_peer_cfg_get_direct_write_to_pmem(const struct rpma_peer_cfg *pcfg,
  *
  *	#include <librpma.h>
  *
- *	const struct rpma_peer_cfg;
+ *	struct rpma_peer_cfg;
  *	int rpma_peer_cfg_get_descriptor(const struct rpma_peer_cfg *pcfg,
  *			void *desc);
  *
@@ -385,7 +385,7 @@ int rpma_peer_cfg_get_descriptor(const struct rpma_peer_cfg *pcfg, void *desc);
  *
  *	#include <librpma.h>
  *
- *	const struct rpma_peer_cfg;
+ *	struct rpma_peer_cfg;
  *	int rpma_peer_cfg_get_descriptor_size(const struct rpma_peer_cfg *pcfg,
  *			size_t *desc_size);
  *
@@ -414,7 +414,7 @@ rpma_peer_cfg_get_descriptor_size(const struct rpma_peer_cfg *pcfg,
  *	#include <librpma.h>
  *
  *	struct rpma_peer_cfg;
- *	int rpma_peer_cfg_from_descriptor(void *desc, size_t desc_size,
+ *	int rpma_peer_cfg_from_descriptor(const void *desc, size_t desc_size,
  *			struct rpma_peer_cfg **pcfg_ptr);
  *
  * DESCRIPTION
@@ -432,7 +432,7 @@ rpma_peer_cfg_get_descriptor_size(const struct rpma_peer_cfg *pcfg,
  * - RPMA_E_INVAL - desc or pcfg_ptr are NULL
  * - RPMA_E_NOMEM - out of memory
  */
-int rpma_peer_cfg_from_descriptor(void *desc, size_t desc_size,
+int rpma_peer_cfg_from_descriptor(const void *desc, size_t desc_size,
 		struct rpma_peer_cfg **pcfg_ptr);
 
 /* peer */
@@ -521,9 +521,9 @@ struct rpma_mr_remote;
  *
  *	#include <librpma.h>
  *
- *	const struct rpma_peer;
+ *	struct rpma_peer;
  *	struct rpma_mr_local;
- *	int rpma_mr_reg(const struct rpma_peer *peer, void *ptr, size_t size,
+ *	int rpma_mr_reg(struct rpma_peer *peer, void *ptr, size_t size,
  *		int usage, struct rpma_mr_local **mr_ptr);
  *
  * DESCRIPTION
@@ -542,7 +542,7 @@ struct rpma_mr_remote;
  * - RPMA_E_NOMEM - out of memory
  * - RPMA_E_PROVIDER - memory registration failed
  */
-int rpma_mr_reg(const struct rpma_peer *peer, void *ptr, size_t size,
+int rpma_mr_reg(struct rpma_peer *peer, void *ptr, size_t size,
 		int usage, struct rpma_mr_local **mr_ptr);
 
 /** 3
@@ -578,7 +578,7 @@ int rpma_mr_dereg(struct rpma_mr_local **mr_ptr);
  *
  *	#include <librpma.h>
  *
- *	const struct rpma_mr_local;
+ *	struct rpma_mr_local;
  *	int rpma_mr_get_descriptor(const struct rpma_mr_local *mr, void *desc);
  *
  * DESCRIPTION
@@ -639,7 +639,7 @@ int rpma_mr_remote_from_descriptor(const void *desc,
  *
  *	#include <librpma.h>
  *
- *	const struct rpma_mr_local;
+ *	struct rpma_mr_local;
  *	int rpma_mr_get_descriptor_size(const struct rpma_mr_local *mr,
  *			size_t *desc_size);
  *
@@ -666,7 +666,7 @@ int rpma_mr_get_descriptor_size(const struct rpma_mr_local *mr,
  *
  *	#include <librpma.h>
  *
- *	const struct rpma_mr_remote;
+ *	struct rpma_mr_remote;
  *	int rpma_mr_remote_get_size(const struct rpma_mr_remote *mr,
  *			size_t *size);
  *
@@ -692,7 +692,7 @@ int rpma_mr_remote_get_size(const struct rpma_mr_remote *mr, size_t *size);
  *
  *	#include <librpma.h>
  *
- *	const struct rpma_mr_remote;
+ *	struct rpma_mr_remote;
  *	int rpma_mr_remote_get_flush_type(const struct rpma_mr_remote *mr,
  *			int *flush_type);
  *
@@ -825,7 +825,7 @@ int rpma_conn_cfg_set_timeout(struct rpma_conn_cfg *cfg, int timeout_ms);
  *
  *	#include <librpma.h>
  *
- *	const struct rpma_conn_cfg;
+ *	struct rpma_conn_cfg;
  *	int rpma_conn_cfg_get_timeout(const struct rpma_conn_cfg *cfg,
  *			int *timeout_ms);
  *
@@ -876,7 +876,7 @@ int rpma_conn_cfg_set_cq_size(struct rpma_conn_cfg *cfg, uint32_t cq_size);
  *
  *	#include <librpma.h>
  *
- *	const struct rpma_conn_cfg;
+ *	struct rpma_conn_cfg;
  *	int rpma_conn_cfg_get_cq_size(const struct rpma_conn_cfg *cfg,
  *			uint32_t *cq_size);
  *
@@ -928,7 +928,7 @@ int rpma_conn_cfg_set_sq_size(struct rpma_conn_cfg *cfg, uint32_t sq_size);
  *
  *	#include <librpma.h>
  *
- *	const struct rpma_conn_cfg;
+ *	struct rpma_conn_cfg;
  *	int rpma_conn_cfg_get_sq_size(const struct rpma_conn_cfg *cfg,
  *			uint32_t *sq_size);
  *
@@ -980,7 +980,7 @@ int rpma_conn_cfg_set_rq_size(struct rpma_conn_cfg *cfg, uint32_t rq_size);
  *
  *	#include <librpma.h>
  *
- *	const struct rpma_conn_cfg;
+ *	struct rpma_conn_cfg;
  *	int rpma_conn_cfg_get_rq_size(const struct rpma_conn_cfg *cfg,
  *			uint32_t *rq_size);
  *
@@ -1011,7 +1011,7 @@ struct rpma_conn;
  *
  *	#include <librpma.h>
  *
- *	const struct rpma_conn;
+ *	struct rpma_conn;
  *	int rpma_conn_get_event_fd(const struct rpma_conn *conn, int *fd);
  *
  * DESCRIPTION
@@ -1117,7 +1117,7 @@ struct rpma_conn_private_data {
  *
  *	#include <librpma.h>
  *
- *	const struct rpma_conn;
+ *	struct rpma_conn;
  *	struct rpma_conn_private_data;
  *	int rpma_conn_get_private_data(const struct rpma_conn *conn,
  *			struct rpma_conn_private_data *pdata);
@@ -1135,6 +1135,7 @@ struct rpma_conn_private_data {
  * rpma_conn_get_private_data() can fail with the following error:
  *
  * - RPMA_E_INVAL - conn or pdata is NULL
+ *
  */
 int rpma_conn_get_private_data(const struct rpma_conn *conn,
 		struct rpma_conn_private_data *pdata);
@@ -1147,7 +1148,7 @@ int rpma_conn_get_private_data(const struct rpma_conn *conn,
  *	#include <librpma.h>
  *
  *	struct rpma_conn;
- *	const struct rpma_peer_cfg;
+ *	struct rpma_peer_cfg;
  *	int rpma_conn_apply_remote_peer_cfg(struct rpma_conn *conn,
  *			const struct rpma_peer_cfg *pcfg);
  *
@@ -1175,8 +1176,8 @@ int rpma_conn_apply_remote_peer_cfg(struct rpma_conn *conn,
  *
  *	#include <librpma.h>
  *
- *	const struct rpma_conn;
- *	int rpma_conn_disconnect(const struct rpma_conn *conn);
+ *	struct rpma_conn;
+ *	int rpma_conn_disconnect(struct rpma_conn *conn);
  *
  * DESCRIPTION
  * rpma_conn_disconnect() initiates disconnecting of the RPMA
@@ -1192,7 +1193,7 @@ int rpma_conn_apply_remote_peer_cfg(struct rpma_conn *conn,
  * - RPMA_E_INVAL - conn is NULL
  * - RPMA_E_PROVIDER - rdma_disconnect() failed
  */
-int rpma_conn_disconnect(const struct rpma_conn *conn);
+int rpma_conn_disconnect(struct rpma_conn *conn);
 
 /** 3
  * rpma_conn_delete - delete already closed connection
@@ -1230,10 +1231,10 @@ struct rpma_conn_req;
  *
  *	#include <librpma.h>
  *
- *	const struct rpma_peer;
- *	const struct rpma_conn_cfg;
+ *	struct rpma_peer;
+ *	struct rpma_conn_cfg;
  *	struct rpma_conn_req;
- *	int rpma_conn_req_new(const struct rpma_peer *peer, const char *addr,
+ *	int rpma_conn_req_new(struct rpma_peer *peer, const char *addr,
  *			const char *port, const struct rpma_conn_cfg *cfg,
  *			struct rpma_conn_req **req_ptr);
  *
@@ -1255,7 +1256,7 @@ struct rpma_conn_req;
  * - RPMA_E_PROVIDER - rdma_create_id(3), rdma_resolve_addr(3),
  *   rdma_resolve_route(3) or ibv_create_cq(3) failed
  */
-int rpma_conn_req_new(const struct rpma_peer *peer, const char *addr,
+int rpma_conn_req_new(struct rpma_peer *peer, const char *addr,
 		const char *port, const struct rpma_conn_cfg *cfg,
 		struct rpma_conn_req **req_ptr);
 
@@ -1297,7 +1298,7 @@ int rpma_conn_req_delete(struct rpma_conn_req **req_ptr);
  *	#include <librpma.h>
  *
  *	struct rpma_conn_req;
- *	const struct rpma_conn_private_data;
+ *	struct rpma_conn_private_data;
  *	struct rpma_conn;
  *	int rpma_conn_req_connect(struct rpma_conn_req **req_ptr,
  *			const struct rpma_conn_private_data *pdata,
@@ -1336,10 +1337,10 @@ int rpma_conn_req_connect(struct rpma_conn_req **req_ptr,
  *
  *	#include <librpma.h>
  *
- *	const struct rpma_conn_req;
- *	const struct rpma_mr_local;
- *	int rpma_conn_req_recv(const struct rpma_conn_req *req,
- *			const struct rpma_mr_local *dst, size_t offset,
+ *	struct rpma_conn_req;
+ *	struct rpma_mr_local;
+ *	int rpma_conn_req_recv(struct rpma_conn_req *req,
+ *			struct rpma_mr_local *dst, size_t offset,
  *			size_t len, const void *op_context);
  *
  * DESCRIPTION
@@ -1358,8 +1359,8 @@ int rpma_conn_req_connect(struct rpma_conn_req **req_ptr,
  * - RPMA_E_INVAL - req or src or op_context is NULL
  * - RPMA_E_PROVIDER - ibv_post_recv(3) failed
  */
-int rpma_conn_req_recv(const struct rpma_conn_req *req,
-		const struct rpma_mr_local *dst, size_t offset,
+int rpma_conn_req_recv(struct rpma_conn_req *req,
+		struct rpma_mr_local *dst, size_t offset,
 		size_t len, const void *op_context);
 
 /* server-side setup */
@@ -1373,9 +1374,9 @@ struct rpma_ep;
  *
  *	#include <librpma.h>
  *
- *	const struct rpma_peer;
+ *	struct rpma_peer;
  *	struct rpma_ep;
- *	int rpma_ep_listen(const struct rpma_peer *peer, const char *addr,
+ *	int rpma_ep_listen(struct rpma_peer *peer, const char *addr,
  *			const char *port, struct rpma_ep **ep_ptr);
  *
  * DESCRIPTION
@@ -1396,7 +1397,7 @@ struct rpma_ep;
  *   rdma_getaddrinfo(3), rdma_listen(3) failed
  * - RPMA_E_NOMEM - out of memory
  */
-int rpma_ep_listen(const struct rpma_peer *peer, const char *addr,
+int rpma_ep_listen(struct rpma_peer *peer, const char *addr,
 		const char *port, struct rpma_ep **ep_ptr);
 
 /** 3
@@ -1433,7 +1434,7 @@ int rpma_ep_shutdown(struct rpma_ep **ep_ptr);
  *
  *	#include <librpma.h>
  *
- *	const struct rpma_ep;
+ *	struct rpma_ep;
  *	int rpma_ep_get_fd(const struct rpma_ep *ep, int *fd);
  *
  * DESCRIPTION
@@ -1458,10 +1459,10 @@ int rpma_ep_get_fd(const struct rpma_ep *ep, int *fd);
  *
  *	#include <librpma.h>
  *
- *	const struct rpma_ep;
- *	const struct rpma_conn_cfg;
+ *	struct rpma_ep;
+ *	struct rpma_conn_cfg;
  *	struct rpma_conn_req;
- *	int rpma_ep_next_conn_req(const struct rpma_ep *ep,
+ *	int rpma_ep_next_conn_req(struct rpma_ep *ep,
  *			const struct rpma_conn_cfg *cfg,
  *			struct rpma_conn_req **req_ptr);
  *
@@ -1483,7 +1484,7 @@ int rpma_ep_get_fd(const struct rpma_ep *ep, int *fd);
  * - RPMA_E_NOMEM - out of memory
  * - RPMA_E_NO_EVENT - no next connection request available
  */
-int rpma_ep_next_conn_req(const struct rpma_ep *ep,
+int rpma_ep_next_conn_req(struct rpma_ep *ep,
 		const struct rpma_conn_cfg *cfg,
 		struct rpma_conn_req **req_ptr);
 
@@ -1501,11 +1502,11 @@ int rpma_ep_next_conn_req(const struct rpma_ep *ep,
  *
  *	#include <librpma.h>
  *
- *	const struct rpma_conn;
- *	const struct rpma_mr_local;
- *	const struct rpma_mr_remote;
- *	int rpma_read(const struct rpma_conn *conn,
- *			const struct rpma_mr_local *dst, size_t dst_offset,
+ *	struct rpma_conn;
+ *	struct rpma_mr_local;
+ *	struct rpma_mr_remote;
+ *	int rpma_read(struct rpma_conn *conn,
+ *			struct rpma_mr_local *dst, size_t dst_offset,
  *			const struct rpma_mr_remote *src,  size_t src_offset,
  *			size_t len, int flags, const void *op_context);
  *
@@ -1524,8 +1525,8 @@ int rpma_ep_next_conn_req(const struct rpma_ep *ep,
  * - RPMA_E_INVAL - flags are not set
  * - RPMA_E_PROVIDER - ibv_post_send(3) failed
  */
-int rpma_read(const struct rpma_conn *conn,
-		const struct rpma_mr_local *dst, size_t dst_offset,
+int rpma_read(struct rpma_conn *conn,
+		struct rpma_mr_local *dst, size_t dst_offset,
 		const struct rpma_mr_remote *src,  size_t src_offset,
 		size_t len, int flags, const void *op_context);
 
@@ -1536,11 +1537,11 @@ int rpma_read(const struct rpma_conn *conn,
  *
  *	#include <librpma.h>
  *
- *	const struct rpma_conn;
- *	const struct rpma_mr_local;
- *	const struct rpma_mr_remote;
- *	int rpma_write(const struct rpma_conn *conn,
- *			const struct rpma_mr_remote *dst, size_t dst_offset,
+ *	struct rpma_conn;
+ *	struct rpma_mr_local;
+ *	struct rpma_mr_remote;
+ *	int rpma_write(struct rpma_conn *conn,
+ *			struct rpma_mr_remote *dst, size_t dst_offset,
  *			const struct rpma_mr_local *src,  size_t src_offset,
  *			size_t len, int flags, const void *op_context);
  *
@@ -1559,8 +1560,8 @@ int rpma_read(const struct rpma_conn *conn,
  * - RPMA_E_INVAL - flags are not set
  * - RPMA_E_PROVIDER - ibv_post_send(3) failed
  */
-int rpma_write(const struct rpma_conn *conn,
-		const struct rpma_mr_remote *dst, size_t dst_offset,
+int rpma_write(struct rpma_conn *conn,
+		struct rpma_mr_remote *dst, size_t dst_offset,
 		const struct rpma_mr_local *src,  size_t src_offset,
 		size_t len, int flags, const void *op_context);
 
@@ -1573,11 +1574,11 @@ int rpma_write(const struct rpma_conn *conn,
  *
  *	#include <librpma.h>
  *
- *	const struct rpma_conn;
- *	const struct rpma_mr_local;
- *	const struct rpma_mr_remote;
- *	int rpma_write_atomic(const struct rpma_conn *conn,
- *			const struct rpma_mr_remote *dst, size_t dst_offset,
+ *	struct rpma_conn;
+ *	struct rpma_mr_local;
+ *	struct rpma_mr_remote;
+ *	int rpma_write_atomic(struct rpma_conn *conn,
+ *			struct rpma_mr_remote *dst, size_t dst_offset,
  *			const struct rpma_mr_local *src,  size_t src_offset,
  *			int flags, const void *op_context);
  *
@@ -1599,8 +1600,8 @@ int rpma_write(const struct rpma_conn *conn,
  * - RPMA_E_INVAL - flags are not set
  * - RPMA_E_PROVIDER - ibv_post_send(3) failed
  */
-int rpma_write_atomic(const struct rpma_conn *conn,
-		const struct rpma_mr_remote *dst, size_t dst_offset,
+int rpma_write_atomic(struct rpma_conn *conn,
+		struct rpma_mr_remote *dst, size_t dst_offset,
 		const struct rpma_mr_local *src,  size_t src_offset,
 		int flags, const void *op_context);
 
@@ -1621,15 +1622,15 @@ enum rpma_flush_type {
  *
  *	#include <librpma.h>
  *
- *	const struct rpma_conn;
- *	const struct rpma_mr_remote;
+ *	struct rpma_conn;
+ *	struct rpma_mr_remote;
  *	enum rpma_flush_type {
  *		RPMA_FLUSH_TYPE_PERSISTENT,
  *		RPMA_FLUSH_TYPE_VISIBILITY,
  *	};
  *
- *	int rpma_flush(const struct rpma_conn *conn,
- *			const struct rpma_mr_remote *dst, size_t dst_offset,
+ *	int rpma_flush(struct rpma_conn *conn,
+ *			struct rpma_mr_remote *dst, size_t dst_offset,
  *			size_t len, enum rpma_flush_type type, int flags,
  *			const void *op_context);
  *
@@ -1655,8 +1656,8 @@ enum rpma_flush_type {
  * - RPMA_E_NOSUPP - type is RPMA_FLUSH_TYPE_PERSISTENT and
  * the direct write to pmem is not supported
  */
-int rpma_flush(const struct rpma_conn *conn,
-		const struct rpma_mr_remote *dst, size_t dst_offset, size_t len,
+int rpma_flush(struct rpma_conn *conn,
+		struct rpma_mr_remote *dst, size_t dst_offset, size_t len,
 		enum rpma_flush_type type, int flags, const void *op_context);
 
 /** 3
@@ -1666,9 +1667,9 @@ int rpma_flush(const struct rpma_conn *conn,
  *
  *	#include <librpma.h>
  *
- *	const struct rpma_conn;
- *	const struct rpma_mr_local;
- *	int rpma_send(const struct rpma_conn *conn,
+ *	struct rpma_conn;
+ *	struct rpma_mr_local;
+ *	int rpma_send(struct rpma_conn *conn,
  *			const struct rpma_mr_local *src, size_t offset,
  *			size_t len, int flags, const void *op_context);
  *
@@ -1687,7 +1688,7 @@ int rpma_flush(const struct rpma_conn *conn,
  * - RPMA_E_INVAL - flags are not set
  * - RPMA_E_PROVIDER - ibv_post_send(3) failed
  */
-int rpma_send(const struct rpma_conn *conn,
+int rpma_send(struct rpma_conn *conn,
 		const struct rpma_mr_local *src, size_t offset, size_t len,
 		int flags, const void *op_context);
 
@@ -1698,10 +1699,10 @@ int rpma_send(const struct rpma_conn *conn,
  *
  *	#include <librpma.h>
  *
- *	const struct rpma_conn;
- *	const struct rpma_mr_local;
- *	int rpma_recv(const struct rpma_conn *conn,
- *			const struct rpma_mr_local *dst, size_t offset,
+ *	struct rpma_conn;
+ *	struct rpma_mr_local;
+ *	int rpma_recv(struct rpma_conn *conn,
+ *			struct rpma_mr_local *dst, size_t offset,
  *			size_t len, const void *op_context);
  *
  * DESCRIPTION
@@ -1731,8 +1732,8 @@ int rpma_send(const struct rpma_conn *conn,
  * - RPMA_E_INVAL - conn or src is NULL
  * - RPMA_E_PROVIDER - ibv_post_recv(3) failed
  */
-int rpma_recv(const struct rpma_conn *conn,
-		const struct rpma_mr_local *dst, size_t offset, size_t len,
+int rpma_recv(struct rpma_conn *conn,
+		struct rpma_mr_local *dst, size_t offset, size_t len,
 		const void *op_context);
 
 /* completion handling */
@@ -1744,7 +1745,7 @@ int rpma_recv(const struct rpma_conn *conn,
  *
  *	#include <librpma.h>
  *
- *	const struct rpma_conn;
+ *	struct rpma_conn;
  *	int rpma_conn_get_completion_fd(const struct rpma_conn *conn, int *fd);
  *
  * DESCRIPTION
@@ -1785,8 +1786,8 @@ struct rpma_completion {
  *
  *	#include <librpma.h>
  *
- *	const struct rpma_conn;
- *	int rpma_conn_prepare_completions(const struct rpma_conn *conn);
+ *	struct rpma_conn;
+ *	int rpma_conn_prepare_completions(struct rpma_conn *conn);
  *
  * DESCRIPTION
  * rpma_conn_prepare_completions() waits for incoming completions. If it
@@ -1803,7 +1804,7 @@ struct rpma_completion {
  * - RPMA_E_PROVIDER - ibv_req_notify_cq(3) failed with a provider error
  * - RPMA_E_NO_COMPLETION - no completions available
  */
-int rpma_conn_prepare_completions(const struct rpma_conn *conn);
+int rpma_conn_prepare_completions(struct rpma_conn *conn);
 
 /** 3
  * rpma_conn_next_completion - receive a completion of an operation
@@ -1812,9 +1813,9 @@ int rpma_conn_prepare_completions(const struct rpma_conn *conn);
  *
  *	#include <librpma.h>
  *
- *	const struct rpma_conn;
+ *	struct rpma_conn;
  *	struct rpma_completion;
- *	int rpma_conn_next_completion(const struct rpma_conn *conn,
+ *	int rpma_conn_next_completion(struct rpma_conn *conn,
  *			struct rpma_completion *cmpl);
  *
  * DESCRIPTION
@@ -1836,7 +1837,7 @@ int rpma_conn_prepare_completions(const struct rpma_conn *conn);
  * - RPMA_E_UNKNOWN - ibv_poll_cq(3) failed but no provider error is available
  * - RPMA_E_NOSUPP - not supported opcode
  */
-int rpma_conn_next_completion(const struct rpma_conn *conn,
+int rpma_conn_next_completion(struct rpma_conn *conn,
 		struct rpma_completion *cmpl);
 
 /* error handling */

--- a/src/mr.c
+++ b/src/mr.c
@@ -109,7 +109,7 @@ usage_to_access(int usage)
  */
 int
 rpma_mr_read(struct ibv_qp *qp,
-	const struct rpma_mr_local *dst, size_t dst_offset,
+	struct rpma_mr_local *dst, size_t dst_offset,
 	const struct rpma_mr_remote *src,  size_t src_offset,
 	size_t len, int flags, const void *op_context)
 {
@@ -153,7 +153,7 @@ rpma_mr_read(struct ibv_qp *qp,
  */
 int
 rpma_mr_write(struct ibv_qp *qp,
-	const struct rpma_mr_remote *dst, size_t dst_offset,
+	struct rpma_mr_remote *dst, size_t dst_offset,
 	const struct rpma_mr_local *src,  size_t src_offset,
 	size_t len, int flags, const void *op_context)
 {
@@ -232,7 +232,7 @@ rpma_mr_send(struct ibv_qp *qp,
  */
 int
 rpma_mr_recv(struct ibv_qp *qp,
-	const struct rpma_mr_local *dst,  size_t offset,
+	struct rpma_mr_local *dst,  size_t offset,
 	size_t len, const void *op_context)
 {
 	struct ibv_recv_wr wr;
@@ -264,7 +264,7 @@ rpma_mr_recv(struct ibv_qp *qp,
  * rpma_mr_reg -- create a local memory registration object
  */
 int
-rpma_mr_reg(const struct rpma_peer *peer, void *ptr, size_t size, int usage,
+rpma_mr_reg(struct rpma_peer *peer, void *ptr, size_t size, int usage,
 		struct rpma_mr_local **mr_ptr)
 {
 	if (peer == NULL || ptr == NULL || size == 0 || mr_ptr == NULL)

--- a/src/mr.h
+++ b/src/mr.h
@@ -22,7 +22,7 @@
  * - RPMA_E_PROVIDER - ibv_post_send(3) failed
  */
 int rpma_mr_read(struct ibv_qp *qp,
-	const struct rpma_mr_local *dst, size_t dst_offset,
+	struct rpma_mr_local *dst, size_t dst_offset,
 	const struct rpma_mr_remote *src,  size_t src_offset,
 	size_t len, int flags, const void *op_context);
 
@@ -36,7 +36,7 @@ int rpma_mr_read(struct ibv_qp *qp,
  * - RPMA_E_PROVIDER - ibv_post_send(3) failed
  */
 int rpma_mr_write(struct ibv_qp *qp,
-	const struct rpma_mr_remote *dst, size_t dst_offset,
+	struct rpma_mr_remote *dst, size_t dst_offset,
 	const struct rpma_mr_local *src,  size_t src_offset,
 	size_t len, int flags, const void *op_context);
 
@@ -63,7 +63,7 @@ int rpma_mr_send(struct ibv_qp *qp,
  * - RPMA_E_PROVIDER - ibv_post_send(3) failed
  */
 int rpma_mr_recv(struct ibv_qp *qp,
-	const struct rpma_mr_local *dst,  size_t offset,
+	struct rpma_mr_local *dst,  size_t offset,
 	size_t len, const void *op_context);
 
 #endif /* LIBRPMA_MR_H */

--- a/src/peer.c
+++ b/src/peer.c
@@ -38,7 +38,7 @@ struct rpma_peer {
  * - cfg != NULL
  */
 int
-rpma_peer_create_qp(const struct rpma_peer *peer, struct rdma_cm_id *id,
+rpma_peer_create_qp(struct rpma_peer *peer, struct rdma_cm_id *id,
 		struct ibv_cq *cq, const struct rpma_conn_cfg *cfg)
 {
 	if (peer == NULL || id == NULL || cq == NULL)
@@ -105,7 +105,7 @@ rpma_peer_create_qp(const struct rpma_peer *peer, struct rdma_cm_id *id,
  * rpma_peer_mr_reg -- register a memory region using ibv_reg_mr()
  */
 int
-rpma_peer_mr_reg(const struct rpma_peer *peer, struct ibv_mr **ibv_mr_ptr,
+rpma_peer_mr_reg(struct rpma_peer *peer, struct ibv_mr **ibv_mr_ptr,
 		void *addr, size_t length, int access)
 {
 	*ibv_mr_ptr = ibv_reg_mr(peer->pd, addr, length,

--- a/src/peer.h
+++ b/src/peer.h
@@ -19,7 +19,7 @@
  * - RPMA_E_INVAL - peer, id or cq is NULL
  * - RPMA_E_PROVIDER - allocating a QP failed
  */
-int rpma_peer_create_qp(const struct rpma_peer *peer, struct rdma_cm_id *id,
+int rpma_peer_create_qp(struct rpma_peer *peer, struct rdma_cm_id *id,
 		struct ibv_cq *cq, const struct rpma_conn_cfg *cfg);
 
 /*
@@ -32,7 +32,7 @@ int rpma_peer_create_qp(const struct rpma_peer *peer, struct rdma_cm_id *id,
  *
  * - RPMA_E_PROVIDER - registering the memory region failed
  */
-int rpma_peer_mr_reg(const struct rpma_peer *peer, struct ibv_mr **ibv_mr_ptr,
+int rpma_peer_mr_reg(struct rpma_peer *peer, struct ibv_mr **ibv_mr_ptr,
 		void *addr, size_t length, int access);
 
 #endif /* LIBRPMA_PEER_H */

--- a/src/peer_cfg.c
+++ b/src/peer_cfg.c
@@ -124,7 +124,7 @@ rpma_peer_cfg_get_descriptor_size(const struct rpma_peer_cfg *pcfg,
  * from a descriptor
  */
 int
-rpma_peer_cfg_from_descriptor(void *desc, size_t desc_size,
+rpma_peer_cfg_from_descriptor(const void *desc, size_t desc_size,
 		struct rpma_peer_cfg **pcfg_ptr)
 {
 	if (desc == NULL || pcfg_ptr == NULL)

--- a/tests/unit/common/mocks-rpma-conn.c
+++ b/tests/unit/common/mocks-rpma-conn.c
@@ -16,7 +16,7 @@
  * rpma_conn_new -- rpma_conn_new()  mock
  */
 int
-rpma_conn_new(const struct rpma_peer *peer, struct rdma_cm_id *id,
+rpma_conn_new(struct rpma_peer *peer, struct rdma_cm_id *id,
 		struct ibv_cq *cq, struct rpma_conn **conn_ptr)
 {
 	assert_ptr_equal(peer, MOCK_PEER);

--- a/tests/unit/common/mocks-rpma-flush.c
+++ b/tests/unit/common/mocks-rpma-flush.c
@@ -20,7 +20,7 @@ struct rpma_flush Rpma_flush;
  */
 int
 rpma_flush_mock_do(struct ibv_qp *qp, struct rpma_flush *flush,
-	const struct rpma_mr_remote *dst, size_t dst_offset, size_t len,
+	struct rpma_mr_remote *dst, size_t dst_offset, size_t len,
 	enum rpma_flush_type type, int flags, const void *op_context)
 {
 	assert_non_null(qp);
@@ -43,7 +43,7 @@ rpma_flush_mock_do(struct ibv_qp *qp, struct rpma_flush *flush,
  * rpma_flush_new -- rpma_flush_new() mock
  */
 int
-rpma_flush_new(const struct rpma_peer *peer, struct rpma_flush **flush_ptr)
+rpma_flush_new(struct rpma_peer *peer, struct rpma_flush **flush_ptr)
 {
 	assert_int_equal(peer, MOCK_PEER);
 	assert_non_null(flush_ptr);

--- a/tests/unit/common/mocks-rpma-mr.c
+++ b/tests/unit/common/mocks-rpma-mr.c
@@ -17,7 +17,7 @@
  */
 int
 rpma_mr_read(struct ibv_qp *qp,
-	const struct rpma_mr_local *dst, size_t dst_offset,
+	struct rpma_mr_local *dst, size_t dst_offset,
 	const struct rpma_mr_remote *src,  size_t src_offset,
 	size_t len, int flags, const void *op_context)
 {
@@ -43,7 +43,7 @@ rpma_mr_read(struct ibv_qp *qp,
  */
 int
 rpma_mr_write(struct ibv_qp *qp,
-	const struct rpma_mr_remote *dst, size_t dst_offset,
+	struct rpma_mr_remote *dst, size_t dst_offset,
 	const struct rpma_mr_local *src,  size_t src_offset,
 	size_t len, int flags, const void *op_context)
 {
@@ -68,7 +68,7 @@ rpma_mr_write(struct ibv_qp *qp,
  * rpma_mr_reg -- a mock of rpma_mr_reg()
  */
 int
-rpma_mr_reg(const struct rpma_peer *peer, void *ptr, size_t size, int usage,
+rpma_mr_reg(struct rpma_peer *peer, void *ptr, size_t size, int usage,
 		struct rpma_mr_local **mr_ptr)
 {
 	check_expected_ptr(peer);
@@ -126,7 +126,7 @@ rpma_mr_send(struct ibv_qp *qp,
  */
 int
 rpma_mr_recv(struct ibv_qp *qp,
-	const struct rpma_mr_local *dst,  size_t offset,
+	struct rpma_mr_local *dst,  size_t offset,
 	size_t len, const void *op_context)
 {
 	assert_non_null(qp);

--- a/tests/unit/common/mocks-rpma-peer.c
+++ b/tests/unit/common/mocks-rpma-peer.c
@@ -17,7 +17,7 @@
  * rpma_peer_create_qp -- rpma_peer_create_qp() mock
  */
 int
-rpma_peer_create_qp(const struct rpma_peer *peer, struct rdma_cm_id *id,
+rpma_peer_create_qp(struct rpma_peer *peer, struct rdma_cm_id *id,
 		struct ibv_cq *cq, const struct rpma_conn_cfg *cfg)
 {
 	assert_ptr_equal(peer, MOCK_PEER);
@@ -37,7 +37,7 @@ rpma_peer_create_qp(const struct rpma_peer *peer, struct rdma_cm_id *id,
  * rpma_peer_mr_reg -- a mock of rpma_peer_mr_reg()
  */
 int
-rpma_peer_mr_reg(const struct rpma_peer *peer, struct ibv_mr **ibv_mr_ptr,
+rpma_peer_mr_reg(struct rpma_peer *peer, struct ibv_mr **ibv_mr_ptr,
 		void *addr, size_t length, int access)
 {
 	/*

--- a/tests/unit/ep/ep-common.c
+++ b/tests/unit/ep/ep-common.c
@@ -271,7 +271,7 @@ rdma_get_cm_event(struct rdma_event_channel *channel,
  * rpma_conn_req_from_cm_event -- rpma_conn_req_from_cm_event() mock
  */
 int
-rpma_conn_req_from_cm_event(const struct rpma_peer *peer,
+rpma_conn_req_from_cm_event(struct rpma_peer *peer,
 		struct rdma_cm_event *edata, const struct rpma_conn_cfg *cfg,
 		struct rpma_conn_req **req_ptr)
 {

--- a/tests/unit/peer/peer-create_qp.c
+++ b/tests/unit/peer/peer-create_qp.c
@@ -49,7 +49,7 @@ create_qp__peer_NULL(void **unused)
 static void
 create_qp__id_NULL(void **peer_ptr)
 {
-	const struct rpma_peer *peer = *peer_ptr;
+	struct rpma_peer *peer = *peer_ptr;
 
 	/* run test */
 	struct ibv_cq *cq = MOCK_IBV_CQ;
@@ -65,7 +65,7 @@ create_qp__id_NULL(void **peer_ptr)
 static void
 create_qp__cq_NULL(void **peer_ptr)
 {
-	const struct rpma_peer *peer = *peer_ptr;
+	struct rpma_peer *peer = *peer_ptr;
 
 	/* run test */
 	struct rdma_cm_id *id = MOCK_CM_ID;
@@ -81,7 +81,7 @@ create_qp__cq_NULL(void **peer_ptr)
 static void
 create_qp__rdma_create_qp_EAGAIN(void **peer_ptr)
 {
-	const struct rpma_peer *peer = *peer_ptr;
+	struct rpma_peer *peer = *peer_ptr;
 
 	/* configure mock: */
 	will_return(rpma_conn_cfg_get_sq_size, &Get_sq_size);
@@ -118,7 +118,7 @@ create_qp__rdma_create_qp_EAGAIN(void **peer_ptr)
 static void
 create_qp__success(void **peer_ptr)
 {
-	const struct rpma_peer *peer = *peer_ptr;
+	struct rpma_peer *peer = *peer_ptr;
 
 	/* configure mock: */
 	will_return(rpma_conn_cfg_get_sq_size, &Get_sq_size);

--- a/tests/unit/peer/peer-mr_reg.c
+++ b/tests/unit/peer/peer-mr_reg.c
@@ -24,7 +24,7 @@
 static void
 mr_reg__fail_ENOMEM(void **peer_ptr)
 {
-	const struct rpma_peer *peer = *peer_ptr;
+	struct rpma_peer *peer = *peer_ptr;
 
 	/* configure mocks */
 	expect_value(ibv_reg_mr, pd, MOCK_IBV_PD);
@@ -50,7 +50,7 @@ mr_reg__fail_ENOMEM(void **peer_ptr)
 static void
 mr_reg__fail_EOPNOTSUPP_no_odp(void **peer_ptr)
 {
-	const struct rpma_peer *peer = *peer_ptr;
+	struct rpma_peer *peer = *peer_ptr;
 
 	/* configure mocks */
 	expect_value(ibv_reg_mr, pd, MOCK_IBV_PD);
@@ -77,7 +77,7 @@ mr_reg__fail_EOPNOTSUPP_no_odp(void **peer_ptr)
 static void
 mr_reg__fail_EOPNOTSUPP_EAGAIN(void **peer_ptr)
 {
-	const struct rpma_peer *peer = *peer_ptr;
+	struct rpma_peer *peer = *peer_ptr;
 
 	/* configure mocks */
 	expect_value(ibv_reg_mr, pd, MOCK_IBV_PD);
@@ -112,7 +112,7 @@ mr_reg__fail_EOPNOTSUPP_EAGAIN(void **peer_ptr)
 static void
 mr_reg__success(void **peer_ptr)
 {
-	const struct rpma_peer *peer = *peer_ptr;
+	struct rpma_peer *peer = *peer_ptr;
 
 	/* configure mocks */
 	expect_value(ibv_reg_mr, pd, MOCK_IBV_PD);
@@ -137,7 +137,7 @@ mr_reg__success(void **peer_ptr)
 static void
 mr_reg__success_odp(void **peer_ptr)
 {
-	const struct rpma_peer *peer = *peer_ptr;
+	struct rpma_peer *peer = *peer_ptr;
 
 	/* configure mocks */
 	expect_value(ibv_reg_mr, pd, MOCK_IBV_PD);


### PR DESCRIPTION
const removed from all public API calls if pointers passed to functions are related to resources that might be modified 
e.g.
mr as destination RMA operation
peer where ibv_pd is modified
connection - almost in all cases

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/pmem/rpma/482)
<!-- Reviewable:end -->
