### PR TITLE
common: fix name of powertools repo in CentOS-8

### DIFF
--- a/utils/docker/images/Dockerfile.centos-8
+++ b/utils/docker/images/Dockerfile.centos-8
@@ -1,6 +1,6 @@
 #
 # SPDX-License-Identifier: BSD-3-Clause
-# Copyright 2020, Intel Corporation
+# Copyright 2020-2021, Intel Corporation
 #
 
 #
@@ -15,7 +15,7 @@ MAINTAINER tomasz.gromadzki@intel.com
 RUN dnf update -y
 RUN dnf install -y epel-release
 RUN dnf install -y 'dnf-command(config-manager)'
-RUN dnf config-manager --set-enabled PowerTools
+RUN dnf config-manager --set-enabled powertools
 
 # base deps
 ENV BASE_DEPS "\


### PR DESCRIPTION
Replace `PowerTools` with `powertools` in the CentOS-8 docker file.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/pmem/rpma/859)
<!-- Reviewable:end -->
