### PR TITLE
tools: librpma_gpspm_server has to run as long as the client needs

### DIFF
--- a/tools/fio_jobs/librpma_gpspm-server.fio
+++ b/tools/fio_jobs/librpma_gpspm-server.fio
@@ -24,3 +24,7 @@ size=100MiB
 # It is set to a fixed value now, but there is a possibility to calculate it
 # at runtime (according to values suggested by protobuff-c).
 blocksize=1KiB
+
+# The client will terminate the server when the client will end up its job.
+time_based
+runtime=365d


### PR DESCRIPTION
Ref: pmem/fio#76

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/pmem/rpma/712)
<!-- Reviewable:end -->
