### PR TITLE
rpma: add rpma_conn_req_get_private_data() to public library API (WIP)

### DIFF
--- a/doc/manuals_3.txt
+++ b/doc/manuals_3.txt
@@ -19,6 +19,7 @@ rpma_conn_get_private_data.3
 rpma_conn_next_event.3
 rpma_conn_req_connect.3
 rpma_conn_req_delete.3
+rpma_conn_req_get_private_data.3
 rpma_conn_req_new.3
 rpma_conn_req_recv.3
 rpma_ep_get_fd.3

--- a/src/conn_req.c
+++ b/src/conn_req.c
@@ -481,3 +481,20 @@ rpma_conn_req_recv(struct rpma_conn_req *req,
 			dst, offset, len,
 			op_context);
 }
+
+/*
+ * rpma_conn_req_get_private_data - get a pointer to the incoming connection's
+ * private data
+ */
+int
+rpma_conn_req_get_private_data(const struct rpma_conn_req *req,
+    struct rpma_conn_private_data *pdata)
+{
+	if (req == NULL || pdata == NULL)
+		return RPMA_E_INVAL;
+
+	pdata->ptr = req->data.ptr;
+	pdata->len = req->data.len;
+
+	return 0;
+}

--- a/src/include/librpma.h
+++ b/src/include/librpma.h
@@ -328,6 +328,7 @@
  * - rpma_conn_next_event()
  * - rpma_conn_req_connect()
  * - rpma_conn_req_delete()
+ * - rpma_conn_req_get_private_data()
  * - rpma_conn_req_new()
  * - rpma_ep_listen()
  * - rpma_ep_next_conn_req()
@@ -1943,6 +1944,48 @@ int rpma_ep_get_fd(const struct rpma_ep *ep, int *fd);
 int rpma_ep_next_conn_req(struct rpma_ep *ep,
 		const struct rpma_conn_cfg *cfg,
 		struct rpma_conn_req **req_ptr);
+
+/** 3
+ * rpma_conn_req_get_private_data - get a pointer to the request's private data
+ *
+ * SYNOPSIS
+ *
+ *	#include <librpma.h>
+ *
+ *	struct rpma_conn_req;
+ *	struct rpma_conn_private_data;
+ *	int rpma_conn_req_get_private_data(const struct rpma_conn_req *req,
+ *			struct rpma_conn_private_data *pdata);
+ *
+ * DESCRIPTION
+ * rpma_conn_req_get_private_data() obtains the pointer to the connection's
+ * private data given by the other side of the connection before the connection
+ * is fully established.
+ *
+ * NOTE
+ * The pdata pointer becomes invalid after the connection is established.
+ * Use rpma_conn_get_private_data(3) to get a pointer to the connection's
+ * private data if access to it is still required after the connection is
+ * established.
+ *
+ * RETURN VALUE
+ * The rpma_conn_req_get_private_data() function returns 0 on success or
+ * a negative error code on failure. rpma_conn_req_get_private_data() does not
+ * set *pdata value on failure.
+ *
+ * ERRORS
+ * rpma_conn_req_get_private_data() can fail with the following error:
+ *
+ * - RPMA_E_INVAL - req or pdata is NULL
+ *
+ * SEE ALSO
+ * rpma_conn_get_private_data(3), rpma_ep_next_conn_req(3), librpma(7)
+ * and https://pmem.io/rpma/
+ */
+int rpma_conn_req_get_private_data(const struct rpma_conn_req *req,
+		struct rpma_conn_private_data *pdata);
+
+
 
 /* remote memory access functions */
 

--- a/src/librpma.map
+++ b/src/librpma.map
@@ -29,6 +29,7 @@ LIBRPMA_1.0 {
 		rpma_conn_next_event;
 		rpma_conn_req_connect;
 		rpma_conn_req_delete;
+		rpma_conn_req_get_private_data;
 		rpma_conn_req_new;
 		rpma_conn_req_recv;
 		rpma_ep_get_fd;


### PR DESCRIPTION
Currently, connection private data are not accessible before
the connection is established.
With this new API call server side (ep_listen) is able to pre-setup
connection using context delivered with incoming connection private data.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/pmem/rpma/646)
<!-- Reviewable:end -->
