### PR TITLE
common: tools: ib/rpma_read_lat sshpass -v for verbosity

### DIFF
--- a/tools/ib_read_lat.sh
+++ b/tools/ib_read_lat.sh
@@ -53,7 +53,7 @@ echo "$HEADER" | sed 's/% /%_/g' | sed -r 's/[[:blank:]]+/,/g' > $OUTPUT
 
 for ds in $DATA_SIZE; do
     # run the server
-    sshpass -p "$REMOTE_PASS" ssh $REMOTE_USER@$SERVER_IP \
+    sshpass -p "$REMOTE_PASS" -v ssh $REMOTE_USER@$SERVER_IP \
         "numactl -N $REMOTE_JOB_NUMA ib_read_lat --size $ds \
         $REMOTE_AUX_PARAMS > /dev/shm/ib_read_lat.log " \
 	    2>>$LOG_ERR &

--- a/tools/rpma_read_lat.sh
+++ b/tools/rpma_read_lat.sh
@@ -64,7 +64,7 @@ for ds in $DATA_SIZE; do
     sshpass -p "$REMOTE_PASS" scp ./fio_jobs/librpma-server.fio \
         $REMOTE_USER@$SERVER_IP:$REMOTE_JOB_PATH
     # run the server
-    sshpass -p "$REMOTE_PASS" ssh $REMOTE_USER@$SERVER_IP \
+    sshpass -p "$REMOTE_PASS" -v ssh $REMOTE_USER@$SERVER_IP \
         "bindname=$SERVER_IP mem=$REMOTE_JOB_MEM num_conns=1 \
         numactl -N $REMOTE_JOB_NUMA \
             ${REMOTE_FIO_PATH}fio $REMOTE_JOB_PATH > $LOG_ERR" 2>>$LOG_ERR &


### PR DESCRIPTION
`ssh -v` allows collecting verbose error output.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/pmem/rpma/615)
<!-- Reviewable:end -->
