### PR TITLE
tools: fix typos in tc1_read.md and tc2_write.md

### DIFF
--- a/tools/templates/tc1_read.md
+++ b/tools/templates/tc1_read.md
@@ -16,7 +16,7 @@ Comparing the latency of `rpma_read()` from PMem on **the RPMA Target** to the l
 
 <h3 id="read-bw">Test Case 1B: Read from PMem: Bandwidth</h3>
 
-Comparing the bandwidth of `rpma_read()` from PMem on **the RPMA Target** to the bandwidth of `rpma_read()` from DRAM on **the RPMA Taraget** using the `ib_read_bw` as the baseline.
+Comparing the bandwidth of `rpma_read()` from PMem on **the RPMA Target** to the bandwidth of `rpma_read()` from DRAM on **the RPMA Target** using the `ib_read_bw` as the baseline.
 
 {{tc\_read\_bw\_config}}
 

--- a/tools/templates/tc2_write.md
+++ b/tools/templates/tc2_write.md
@@ -1,7 +1,7 @@
 Benchmarking two ways of writing data persistently to **the RPMA Target**: *Appliance Persistency Method* (**APM**) and *General Purpose Persistency Method* (**GPSPM**). Where:
 
 - **APM** uses `rpma_flush()` following a sequence `rpma_write()` operations to provide the remote persistency. This method requires **the RPMA Target** to be capable of *Direct Write to PMem* (for details please see [Direct Write to PMem][direct-write-to-pmem]).
-- **GPSPM** uses `rpma_send()` and `rpma_recv()` operations for sending requests to **the RPMA Target** to assure persistency of the data written using `rpma_write()`. **The RPMA Taget** has to provide a thread handling these requests e.g. persisting the data using the `pmem_persist()` operation. When the persistency of the data is assured the response is sent back using also `rpma_send()` and `rpma_recv()`.
+- **GPSPM** uses `rpma_send()` and `rpma_recv()` operations for sending requests to **the RPMA Target** to assure persistency of the data written using `rpma_write()`. **The RPMA Target** has to provide a thread handling these requests e.g. persisting the data using the `pmem_persist()` operation. When the persistency of the data is assured the response is sent back using also `rpma_send()` and `rpma_recv()`.
 
 For more details on **APM** and **GPSPM** please see: "[Persistent Memory Replication Over Traditional RDMA Part 1: Understanding Remote Persistent Memory][rpmem-wp]" Chapter "Two Remote Replication Methods".
 


### PR DESCRIPTION
Fix one typo in tools/templates/tc1_read.md:19:
- 'Taraget' ==> 'Target'

and another one in tools/templates/tc2_write.md:4
- 'Taget' ==> 'Target'

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/pmem/rpma/854)
<!-- Reviewable:end -->
