### PR TITLE
examples: support FLUSH_TYPE_VISIBILITY on pmem

### DIFF
--- a/examples/05-flush-to-persistent/client.c
+++ b/examples/05-flush-to-persistent/client.c
@@ -151,7 +151,7 @@ main(int argc, char *argv[])
 	struct rpma_peer *peer = NULL;
 	struct rpma_conn *conn = NULL;
 	bool direct_write_to_pmem = false;
-	enum rpma_flush_type flush_type = RPMA_FLUSH_TYPE_VISIBILITY;
+	enum rpma_flush_type flush_type;
 
 	/*
 	 * lookup an ibv_context via the address and create a new peer using it
@@ -227,7 +227,8 @@ main(int argc, char *argv[])
 		printf("RPMA_FLUSH_TYPE_PERSISTENT is supported\n");
 		flush_type = RPMA_FLUSH_TYPE_PERSISTENT;
 	} else {
-		printf("RPMA_FLUSH_TYPE_PERSISTENT is NOT supported\n");
+		printf(
+			"RPMA_FLUSH_TYPE_PERSISTENT is NOT supported, RPMA_FLUSH_TYPE_VISIBILITY is used instead\n");
 		flush_type = RPMA_FLUSH_TYPE_VISIBILITY;
 	}
 

--- a/examples/05-flush-to-persistent/server.c
+++ b/examples/05-flush-to-persistent/server.c
@@ -162,7 +162,8 @@ main(int argc, char *argv[])
 	/* register the memory */
 	ret = rpma_mr_reg(peer, mr_ptr, mr_size,
 			RPMA_MR_USAGE_WRITE_DST |
-			(is_pmem ? RPMA_MR_USAGE_FLUSH_TYPE_PERSISTENT :
+			(is_pmem ? (RPMA_MR_USAGE_FLUSH_TYPE_PERSISTENT |
+				RPMA_MR_USAGE_FLUSH_TYPE_VISIBILITY) :
 				RPMA_MR_USAGE_FLUSH_TYPE_VISIBILITY),
 			&mr);
 	if (ret)


### PR DESCRIPTION
For server with pmem support in 05-flush-to-persistent, rpma_mr_reg()
should call RPMA_MR_USAGE_FLUSH_TYPE_VISIBILITY instead of
RPMA_MR_USAGE_FLUSH_TYPE_PERSISTENT if direct-pmem-write parameter
is not specified.

Also remove unneeded initialization of flush_type for client.

Signed-off-by: Xiao Yang <yangx.jy@cn.fujitsu.com>

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/pmem/rpma/577)
<!-- Reviewable:end -->
