### PR TITLE
common: remove the 'hub' package from Fedora rawhide docker file

### DIFF
--- a/utils/docker/images/Dockerfile.fedora-rawhide
+++ b/utils/docker/images/Dockerfile.fedora-rawhide
@@ -41,16 +41,11 @@ ENV RPMA_DEPS "\
 	pandoc \
 	rdma-core-devel"
 
-# doc update deps
-ENV DOC_UPDATE_DEPS "\
-	hub"
-
 # Install all required packages
 RUN dnf install -y \
 	$BASE_DEPS \
 	$EXAMPLES_DEPS \
 	$RPMA_DEPS \
-	$DOC_UPDATE_DEPS \
 && dnf clean all
 
 # Install cmocka


### PR DESCRIPTION
Remove the 'hub' package from Fedora rawhide docker file,
because it is no longer available in this version:
```
No match for argument: hub
Error: Unable to find a match: hub
```

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/pmem/rpma/588)
<!-- Reviewable:end -->
