### PR TITLE
examples: fix compilation error of 01-example

### DIFF
--- a/examples/01-connection/CMakeLists.txt
+++ b/examples/01-connection/CMakeLists.txt
@@ -1,6 +1,6 @@
 #
 # SPDX-License-Identifier: BSD-3-Clause
-# Copyright 2020, Intel Corporation
+# Copyright 2020-2021, Intel Corporation
 #
 
 cmake_minimum_required(VERSION 3.3)
@@ -13,6 +13,8 @@ set(CMAKE_MODULE_PATH ${CMAKE_MODULE_PATH}
 include(${CMAKE_SOURCE_DIR}/../../cmake/functions.cmake)
 # set LIBRT_LIBRARIES if linking with librt is required
 check_if_librt_is_required()
+
+set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -std=gnu99")
 
 find_package(PkgConfig QUIET)
 


### PR DESCRIPTION
It fixes the following compilation error:

```
/rpma/examples/01-connection/client.c: In function 'main':
/rpma/examples/01-connection/client.c:72:2: error: 'for' loop \
  initial declarations are only allowed in C99 mode
  for (int retry = 0; retry < MAX_RETRY; retry++) {
  ^
/rpma/examples/01-connection/client.c:72:2: note: use option \
  -std=c99 or -std=gnu99 to compile your code
make[2]: *** [CMakeFiles/client.dir/client.c.o] Error 1
```

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/pmem/rpma/822)
<!-- Reviewable:end -->
