### PR TITLE
common: always rebuild docker images of rolling and testing distros

### DIFF
--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -50,13 +50,13 @@ jobs:
                  "N=Debian9      OS=debian  OS_VER=9",
                  "N=DebianS      OS=debian  OS_VER=stable",
                  # Rolling/testing/experimental distributions:
-                 "N=Ubuntu_Rolling       OS=ubuntu               OS_VER=rolling",
-                 "N=Fedora_Rawhide       OS=fedora               OS_VER=rawhide",
-                 "N=Debian_Testing       OS=debian               OS_VER=testing",
-                 "N=Debian_Experimental  OS=debian               OS_VER=experimental",
-                 "N=Arch_Linux_Latest    OS=archlinux-base       OS_VER=latest",
-                 "N=OpenSUSE_Leap        OS=opensuse-leap        OS_VER=latest",
-                 "N=OpenSUSE_Tumbleweed  OS=opensuse-tumbleweed  OS_VER=latest"]
+                 "N=Ubuntu_Rolling       OS=ubuntu               OS_VER=rolling        REBUILD_ALWAYS=YES",
+                 "N=Fedora_Rawhide       OS=fedora               OS_VER=rawhide        REBUILD_ALWAYS=YES",
+                 "N=Debian_Testing       OS=debian               OS_VER=testing        REBUILD_ALWAYS=YES",
+                 "N=Debian_Experimental  OS=debian               OS_VER=experimental   REBUILD_ALWAYS=YES",
+                 "N=Arch_Linux_Latest    OS=archlinux-base       OS_VER=latest         REBUILD_ALWAYS=YES",
+                 "N=OpenSUSE_Leap        OS=opensuse-leap        OS_VER=latest         REBUILD_ALWAYS=YES",
+                 "N=OpenSUSE_Tumbleweed  OS=opensuse-tumbleweed  OS_VER=latest         REBUILD_ALWAYS=YES"]
     steps:
        - name: Clone the git repo
          uses: actions/checkout@v1

--- a/utils/docker/pull-or-rebuild-image.sh
+++ b/utils/docker/pull-or-rebuild-image.sh
@@ -98,7 +98,8 @@ base_dir=utils/docker/$images_dir_name
 for file in $files; do
 	# Check if modified files are relevant to the current build
 	if [[ $file =~ ^($base_dir)\/Dockerfile\.($OS)-($OS_VER)$ ]] \
-		|| [[ $file =~ ^($base_dir)\/.*\.sh$ ]]
+		|| [[ $file =~ ^($base_dir)\/.*\.sh$ ]] \
+		|| [[ "$REBUILD_ALWAYS" == "YES" ]]
 	then
 		rebuild_and_push_image
 	fi


### PR DESCRIPTION
Always rebuild docker images of rolling and testing distros
in the Nightly build, because they change very often.

Rebuild always only the "GCC" jobs, because only they push images out.
The "CLANG" jobs will use the old image but the new one will be used
during the next build (on the day after).

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/pmem/rpma/592)
<!-- Reviewable:end -->
