### PR TITLE
common: remove the coverity job from the regular GHA builds

### DIFF
--- a/.github/workflows/gha.yml
+++ b/.github/workflows/gha.yml
@@ -23,8 +23,8 @@ jobs:
         CONFIG: ["N=1 OS=ubuntu OS_VER=20.04 TYPE=normal CC=gcc PUSH_IMAGE=1",
                  "N=2 OS=fedora OS_VER=32    TYPE=normal CC=gcc PUSH_IMAGE=1 AUTO_DOC_UPDATE=1",
                  "N=3 OS=fedora OS_VER=32    TYPE=normal CC=clang",
-                 "N=4 OS=ubuntu OS_VER=20.04 TYPE=normal CC=gcc COVERAGE=1",
-                 "N=5 OS=ubuntu OS_VER=20.04 TYPE=coverity CC=gcc"]
+                 "N=4 OS=ubuntu OS_VER=20.04 TYPE=normal CC=gcc COVERAGE=1"]
+               # "N=5 OS=ubuntu OS_VER=20.04 TYPE=coverity CC=gcc"]
     steps:
        - name: Clone the git repo
          uses: actions/checkout@v1


### PR DESCRIPTION
The coverity job is not used now, so comment it out
to save the GHA resources.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/pmem/rpma/590)
<!-- Reviewable:end -->
