### PR TITLE
common: remove unused Coverity job from the Travis build

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -15,7 +15,6 @@ env:
     - OS=ubuntu OS_VER=19.10 TYPE=normal CC=gcc
     - OS=fedora OS_VER=31    TYPE=normal CC=gcc
     - OS=fedora OS_VER=31    TYPE=normal CC=clang
-    - OS=ubuntu OS_VER=19.10 TYPE=coverity CC=gcc
 
 before_install:
   - echo $TRAVIS_COMMIT_RANGE


### PR DESCRIPTION
We do not use Coverity now and do not plan to do it
in the near future.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/pmem/rpma/554)
<!-- Reviewable:end -->
