### PR TITLE
tools: introduce a bw(threads) comparison layout

### DIFF
--- a/tools/csv_compare.py
+++ b/tools/csv_compare.py
@@ -18,9 +18,10 @@ import pandas as pd
 import matplotlib.pyplot as plt
 
 column_to_label = {
-    'bs':   'block size [B]',
-    'lat':  'latency [nsec]',
-    'bw':   'bandwidth [Gb/s]',
+    'threads':  '# of threads',
+    'bs':       'block size [B]',
+    'lat':      'latency [nsec]',
+    'bw':       'bandwidth [Gb/s]',
 }
 
 layouts = {
@@ -39,6 +40,14 @@ layouts = {
         'nrows': 1,
         'ncols': 1,
         'x': 'bs',
+        'columns': [
+            'bw_avg'
+        ]
+    },
+    'bw_vs_th': {
+        'nrows': 1,
+        'ncols': 1,
+        'x': 'threads',
         'columns': [
             'bw_avg'
         ]


### PR DESCRIPTION
```sh
$ ./csv_compare.py --output_layout bw_vs_th --legend ib_read_bw --output_title "A show off of the new layout" \
ib_read_bw-th-4096bs-20-12-09-124331.csv
```

![compare](https://user-images.githubusercontent.com/3518702/101640512-e503ba00-3a30-11eb-8840-5410af740a42.png)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/pmem/rpma/649)
<!-- Reviewable:end -->
