### PR TITLE
rpma: error message on pmem_map_file() failure

### DIFF
--- a/examples/03-read-to-persistent/client.c
+++ b/examples/03-read-to-persistent/client.c
@@ -70,8 +70,11 @@ main(int argc, char *argv[])
 		/* map the file */
 		mr_ptr = pmem_map_file(path, 0 /* len */, 0 /* flags */,
 				0 /* mode */, &mr_size, &is_pmem);
-		if (mr_ptr == NULL)
+		if (mr_ptr == NULL) {
+			(void) fprintf(stderr, "pmem_map_file() for %s "
+					"failed\n", path);
 			return -1;
+		}
 
 		/* pmem is expected */
 		if (!is_pmem) {

--- a/examples/04-write-to-persistent/client.c
+++ b/examples/04-write-to-persistent/client.c
@@ -85,8 +85,11 @@ main(int argc, char *argv[])
 		/* map the file */
 		mr_ptr = pmem_map_file(path, 0 /* len */, 0 /* flags */,
 				0 /* mode */, &mr_size, &is_pmem);
-		if (mr_ptr == NULL)
+		if (mr_ptr == NULL) {
+			(void) fprintf(stderr, "pmem_map_file() for %s "
+					"failed\n", path);
 			return -1;
+		}
 
 		/* pmem is expected */
 		if (!is_pmem) {

--- a/examples/04-write-to-persistent/server.c
+++ b/examples/04-write-to-persistent/server.c
@@ -59,8 +59,11 @@ main(int argc, char *argv[])
 		/* map the file */
 		mr_ptr = pmem_map_file(path, 0 /* len */, 0 /* flags */,
 				0 /* mode */, &mr_size, &is_pmem);
-		if (mr_ptr == NULL)
+		if (mr_ptr == NULL) {
+			(void) fprintf(stderr, "pmem_map_file() for %s "
+					"failed\n", path);
 			return -1;
+		}
 
 		/* pmem is expected */
 		if (!is_pmem) {

--- a/examples/05-flush-to-persistent/client.c
+++ b/examples/05-flush-to-persistent/client.c
@@ -78,8 +78,11 @@ main(int argc, char *argv[])
 		/* map the file */
 		mr_ptr = pmem_map_file(path, 0 /* len */, 0 /* flags */,
 				0 /* mode */, &mr_size, &is_pmem);
-		if (mr_ptr == NULL)
+		if (mr_ptr == NULL) {
+			(void) fprintf(stderr, "pmem_map_file() for %s "
+					"failed\n", path);
 			return -1;
+		}
 
 		/* pmem is expected */
 		if (!is_pmem) {

--- a/examples/05-flush-to-persistent/server.c
+++ b/examples/05-flush-to-persistent/server.c
@@ -59,8 +59,11 @@ main(int argc, char *argv[])
 		/* map the file */
 		mr_ptr = pmem_map_file(path, 0 /* len */, 0 /* flags */,
 				0 /* mode */, &mr_size, &is_pmem);
-		if (mr_ptr == NULL)
+		if (mr_ptr == NULL) {
+			(void) fprintf(stderr, "pmem_map_file() for %s "
+					"failed\n", path);
 			return -1;
+		}
 
 		/* pmem is expected */
 		if (!is_pmem) {

--- a/examples/07-atomic-write/server.c
+++ b/examples/07-atomic-write/server.c
@@ -70,8 +70,11 @@ main(int argc, char *argv[])
 		/* map the file */
 		mr_ptr = pmem_map_file(path, 0 /* len */, 0 /* flags */,
 				0 /* mode */, &mr_size, &is_pmem);
-		if (mr_ptr == NULL)
+		if (mr_ptr == NULL) {
+			(void) fprintf(stderr, "pmem_map_file() for %s "
+					"failed\n", path);
 			return -1;
+		}
 
 		/* pmem is expected */
 		if (!is_pmem) {

--- a/examples/09-flush-to-persistent-GPSPM/client.c
+++ b/examples/09-flush-to-persistent-GPSPM/client.c
@@ -91,8 +91,11 @@ main(int argc, char *argv[])
 		/* map the file */
 		mr_ptr = pmem_map_file(path, 0 /* len */, 0 /* flags */,
 				0 /* mode */, &mr_size, &is_pmem);
-		if (mr_ptr == NULL)
+		if (mr_ptr == NULL) {
+			(void) fprintf(stderr, "pmem_map_file() for %s "
+					"failed\n", path);
 			return -1;
+		}
 
 		/* pmem is expected */
 		if (!is_pmem) {

--- a/examples/09-flush-to-persistent-GPSPM/server.c
+++ b/examples/09-flush-to-persistent-GPSPM/server.c
@@ -67,8 +67,11 @@ main(int argc, char *argv[])
 		/* map the file */
 		mr_ptr = pmem_map_file(path, 0 /* len */, 0 /* flags */,
 				0 /* mode */, &mr_size, &is_pmem);
-		if (mr_ptr == NULL)
+		if (mr_ptr == NULL) {
+			(void) fprintf(stderr, "pmem_map_file() for %s "
+					"failed\n", path);
 			return -1;
+		}
 
 		/* pmem is expected */
 		if (!is_pmem) {


### PR DESCRIPTION
Explicit error message to stderr in case example could not
open pmem file.
Renaming dst_ptr -> mr_ptr for examples uniformity.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/pmem/rpma/708)
<!-- Reviewable:end -->
