### PR TITLE
common: fix description of librpma

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@
 [![librpma version](https://img.shields.io/github/tag/pmem/rpma.svg)](https://github.com/pmem/rpma/releases/latest)
 [![Coverage Status](https://codecov.io/github/pmem/rpma/coverage.svg?branch=master)](https://codecov.io/gh/pmem/rpma/branch/master)
 
-The **Remote Persistent Memory Access (RPMA)** is a C library to simplify accessing persistent memory devices on remote hosts over **Remote Direct Memory Access (RDMA)**. For more information, see
+The **Remote Persistent Memory Access (RPMA)** is a C library to simplify accessing persistent memory on remote hosts over **Remote Direct Memory Access (RDMA)**. For more information, see
 [pmem.io](https://pmem.io).
 
 

--- a/cmake/librpma.pc.in
+++ b/cmake/librpma.pc.in
@@ -3,7 +3,7 @@ includedir=${prefix}/@CMAKE_INSTALL_INCLUDEDIR@
 libdir=${prefix}/@CMAKE_INSTALL_LIBDIR@
 
 Name: librpma
-Description: librpma - library to simplify accessing persistent memory devices on remote hosts over RDMA
+Description: librpma - library to simplify accessing persistent memory on remote hosts over RDMA
 Version: @VERSION@
 URL: https://github.com/pmem/rpma
 Cflags: -I${includedir}

--- a/cmake/packages.cmake
+++ b/cmake/packages.cmake
@@ -48,7 +48,7 @@ set(CPACK_PACKAGE_NAME "librpma")
 set(CPACK_PACKAGE_VERSION ${VERSION})
 set(CPACK_PACKAGE_VERSION_MAJOR ${VERSION_MAJOR})
 set(CPACK_PACKAGE_VERSION_MINOR ${VERSION_MINOR})
-set(CPACK_PACKAGE_DESCRIPTION_SUMMARY "library to simplify accessing persistent memory devices on remote hosts over RDMA")
+set(CPACK_PACKAGE_DESCRIPTION_SUMMARY "library to simplify accessing persistent memory on remote hosts over RDMA")
 set(CPACK_PACKAGE_VENDOR "Intel")
 
 set(CPACK_RPM_PACKAGE_NAME "librpma-devel")

--- a/examples/README.md
+++ b/examples/README.md
@@ -2,7 +2,7 @@ Examples for librpma
 ===
 
 This directory contains examples for librpma,
-the library to simplify accessing persistent memory devices
+the library to simplify accessing persistent memory
 on remote hosts over Remote Direct Memory Access (RDMA).
 
 If you're looking for documentation to get you started using RPMA,

--- a/src/include/librpma.h
+++ b/src/include/librpma.h
@@ -28,7 +28,7 @@
  *
  * DESCRIPTION
  *
- * librpma is a C library to simplify accessing persistent memory (PMem) devices
+ * librpma is a C library to simplify accessing persistent memory (PMem)
  * on remote hosts over Remote Direct Memory Access (RDMA).
  *
  * The librpma library provides two possible schemes of operation:


### PR DESCRIPTION
librpma is a C library to simplify accessing
persistent memory (PMem) and not persistent memory devices.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/pmem/rpma/546)
<!-- Reviewable:end -->
