### PR TITLE
common: remove unnecessary prefix in example executable name

### DIFF
--- a/examples/02-read-to-volatile/CMakeLists.txt
+++ b/examples/02-read-to-volatile/CMakeLists.txt
@@ -27,12 +27,12 @@ link_directories(${LIBRPMA_LIBRARY_DIRS})
 
 function(add_example name)
 	set(srcs ${ARGN})
-	add_executable(example-${name} ${srcs})
-	target_include_directories(example-${name}
+	add_executable(${name} ${srcs})
+	target_include_directories(${name}
 		PUBLIC
 			${LIBRPMA_INCLUDE_DIRS}
 			../common)
-	target_link_libraries(example-${name} rpma ${LIBRT_LIBRARIES})
+	target_link_libraries(${name} rpma ${LIBRT_LIBRARIES})
 endfunction()
 
 add_example(server server.c ../common/common-conn.c)

--- a/examples/03-read-to-persistent/CMakeLists.txt
+++ b/examples/03-read-to-persistent/CMakeLists.txt
@@ -33,18 +33,18 @@ link_directories(${LIBRPMA_LIBRARY_DIRS})
 
 function(add_example name)
 	set(srcs ${ARGN})
-	add_executable(example-${name} ${srcs})
-	target_include_directories(example-${name}
+	add_executable(${name} ${srcs})
+	target_include_directories(${name}
 		PRIVATE
 			${LIBRPMA_INCLUDE_DIRS}
 			../common)
-	target_link_libraries(example-${name} rpma ${LIBRT_LIBRARIES})
+	target_link_libraries(${name} rpma ${LIBRT_LIBRARIES})
 
 	if(LIBPMEM_FOUND)
-		target_include_directories(example-${name}
+		target_include_directories(${name}
 			PRIVATE ${LIBPMEM_INCLUDE_DIRS})
-		target_link_libraries(example-${name} ${LIBPMEM_LIBRARIES})
-		target_compile_definitions(example-${name}
+		target_link_libraries(${name} ${LIBPMEM_LIBRARIES})
+		target_compile_definitions(${name}
 			PRIVATE USE_LIBPMEM)
 	endif()
 endfunction()

--- a/examples/04-write-to-persistent/CMakeLists.txt
+++ b/examples/04-write-to-persistent/CMakeLists.txt
@@ -33,18 +33,18 @@ link_directories(${LIBRPMA_LIBRARY_DIRS})
 
 function(add_example name)
 	set(srcs ${ARGN})
-	add_executable(example-${name} ${srcs})
-	target_include_directories(example-${name}
+	add_executable(${name} ${srcs})
+	target_include_directories(${name}
 		PRIVATE
 			${LIBRPMA_INCLUDE_DIRS}
 			../common)
-	target_link_libraries(example-${name} rpma ${LIBRT_LIBRARIES})
+	target_link_libraries(${name} rpma ${LIBRT_LIBRARIES})
 
 	if(LIBPMEM_FOUND)
-		target_include_directories(example-${name}
+		target_include_directories(${name}
 			PRIVATE ${LIBPMEM_INCLUDE_DIRS})
-		target_link_libraries(example-${name} ${LIBPMEM_LIBRARIES})
-		target_compile_definitions(example-${name}
+		target_link_libraries(${name} ${LIBPMEM_LIBRARIES})
+		target_compile_definitions(${name}
 			PRIVATE USE_LIBPMEM)
 	endif()
 endfunction()

--- a/examples/05-flush-to-persistent/CMakeLists.txt
+++ b/examples/05-flush-to-persistent/CMakeLists.txt
@@ -33,18 +33,18 @@ link_directories(${LIBRPMA_LIBRARY_DIRS})
 
 function(add_example name)
 	set(srcs ${ARGN})
-	add_executable(example-${name} ${srcs})
-	target_include_directories(example-${name}
+	add_executable(${name} ${srcs})
+	target_include_directories(${name}
 		PRIVATE
 			${LIBRPMA_INCLUDE_DIRS}
 			../common)
-	target_link_libraries(example-${name} rpma ${LIBRT_LIBRARIES})
+	target_link_libraries(${name} rpma ${LIBRT_LIBRARIES})
 
 	if(LIBPMEM_FOUND)
-		target_include_directories(example-${name}
+		target_include_directories(${name}
 			PRIVATE ${LIBPMEM_INCLUDE_DIRS})
-		target_link_libraries(example-${name} ${LIBPMEM_LIBRARIES})
-		target_compile_definitions(example-${name}
+		target_link_libraries(${name} ${LIBPMEM_LIBRARIES})
+		target_compile_definitions(${name}
 			PRIVATE USE_LIBPMEM)
 	endif()
 endfunction()

--- a/examples/06-multiple-connections/CMakeLists.txt
+++ b/examples/06-multiple-connections/CMakeLists.txt
@@ -35,18 +35,18 @@ link_directories(${LIBRPMA_LIBRARY_DIRS})
 
 function(add_example name)
 	set(srcs ${ARGN})
-	add_executable(example-${name} ${srcs})
-	target_include_directories(example-${name}
+	add_executable(${name} ${srcs})
+	target_include_directories(${name}
 		PRIVATE
 			${LIBRPMA_INCLUDE_DIRS}
 			../common)
-	target_link_libraries(example-${name} rpma ${LIBRT_LIBRARIES})
+	target_link_libraries(${name} rpma ${LIBRT_LIBRARIES})
 
 	if(LIBPMEM_FOUND)
-		target_include_directories(example-${name}
+		target_include_directories(${name}
 			PRIVATE ${LIBPMEM_INCLUDE_DIRS})
-		target_link_libraries(example-${name} ${LIBPMEM_LIBRARIES})
-		target_compile_definitions(example-${name}
+		target_link_libraries(${name} ${LIBPMEM_LIBRARIES})
+		target_compile_definitions(${name}
 			PRIVATE USE_LIBPMEM)
 	endif()
 endfunction()

--- a/examples/07-atomic-write/CMakeLists.txt
+++ b/examples/07-atomic-write/CMakeLists.txt
@@ -35,18 +35,18 @@ link_directories(${LIBRPMA_LIBRARY_DIRS})
 
 function(add_example name)
 	set(srcs ${ARGN})
-	add_executable(example-${name} ${srcs})
-	target_include_directories(example-${name}
+	add_executable(${name} ${srcs})
+	target_include_directories(${name}
 		PRIVATE
 			${LIBRPMA_INCLUDE_DIRS}
 			../common)
-	target_link_libraries(example-${name} rpma ${LIBRT_LIBRARIES})
+	target_link_libraries(${name} rpma ${LIBRT_LIBRARIES})
 
 	if(LIBPMEM_FOUND)
-		target_include_directories(example-${name}
+		target_include_directories(${name}
 			PRIVATE ${LIBPMEM_INCLUDE_DIRS})
-		target_link_libraries(example-${name} ${LIBPMEM_LIBRARIES})
-		target_compile_definitions(example-${name}
+		target_link_libraries(${name} ${LIBPMEM_LIBRARIES})
+		target_compile_definitions(${name}
 			PRIVATE USE_LIBPMEM)
 	endif()
 endfunction()

--- a/examples/08-messages-ping-pong/CMakeLists.txt
+++ b/examples/08-messages-ping-pong/CMakeLists.txt
@@ -31,13 +31,13 @@ link_directories(${LIBRPMA_LIBRARY_DIRS} ${LIBIBVERBS_LIBRARY_DIRS})
 
 function(add_example name)
 	set(srcs ${ARGN})
-	add_executable(example-${name} ${srcs})
-	target_include_directories(example-${name}
+	add_executable(${name} ${srcs})
+	target_include_directories(${name}
 		PRIVATE
 			${LIBRPMA_INCLUDE_DIRS}
 			${LIBIBVERBS_INCLUDE_DIRS}
 			../common)
-	target_link_libraries(example-${name} rpma ${LIBIBVERBS_LIBRARIES} ${LIBRT_LIBRARIES})
+	target_link_libraries(${name} rpma ${LIBIBVERBS_LIBRARIES} ${LIBRT_LIBRARIES})
 endfunction()
 
 add_example(server server.c ../common/common-conn.c)

--- a/examples/09-flush-to-persistent-GPSPM/CMakeLists.txt
+++ b/examples/09-flush-to-persistent-GPSPM/CMakeLists.txt
@@ -37,24 +37,24 @@ link_directories(${LIBRPMA_LIBRARY_DIRS})
 
 function(add_example name)
 	set(srcs ${ARGN})
-	add_executable(example-${name} ${srcs})
-	target_include_directories(example-${name}
+	add_executable(${name} ${srcs})
+	target_include_directories(${name}
 		PRIVATE
 			${LIBRPMA_INCLUDE_DIRS}
 			../common)
-	target_link_libraries(example-${name} rpma ${LIBRT_LIBRARIES})
+	target_link_libraries(${name} rpma ${LIBRT_LIBRARIES})
 
 	if(LIBPMEM_FOUND)
-		target_include_directories(example-${name}
+		target_include_directories(${name}
 			PRIVATE ${LIBPMEM_INCLUDE_DIRS})
-		target_link_libraries(example-${name} ${LIBPMEM_LIBRARIES})
-		target_compile_definitions(example-${name}
+		target_link_libraries(${name} ${LIBPMEM_LIBRARIES})
+		target_compile_definitions(${name}
 			PRIVATE USE_LIBPMEM)
 	endif()
 	
-	target_include_directories(example-${name}
+	target_include_directories(${name}
 		PRIVATE ${LIBPROTOBUFC_INCLUDE_DIRS})
-	target_link_libraries(example-${name} ${LIBPROTOBUFC_LIBRARIES})
+	target_link_libraries(${name} ${LIBPROTOBUFC_LIBRARIES})
 endfunction()
 
 add_example(server server.c GPSPM_flush.pb-c.c ../common/common-conn.c)


### PR DESCRIPTION
According to the readme, examples' executable names shall be
either client or server, without 'example-' prefix

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/pmem/rpma/768)
<!-- Reviewable:end -->
