### PR TITLE
rpma: limit size of registered memory to 1K

### DIFF
--- a/examples/03-read-to-persistent/client.c
+++ b/examples/03-read-to-persistent/client.c
@@ -133,6 +133,8 @@ main(int argc, char *argv[])
 			memcpy(mr_ptr, SIGNATURE_STR, SIGNATURE_LEN);
 			pmem_persist(mr_ptr, SIGNATURE_LEN);
 		}
+
+		mr_size = sizeof(struct hello_t) + data_offset;
 	}
 #endif
 

--- a/examples/03-read-to-persistent/server.c
+++ b/examples/03-read-to-persistent/server.c
@@ -101,6 +101,8 @@ main(int argc, char *argv[])
 			memcpy(dst_ptr, SIGNATURE_STR, SIGNATURE_LEN);
 			pmem_persist(dst_ptr, SIGNATURE_LEN);
 		}
+
+		dst_size = KILOBYTE + SIGNATURE_LEN;
 	}
 #endif
 


### PR DESCRIPTION
SodtRoCE and probably CLV does not accept huge memory registration
Memory region size limited to 1024 bytes

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/pmem/rpma/574)
<!-- Reviewable:end -->
