### PR TITLE
common: remove broken block for in-source builds

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -7,11 +7,6 @@ cmake_minimum_required(VERSION 3.3)
 
 project(rpma C)
 
-# disable in-source builds
-if(${PROJECT_SOURCE_DIR} STREQUAL ${PROJECT_BINARY_DIR})
-	message(FATAL_ERROR "In-source build is not allowed.")
-endif()
-
 set(VERSION_MAJOR 0)
 set(VERSION_MINOR 9)
 set(VERSION_PATCH 0)


### PR DESCRIPTION
It blocked also under-source builds (a subdir inside tree, as suggested
by the documentation), and completely external directories.  On the other
hand, after removing this block, in-source builds work perfectly.

Closes #301 

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/pmem/rpma/513)
<!-- Reviewable:end -->
