### PR TITLE
examples: fix error: variable 'is_pmem' set but not used

### DIFF
--- a/examples/09-flush-to-persistent-GPSPM/client.c
+++ b/examples/09-flush-to-persistent-GPSPM/client.c
@@ -96,9 +96,8 @@ main(int argc, char *argv[])
 
 	struct hello_t *hello = NULL;
 
-	int is_pmem = 0;
-
 #ifdef USE_LIBPMEM
+	int is_pmem = 0;
 	if (argc >= 4) {
 		char *path = argv[3];
 
@@ -166,7 +165,6 @@ main(int argc, char *argv[])
 
 		mr_size = sizeof(struct hello_t);
 		hello = mr_ptr;
-		is_pmem = 0;
 
 		/* write an initial value */
 		write_hello_str(hello, en);


### PR DESCRIPTION
Fix the compilation error:

```
examples/09-flush-to-persistent-GPSPM/client.c:99:6: error: variable 'is_pmem' set but not used [-Werror=unused-but-set-variable]
```
See: https://github.com/ldorau/rpma/actions/runs/291154483

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/pmem/rpma/544)
<!-- Reviewable:end -->
