### PR TITLE
rpma: remove redundant assignment in usage_to_access()

### DIFF
--- a/src/mr.c
+++ b/src/mr.c
@@ -68,36 +68,24 @@ usage_to_access(int usage)
 
 	if (usage & (RPMA_MR_USAGE_READ_SRC |\
 			RPMA_MR_USAGE_FLUSH_TYPE_VISIBILITY |\
-			RPMA_MR_USAGE_FLUSH_TYPE_PERSISTENT)) {
+			RPMA_MR_USAGE_FLUSH_TYPE_PERSISTENT))
 		access |= IBV_ACCESS_REMOTE_READ;
-		usage &= ~(RPMA_MR_USAGE_READ_SRC |\
-				RPMA_MR_USAGE_FLUSH_TYPE_VISIBILITY |\
-				RPMA_MR_USAGE_FLUSH_TYPE_PERSISTENT);
-	}
 
-	if (usage & RPMA_MR_USAGE_READ_DST) {
+	if (usage & RPMA_MR_USAGE_READ_DST)
 		access |= IBV_ACCESS_LOCAL_WRITE;
-		usage &= ~RPMA_MR_USAGE_READ_DST;
-	}
 
-	if (usage & RPMA_MR_USAGE_WRITE_SRC) {
+	if (usage & RPMA_MR_USAGE_WRITE_SRC)
 		access |= IBV_ACCESS_LOCAL_WRITE;
-		usage &= ~RPMA_MR_USAGE_WRITE_SRC;
-	}
 
-	if (usage & RPMA_MR_USAGE_WRITE_DST) {
+	if (usage & RPMA_MR_USAGE_WRITE_DST)
 		/*
 		 * If IBV_ACCESS_REMOTE_WRITE is set, then
 		 * IBV_ACCESS_LOCAL_WRITE must be set too.
 		 */
 		access |= IBV_ACCESS_REMOTE_WRITE | IBV_ACCESS_LOCAL_WRITE;
-		usage &= ~RPMA_MR_USAGE_WRITE_DST;
-	}
 
-	if (usage & RPMA_MR_USAGE_RECV) {
+	if (usage & RPMA_MR_USAGE_RECV)
 		access |= IBV_ACCESS_LOCAL_WRITE;
-		usage &= ~RPMA_MR_USAGE_RECV;
-	}
 
 	return access;
 }


### PR DESCRIPTION
Signed-off-by: Xiao Yang <yangx.jy@cn.fujitsu.com>

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/pmem/rpma/576)
<!-- Reviewable:end -->
