### PR TITLE
common: enhance custom make targets

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -143,8 +143,6 @@ add_custom_target(check-whitespace-main
 
 add_dependencies(check-whitespace check-whitespace-main)
 
-add_custom_target(tests)
-
 add_flag(-Wpointer-arith)
 add_flag(-Wunused-macros)
 add_flag(-Wsign-conversion)

--- a/examples/CMakeLists.txt
+++ b/examples/CMakeLists.txt
@@ -21,6 +21,7 @@ include(${CMAKE_SOURCE_DIR}/cmake/functions.cmake)
 # set LIBRT_LIBRARIES if linking with librt is required
 check_if_librt_is_required()
 
+add_custom_target(examples)
 include_directories(${LIBRPMA_INCLUDE_DIRS})
 link_directories(${LIBRPMA_LIBRARY_DIRS})
 
@@ -49,7 +50,7 @@ function(add_example)
 		"${oneValueArgs}"
 		"${multiValueArgs}"
 		${ARGN})
-		
+
 	set(target example-${EXAMPLE_NAME}-${EXAMPLE_BIN})
 
 	if (EXAMPLE_USE_LIBPROTOBUFC AND NOT LIBPROTOBUFC_FOUND)
@@ -59,6 +60,7 @@ function(add_example)
 
 	prepend(srcs ${CMAKE_CURRENT_SOURCE_DIR} ${srcs})
 	add_executable(${target} ${EXAMPLE_SRCS})
+	add_dependencies(examples ${target})
 	set_target_properties(${target} PROPERTIES
 		OUTPUT_NAME ${EXAMPLE_BIN}
 		RUNTIME_OUTPUT_DIRECTORY ${EXAMPLE_NAME})

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -5,6 +5,8 @@
 
 include(cmake/ctest_helpers.cmake)
 
+add_custom_target(tests)
+
 add_cstyle(tests)
 
 add_check_whitespace(tests)


### PR DESCRIPTION
- add `make examples` to compile all examples at once
- move `make tests` into tests dir, not to have this target if e.g. `BUILD_TESTS=OFF`

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/pmem/rpma/539)
<!-- Reviewable:end -->
