### PR TITLE
tools: save whole path of mmap directory

### DIFF
--- a/tools/rpma_fio_bench.sh
+++ b/tools/rpma_fio_bench.sh
@@ -94,7 +94,7 @@ esac
 if [ -z "$REMOTE_JOB_MEM" ]; then
 	MEM=dram
 else
-	MEM="$( echo "$REMOTE_JOB_MEM" | cut -c11- )"
+	MEM="$(echo $REMOTE_JOB_MEM | cut -d'/' -f2- | sed 's/\//_/g')"
 fi
 
 NAME=rpma_fio_${OP}_${MODE}_${MEM}-${TIMESTAMP}


### PR DESCRIPTION
Save whole path of the mmap directory:
- save `dev_dax1.0` instead of `dax1.0` in case of `mmap:/dev/dax1.0`
- save `tmp_dir` instead of `dir` in case of `mmap:/tmp/dir`
- save `d1_d2_d3_d4` instead of `2/d3/d4` in case of `mmap:/d1/d2/d3/d4`

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/pmem/rpma/681)
<!-- Reviewable:end -->
