### PR TITLE
doc: fix description of librpma

### DIFF
--- a/index.md
+++ b/index.md
@@ -5,8 +5,8 @@ layout: pmdk
 
 #### The librpma library
 
-The **Remote Persistent Memory Access (RPMA)** (*librpma*) is a C library to
-simplify accessing persistent memory devices on remote hosts over
+The **Remote Persistent Memory Access (RPMA)** (*librpma*) is a C library
+to simplify accessing persistent memory on remote hosts over
 **Remote Direct Memory Access (RDMA)**.
 
 The documentation is available [here](./manpages/master/librpma.7.html).


### PR DESCRIPTION
librpma is a C library to simplify accessing
persistent memory (PMem) and not persistent memory devices.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/pmem/rpma/549)
<!-- Reviewable:end -->
