### PR TITLE
common: add an argument for common header of markup manuals

### DIFF
--- a/doc/CMakeLists.txt
+++ b/doc/CMakeLists.txt
@@ -20,11 +20,14 @@ if(SRC2MAN AND GROFF AND FIND AND DIFF)
 
 	add_custom_target(doc ALL 
 		COMMAND ${CMAKE_SOURCE_DIR}/utils/src2mans.sh
-			${CMAKE_SOURCE_DIR}/src ${man3_list} ${man7_list})
+			${CMAKE_SOURCE_DIR}/src ${man3_list} ${man7_list}
+			${CMAKE_SOURCE_DIR}/utils/mans_header.md)
 
 	add_custom_target(doc-fix
 		COMMAND ${CMAKE_SOURCE_DIR}/utils/src2mans.sh
-			${CMAKE_SOURCE_DIR}/src ${man3_list} ${man7_list} fix)
+			${CMAKE_SOURCE_DIR}/src ${man3_list} ${man7_list}
+			${CMAKE_SOURCE_DIR}/utils/mans_header.md
+			fix)
 
 	file(STRINGS ${man3_list} man3)
 	file(STRINGS ${man7_list} man7)

--- a/utils/src2mans.sh
+++ b/utils/src2mans.sh
@@ -9,21 +9,24 @@
 DIR=$1
 MAN_3=$2
 MAN_7=$3
-[ "$4" == "fix" ] && FIX=1 || FIX=0
+MANS_HEADER=$4
+[ "$5" == "fix" ] && FIX=1 || FIX=0
 
-if [ $# -lt 3 ] || [ ! -d $DIR ] || [ ! -f $MAN_3 ] || [ ! -f $MAN_7 ]; then
+if [ $# -lt 4 ] || [ ! -d $DIR ] || [ ! -f $MAN_3 ] || [ ! -f $MAN_7 ] || [ ! -f $MANS_HEADER ]; then
 	echo "$ $0 $*"
 	echo "Error: missing or wrong argument"
 	echo
-	echo "Usage: $(basename $0) <directory> <man3-file> <man7-file> [fix]"
-	echo "   <directory> - directory to be searched for *.h files"
-	echo "   <man3-file> - file containing list of section #3 manuals"
-	echo "   <man7-file> - file containing list of section #7 manuals"
-	echo "   fix         - fix files containing list of manuals"
+	echo "Usage: $(basename $0) <directory> <man3-file> <man7-file> <mans_header> [fix]"
+	echo "   <directory>   - directory to be searched for *.h files"
+	echo "   <man3-file>   - file containing list of section #3 manuals"
+	echo "   <man7-file>   - file containing list of section #7 manuals"
+	echo "   <mans_header> - common header of markup manuals"
+	echo "   fix           - fix files containing list of manuals"
 	echo
 	[ ! -d $DIR ] && echo "Error: $DIR does not exist or is not a directory"
 	[ ! -f $MAN_3 ] && echo "Error: $MAN_3 does not exist or is not a regular file"
 	[ ! -f $MAN_7 ] && echo "Error: $MAN_7 does not exist or is not a regular file"
+	[ ! -f $MANS_HEADER ] && echo "Error: $MANS_HEADER does not exist or is not a regular file"
 	exit 1
 fi
 
@@ -84,7 +87,7 @@ do
 			# fix the name issue '**a **-' -> '**a** -'
 			sed -i '5s/ \*\*-/\*\* -/' $f.tmp2
 			# start with a custom header
-			cat ../../utils/mans_header.md > md/$f.md
+			cat $MANS_HEADER > md/$f.md
 			cat $f.tmp2 >> md/$f.md
 			rm $f.tmp1 $f.tmp2
 		done


### PR DESCRIPTION
The common header of markup manuals has to be given
using the absolute path so that it works in case of out-of-tree builds.

Ref: #562

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/pmem/rpma/583)
<!-- Reviewable:end -->
