### PR TITLE
examples: link 10-send-with-imm example with librt for glibc<2.17

### DIFF
--- a/examples/10-send-with-imm/CMakeLists.txt
+++ b/examples/10-send-with-imm/CMakeLists.txt
@@ -1,6 +1,7 @@
 #
 # SPDX-License-Identifier: BSD-3-Clause
 # Copyright (c) 2020 Fujitsu
+# Copyright 2021, Intel Corporation
 #
 
 cmake_minimum_required(VERSION 3.3)
@@ -37,7 +38,7 @@ function(add_example name)
 			${LIBRPMA_INCLUDE_DIRS}
 			${LIBIBVERBS_INCLUDE_DIRS}
 			../common)
-	target_link_libraries(${name} rpma ${LIBIBVERBS_LIBRARIES})
+	target_link_libraries(${name} rpma ${LIBIBVERBS_LIBRARIES} ${LIBRT_LIBRARIES})
 endfunction()
 
 add_example(server server.c ../common/common-conn.c)


### PR DESCRIPTION
`clock_gettime()` requires linking with `librt` for `glibc` versions before 2.17.
It fixes the following error:

```
/usr/lib64/librpma.so: undefined reference to `clock_gettime'
collect2: ld returned 1 exit status
/make[2]: *** [server] Error 1
```
See: https://github.com/ldorau/rpma/actions/runs/538482802 - 2 builds failed

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/pmem/rpma/853)
<!-- Reviewable:end -->
