### PR TITLE
tools: add further sections to the report

### DIFF
--- a/tools/templates/.gitignore
+++ b/tools/templates/.gitignore
@@ -1,0 +1,2 @@
+*.md
+!report.md

--- a/tools/templates/audience.md.template
+++ b/tools/templates/audience.md.template
@@ -1,0 +1,5 @@
+## Audience and Purpose
+
+This report is intended for people who are interested in evaluating RPMA performance.
+
+The purpose of the report is not to imply a single "correct" approach, but rather to provide a baseline of well-tested configurations and procedures that produce repeatable results. This report can also be viewed as information regarding best-known methods/practices when testing the RPMA performance.

--- a/tools/templates/authors.md.template
+++ b/tools/templates/authors.md.template
@@ -1,0 +1,3 @@
+**Performed by**:
+
+- Name Surname (name.surname@company.com)

--- a/tools/templates/bios.md.template
+++ b/tools/templates/bios.md.template
@@ -1,0 +1,12 @@
+### BIOS Settings
+
+|Applied procedure|[Details](https://domain/url)|
+|---|---|
+|Repository|<i>https://github.com/domain/url</i>|
+|Version|<i>hash</i>|
+
+Excerpt:
+
+|Item|Description|
+|---|---|
+|<i>Key</i>|<i>value</i>|

--- a/tools/templates/configuration_common.md.template
+++ b/tools/templates/configuration_common.md.template
@@ -1,0 +1,16 @@
+### Common Configuration (both initiator and target)
+
+|Item|Description|
+|---|---|
+|Server Platform|<i>The name of the platform</i>|
+|CPU|<i>Producer&reg; Name A.BGHz</i>|
+|Memory|<i>Cx DGB Producer&reg; Model, DDRE, FMT/s</i><br/><i>Gx HGB Producer&reg; Model Persistent Memory, IMT/s</i><br/><i>Total of JGB DRAM + KGB PMem</i><br/>|
+|Operating System|Distribution Linux L.M|
+|BIOS|<i>N</i>|
+|Linux kernel version|<i>version-patch.architecture</i>|
+|librpma|<i>major.minor-patch-hash</i>|
+|libibverbs|<i>major.minor-patch-hash</i>|
+|libpmem|<i>major.minor-patch-hash</i>|
+|FIO version|<i>fio-major.minor-patch-hash</i>|
+|NIC|<i>Ox PGbps Producer&reg; Model NIC</i>|
+|OFED|<i>major.minor-patch-hash</i>|

--- a/tools/templates/configuration_target.md.template
+++ b/tools/templates/configuration_target.md.template
@@ -1,0 +1,8 @@
+### Target Configuration
+
+Description of applied configuration.
+
+|Applied procedure|[Details](https://domain/url)|
+|---|---|
+|Repository|https://github.com/domain/url|
+|Version|hash|

--- a/tools/templates/report.md
+++ b/tools/templates/report.md
@@ -1,1 +1,17 @@
 # RPMA - Performance Report - Release {{release}}
+
+**Testing Date**: {{test_date}}
+
+{{authors}}
+
+{{audience}}
+
+## Test Setup
+
+{{configuration_common}}
+
+{{configuration_target}}
+
+{{bios}}
+
+{{security}}

--- a/tools/templates/security.md.template
+++ b/tools/templates/security.md.template
@@ -1,0 +1,3 @@
+### Kernel & BIOS spectre-meltdown information
+
+<i>Elaborate on the kernel and BIOS security.</i>


### PR DESCRIPTION
New sections are:
- authors
- audience
- configuration_common
- configuration_target
- bios
- security

Using the following command:

```sh
$ ./create_report.py --report_dir report_trial/ --release 0.9 --test_date "December 2020"
```
initially, you will get the following result:

![image](https://user-images.githubusercontent.com/3518702/105756064-6c0ee200-5f4c-11eb-89d1-ed2c3947fa6a.png)

If you just copy the predefined *.md.template files:

```sh
$ for t in templates/*.template; do cp $t ${t//\.template/}; done
```

place holders will take their place:

![image](https://user-images.githubusercontent.com/3518702/105756827-6e257080-5f4d-11eb-8481-305baccf6472.png)

which when filled with actual content will look similar to the following pictures:

![image](https://user-images.githubusercontent.com/3518702/105755794-16d2d080-5f4c-11eb-9433-70b5b1eb1536.png)
![image](https://user-images.githubusercontent.com/3518702/105755865-2a7e3700-5f4c-11eb-9e80-9b9370e619be.png)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/pmem/rpma/764)
<!-- Reviewable:end -->
