### PR TITLE
rpma: limit size of registered memory to 1K

### DIFF
--- a/examples/03-read-to-persistent/client.c
+++ b/examples/03-read-to-persistent/client.c
@@ -133,6 +133,7 @@ main(int argc, char *argv[])
 			memcpy(mr_ptr, SIGNATURE_STR, SIGNATURE_LEN);
 			pmem_persist(mr_ptr, SIGNATURE_LEN);
 		}
+		mr_size = KILOBYTE;
 	}
 #endif
 

--- a/examples/03-read-to-persistent/server.c
+++ b/examples/03-read-to-persistent/server.c
@@ -101,6 +101,7 @@ main(int argc, char *argv[])
 			memcpy(dst_ptr, SIGNATURE_STR, SIGNATURE_LEN);
 			pmem_persist(dst_ptr, SIGNATURE_LEN);
 		}
+		dst_size = KILOBYTE;
 	}
 #endif
 
@@ -112,7 +113,6 @@ main(int argc, char *argv[])
 
 		dst_size = KILOBYTE;
 	}
-
 	/* RPMA resources */
 	struct rpma_peer *peer = NULL;
 	struct rpma_ep *ep = NULL;
@@ -164,7 +164,8 @@ main(int argc, char *argv[])
 	}
 
 	ret = rpma_read(conn, dst_mr, dst_offset, src_mr, src_data->data_offset,
-			KILOBYTE, RPMA_F_COMPLETION_ALWAYS, NULL);
+			(size_t)KILOBYTE - src_data->data_offset,
+			RPMA_F_COMPLETION_ALWAYS, NULL);
 	if (ret)
 		goto err_mr_remote_delete;
 


### PR DESCRIPTION
SodtRoCE and probably CVL does not accept huge memory registration
Memory region size limited to 1024 bytes

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/pmem/rpma/573)
<!-- Reviewable:end -->
