### PR TITLE
tools: Disable StrictHostKeyChecking for scp/ssh

### DIFF
--- a/tools/ib_read.sh
+++ b/tools/ib_read.sh
@@ -206,9 +206,10 @@ function benchmark_one() {
 		esac
 
 		# run the server
-		sshpass -p "$REMOTE_PASS" -v ssh $REMOTE_USER@$SERVER_IP \
-			"numactl -N $REMOTE_JOB_NUMA ${IB_TOOL} $BS_OPT $QP_OPT $DP_OPT \
-			$REMOTE_AUX_PARAMS >> $LOG_ERR" 2>>$LOG_ERR &
+		sshpass -p "$REMOTE_PASS" -v ssh -o StrictHostKeyChecking=no \
+			$REMOTE_USER@$SERVER_IP "numactl -N $REMOTE_JOB_NUMA \
+			${IB_TOOL} $BS_OPT $QP_OPT $DP_OPT $REMOTE_AUX_PARAMS \
+			>> $LOG_ERR" 2>>$LOG_ERR &
 		sleep 1
 
 		# XXX --duration hides detailed statistics

--- a/tools/rpma_fio_bench.sh
+++ b/tools/rpma_fio_bench.sh
@@ -148,7 +148,8 @@ function benchmark_one() {
 		esac
 
 		# copy config to the server
-		sshpass -p "$REMOTE_PASS" scp ./fio_jobs/librpma${GPSPM}-server.fio \
+		sshpass -p "$REMOTE_PASS" scp -o StrictHostKeyChecking=no \
+			./fio_jobs/librpma${GPSPM}-server.fio \
 			$REMOTE_USER@$SERVER_IP:$REMOTE_JOB_PATH
 		# run the server
 		sshpass -p "$REMOTE_PASS" -v ssh $REMOTE_USER@$SERVER_IP \


### PR DESCRIPTION
sshpass doesn't work well when .ssh/known_hosts doesn't have the
related public key record(e.g. do scp/ssh for the first time).
For example:
\-------------------------------------------------------
Are you sure you want to continue connecting (yes/no/[fingerprint])?
SSHPASS detected host authentication prompt. Exiting.
Host key verification failed.
\-------------------------------------------------------

Make sshpass work well by disabling StrictHostKeyChecking.

Signed-off-by: Xiao Yang <yangx.jy@cn.fujitsu.com>

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/pmem/rpma/699)
<!-- Reviewable:end -->
