### PR TITLE
examples: add support for USB Ethernet network interfaces

### DIFF
--- a/examples/config_softroce.sh
+++ b/examples/config_softroce.sh
@@ -72,8 +72,17 @@ if [ "$LINK" == "" ]; then
 	# pick up the first 'up' one
 	LINK=$(ip link | grep -v -e "LOOPBACK" | grep -e "state UP" | head -n1 | cut -d: -f2 | cut -d' ' -f2)
 	if [ "$LINK" == "" ]; then
-		echo "Error: cannot find an active and up network interface"
-		exit 1
+		#
+		# Look for a USB Ethernet network interfaces,
+		# which may not have 'state UP',
+		# but only 'UP' and 'state UNKNOWN', for example:
+		# ... <BROADCAST,MULTICAST,UP,LOWER_UP> ... state UNKNOWN ...
+		#
+		LINK=$(ip link | grep -v -e "LOOPBACK" | grep -e "UP" | grep -e "state UNKNOWN" | head -n1 | cut -d: -f2 | cut -d' ' -f2)
+		if [ "$LINK" == "" ]; then
+			echo "Error: cannot find an active and up network interface"
+			exit 1
+		fi
 	fi
 fi
 


### PR DESCRIPTION
Add support for running examples on SoftRoCE
on a USB Ethernet network interfaces,
which may not have 'state UP',
but only 'UP' and 'state UNKNOWN', for example:

```
enp0s29u1u3: <BROADCAST,MULTICAST,UP,LOWER_UP> mtu 1500 qdisc fq_codel state UNKNOWN mode DEFAULT  group default qlen 1000
```

is a correct network interface that can be used
for running examples on SoftRoCE.

Requires:
- [x] #541

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/pmem/rpma/542)
<!-- Reviewable:end -->
