### PR TITLE
tools: generate legend from file names __COMMENT__s

### DIFF
--- a/tools/csv_compare.py
+++ b/tools/csv_compare.py
@@ -272,10 +272,19 @@ def main():
         default='title', help='an output title')
     parser.add_argument('--legend', metavar='SERIES', nargs='+',
         help='a legend for the data series read from the CSV files')
+    parser.add_argument('--legend_from_file_name_comment', action='store_true',
+        help='generate a legend from the file name comments __COMMENT__')
     args = parser.parse_args()
 
-    # validate the legend
-    if args.legend is None:
+    # generate or validate the legend
+    if args.legend_from_file_name_comment:
+        args.legend = []
+        for fname in args.csv_files:
+            comment = fname.split('__')
+            if len(comment) != 3 or len(comment[1]) == 0:
+                args.legend.append(fname)
+            args.legend.append(comment[1])
+    elif args.legend is None:
         args.legend = args.csv_files
     elif len(args.legend) != len(args.csv_files):
         raise Exception(


### PR DESCRIPTION
Having a properly named files e.g.:

```sh
$ ls | grep \\.csv
rpma_fio_read_lat__WP_135_137__-20-12-14-110446.csv
rpma_fio_read_lat__WP_146_145__-20-12-14-113257.csv
rpma_fio_read_lat__WP_202_203__-20-12-14-092316.csv
```

you can easily generate:

```sh
$ ./csv_compare.py --output_layout lat_avg --output_with_tables --legend_from_file_names *.csv
```

a nifty comparison:
![compare](https://user-images.githubusercontent.com/3518702/103227925-e3425d80-492f-11eb-812d-9e093d80d35f.png)

Should play nicely with #691.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/pmem/rpma/695)
<!-- Reviewable:end -->
