### PR TITLE
rpma: make rpma_flush() use custom flags

### DIFF
--- a/src/flush.c
+++ b/src/flush.c
@@ -124,7 +124,7 @@ rpma_flush_apm_do(struct ibv_qp *qp, struct rpma_flush *flush,
 			(struct flush_apm *)flush_internal->context;
 
 	return rpma_mr_read(qp, flush_apm->raw_mr, 0, dst, dst_offset,
-			RAW_SIZE, RPMA_F_COMPLETION_ALWAYS, op_context);
+			RAW_SIZE, flags, op_context);
 }
 
 /* internal librpma API */

--- a/tests/unit/flush/flush-apm_do.c
+++ b/tests/unit/flush/flush-apm_do.c
@@ -27,7 +27,7 @@ apm_do__success(void **fstate_ptr)
 	expect_value(rpma_mr_read, src, MOCK_RPMA_MR_REMOTE);
 	expect_value(rpma_mr_read, src_offset, MOCK_REMOTE_OFFSET);
 	expect_value(rpma_mr_read, len, MOCK_RAW_LEN);
-	expect_value(rpma_mr_read, flags, RPMA_F_COMPLETION_ALWAYS);
+	expect_value(rpma_mr_read, flags, MOCK_FLAGS);
 	expect_value(rpma_mr_read, op_context, MOCK_OP_CONTEXT);
 	will_return(rpma_mr_read, MOCK_OK);
 


### PR DESCRIPTION
Current rpma_flush() always uses RPMA_F_COMPLETION_ALWAYS and
ignores RPMA_F_COMPLETION_ON_ERROR.  In this case, rpma_flush()
cannot choose that the completion event is only generated on
error.

Signed-off-by: Xiao Yang <yangx.jy@cn.fujitsu.com>

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/pmem/rpma/580)
<!-- Reviewable:end -->
