### PR TITLE
rpma: fix the implicit conversion error

### DIFF
--- a/src/conn.c
+++ b/src/conn.c
@@ -539,7 +539,8 @@ rpma_conn_completion_get(struct rpma_conn *conn,
 	cmpl->op_context = (void *)wc.wr_id;
 	cmpl->byte_len = wc.byte_len;
 	cmpl->op_status = wc.status;
-	cmpl->flags = wc.wc_flags;
+	/* 'wc_flags' is of 'int' type in older versions of libibverbs */
+	cmpl->flags = (unsigned)wc.wc_flags;
 
 	/*
 	 * The value of imm_data can only be placed in the receive Completion

--- a/tests/unit/conn/conn-completion_get.c
+++ b/tests/unit/conn/conn-completion_get.c
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: BSD-3-Clause
-/* Copyright 2020, Intel Corporation */
+/* Copyright 2020-2021, Intel Corporation */
 
 /*
  * conn-completion_get.c -- the rpma_conn_completion_get() unit tests
@@ -193,7 +193,11 @@ completion_get__success(void **cstate_ptr)
 		wc.byte_len = MOCK_LEN;
 		wc.status = MOCK_WC_STATUS;
 		if (flags[i] == IBV_WC_WITH_IMM) {
-			wc.wc_flags = flags[i];
+			/*
+			 * 'wc_flags' is of 'int' type
+			 * in older versions of libibverbs.
+			 */
+			wc.wc_flags = (typeof(wc.wc_flags))flags[i];
 			wc.imm_data = htonl(MOCK_IMM_DATA);
 		}
 		will_return(poll_cq, &wc);


### PR DESCRIPTION
`wc_flags` is of `int` type in older versions of libibverbs.
This patch fixes the following two errors:

```
/rpma/src/conn.c:542:19: error: implicit conversion changes \
   signedness: 'int' to 'unsigned int' [-Werror,-Wsign-conversion]
        cmpl->flags = wc.wc_flags;
                    ~ ~~~^~~~~~~~
1 error generated.
make[2]: *** [src/CMakeFiles/rpma.dir/conn.c.o] Error 1
```
See: 
https://github.com/ldorau/rpma/actions/runs/538381902 - 14 builds failed

and:

```
/rpma/tests/unit/conn/conn-completion_get.c:196:18: \
  error: implicit conversion changes signedness: \
  'unsigned int' to 'int' [-Werror,-Wsign-conversion]
                        wc.wc_flags = flags[i];
                                    ~ ^~~~~~~~
1 error generated.
```

See: 
https://github.com/ldorau/rpma/actions/runs/538410281 - 14 builds failed.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/pmem/rpma/851)
<!-- Reviewable:end -->
