### PR TITLE
common: do not skip regular jobs if build is triggered by cron

### DIFF
--- a/utils/docker/build.sh
+++ b/utils/docker/build.sh
@@ -32,16 +32,14 @@ if [[ -z "$HOST_WORKDIR" ]]; then
 	HOST_WORKDIR=$(readlink -f ../..)
 fi
 
-if [[ "$CI_EVENT_TYPE" == "cron" || "$CI_BRANCH" == "coverity_scan" ]]; then
-	if [[ "$TYPE" != "coverity" ]]; then
-		echo "Skipping non-Coverity job for cron/Coverity build"
-		exit 0
-	fi
-else
-	if [[ "$TYPE" == "coverity" ]]; then
-		echo "Skipping Coverity job for non cron/Coverity build"
-		exit 0
-	fi
+if [[ "$TYPE" == "coverity" && "$CI_EVENT_TYPE" != "cron" && "$CI_BRANCH" != "coverity_scan" ]]; then
+	echo "Skipping Coverity job for non cron/Coverity build"
+	exit 0
+fi
+
+if [[ "$CI_BRANCH" == "coverity_scan" && "$TYPE" != "coverity" ]]; then
+	echo "Skipping non-Coverity job for cron/Coverity build"
+	exit 0
 fi
 
 imageName=${DOCKER_REPO}:${IMG_VER}-${OS}-${OS_VER}

--- a/utils/docker/pull-or-rebuild-image.sh
+++ b/utils/docker/pull-or-rebuild-image.sh
@@ -25,17 +25,14 @@ set -e
 source $(dirname $0)/set-ci-vars.sh
 source $(dirname $0)/set-vars.sh
 
-if [[ "$CI_EVENT_TYPE" != "cron" && "$CI_BRANCH" != "coverity_scan" \
-	&& "$TYPE" == "coverity" ]]; then
+if [[ "$TYPE" == "coverity" && "$CI_EVENT_TYPE" != "cron" && "$CI_BRANCH" != "coverity_scan" ]]; then
 	echo "INFO: Skip Coverity scan job if build is triggered neither by " \
 		"'cron' nor by a push to 'coverity_scan' branch"
 	exit 0
 fi
 
-if [[ ( "$CI_EVENT_TYPE" == "cron" || "$CI_BRANCH" == "coverity_scan" )\
-	&& "$TYPE" != "coverity" ]]; then
-	echo "INFO: Skip regular jobs if build is triggered either by 'cron'" \
-		" or by a push to 'coverity_scan' branch"
+if [[ "$CI_BRANCH" == "coverity_scan" && "$TYPE" != "coverity" ]]; then
+	echo "INFO: Skip regular jobs if build is triggered by a push to 'coverity_scan' branch"
 	exit 0
 fi
 


### PR DESCRIPTION
The "Nightly" cron builds have been skipping
all building and testing so far. This patch fixes that.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/pmem/rpma/589)
<!-- Reviewable:end -->
