### PR TITLE
tools: report_bench.sh to all benchmarks required for the report

### DIFF
--- a/tools/.gitignore
+++ b/tools/.gitignore
@@ -1,3 +1,4 @@
 *.csv
 *.png
 report_*
+!report_bench.sh

--- a/tools/report_bench.sh
+++ b/tools/report_bench.sh
@@ -1,0 +1,41 @@
+#!/bin/bash
+#
+# SPDX-License-Identifier: BSD-3-Clause
+# Copyright 2021, Intel Corporation
+#
+
+#
+# report_bench.sh -- XXX (EXPERIMENTAL)
+#
+
+function usage()
+{
+	echo "Error: $1"
+	echo
+	echo "Usage: $0 <server_ip>"
+    echo
+	echo "export REMOTE_JOB_MEM_PATH=/path/to/mem (required)"
+	echo
+	exit 1
+}
+
+if [ "$#" -lt 1 ]; then
+	usage "Too few arguments"
+elif [ -z "$REMOTE_JOB_MEM_PATH" ]; then
+	usage "REMOTE_JOB_MEM_PATH not set"
+fi
+
+# export is required to access these variables from a subshell
+export SERVER_IP=$1
+export PMEM=$REMOTE_JOB_MEM_PATH
+export DRAM="malloc"
+
+echo "READ LAT"
+# The subshell and -x is used as cheap logging
+(set -x; \
+    ./ib_read.sh $SERVER_IP lat &&
+    REMOTE_JOB_MEM_PATH=$DRAM ./rpma_fio_bench.sh $SERVER_IP apm read lat && \
+    REMOTE_JOB_MEM_PATH=$PMEM ./rpma_fio_bench.sh $SERVER_IP apm randread lat
+)
+
+# XXX To be continued...


### PR DESCRIPTION
Since `rpma_fio_bench.sh` does a lot more than it is specified for the upcoming report format I have created a separate script doing just that - runs all benchmarks required to prepare the report. All comments are very welcome.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/pmem/rpma/781)
<!-- Reviewable:end -->
