### PR TITLE
rpma: fix documentation of rpma_log_function()

### DIFF
--- a/src/include/librpma.h
+++ b/src/include/librpma.h
@@ -2593,7 +2593,7 @@ typedef void rpma_log_function(
  * - line_no - the source file line where the message coming from
  * - function_name - the function name where the message coming from
  * - message_format - printf(3)-like format string of the message
- * - ... - additional arguments of the message format string
+ * - "..." - additional arguments of the message format string
  *
  * THE DEFAULT LOGGING FUNCTION
  * The initial value of the logging function is RPMA_LOG_USE_DEFAULT_FUNCTION.


### PR DESCRIPTION
The unquoted '..' string is interpreted by 'man' as undefined macro
and produces the following warning:

```
$ man --warnings >/dev/null ./rpma_log_set_function.3
troff: <standard input>:45: warning: macro '..' not defined
```

Ref: #564

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/pmem/rpma/584)
<!-- Reviewable:end -->
