### PR TITLE
examples: fix setting unset variable STATE_OK

### DIFF
--- a/examples/run-all-on-SoftRoCE.sh
+++ b/examples/run-all-on-SoftRoCE.sh
@@ -13,6 +13,7 @@ IP_ADDRESS=$2
 PORT=$3
 
 MODULE="rdma_rxe"
+STATE_OK="state ACTIVE physical_state LINK_UP"
 
 function verify_SoftRoCE() {
 	SCRIPT_DIR=$(dirname $0)


### PR DESCRIPTION
The `STATE_OK` variable was used in the line no. 23,
but it has never been set in this script,
so the script has been working correctly so far
only because there was always exactly one good (active and up)
network interface.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/pmem/rpma/541)
<!-- Reviewable:end -->
