### PR TITLE
tools: rename OFED -> rdma-core and get rid of the irrelevant NIC

### DIFF
--- a/tools/templates/configuration_common.md.template
+++ b/tools/templates/configuration_common.md.template
@@ -15,5 +15,4 @@
 |libibverbs|<i>major.minor-patch-hash</i>|
 |libpmem|<i>major.minor-patch-hash</i>|
 |FIO version|<i>fio-major.minor-patch-hash</i>|
-|NIC|<i>Ox PGbps Producer&reg; Model NIC</i>|
-|OFED|<i>major.minor-patch-hash</i>|
+|rdma-core|<i>major.minor-patch-hash</i>|


### PR DESCRIPTION


<!-- Reviewable:start -->
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/pmem/rpma/829)
<!-- Reviewable:end -->
