### PR TITLE
rpma: mmap() memory for rpma_mr_reg() in rpma_flush_apm_new()

### DIFF
--- a/src/flush.h
+++ b/src/flush.h
@@ -1,5 +1,5 @@
 /* SPDX-License-Identifier: BSD-3-Clause */
-/* Copyright 2020, Intel Corporation */
+/* Copyright 2020-2021, Intel Corporation */
 
 /*
  * flush.h -- librpma flush-related internal definitions
@@ -24,7 +24,7 @@ struct rpma_flush {
  * ERRORS
  * rpma_flush_new() can fail with the following errors:
  *
- * - RPMA_E_NOMEM - out of memory
+ * - RPMA_E_NOMEM - out of memory (mmap() failed)
  * - RPMA_E_PROVIDER - sysconf() or ibv_reg_mr() failed
  */
 int rpma_flush_new(struct rpma_peer *peer, struct rpma_flush **flush_ptr);
@@ -33,7 +33,8 @@ int rpma_flush_new(struct rpma_peer *peer, struct rpma_flush **flush_ptr);
  * ERRORS
  * rpma_flush_delete() can fail with the following error:
  *
- * - RPMA_E_PROVIDER ibv_dereg_mr() failed
+ * - RPMA_E_PROVIDER - ibv_dereg_mr() failed
+ * - RPMA_E_INVAL - munmap() failed
  */
 int rpma_flush_delete(struct rpma_flush **flush_ptr);
 

--- a/src/include/librpma.h
+++ b/src/include/librpma.h
@@ -1637,7 +1637,7 @@ int rpma_conn_disconnect(struct rpma_conn *conn);
  *
  * ERRORS
  * rpma_conn_delete() can fail with the following errors:
- * - RPMA_E_INVAL - conn_ptr is NULL
+ * - RPMA_E_INVAL - conn_ptr is NULL or munmap() failed
  * - RPMA_E_PROVIDER - ibv_destroy_cq() or rdma_destroy_id() failed
  *
  * SEE ALSO

--- a/tests/integration/common/mocks.c
+++ b/tests/integration/common/mocks.c
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: BSD-3-Clause
-/* Copyright 2020, Intel Corporation */
+/* Copyright 2020-2021, Intel Corporation */
 
 /*
  * mocks.c -- common mocks for integration tests
@@ -7,6 +7,8 @@
 
 #include <string.h>
 #include <librpma.h>
+#include <sys/types.h>
+#include <sys/mman.h>
 
 #include "cmocka_headers.h"
 #include "conn_cfg.h"
@@ -755,6 +757,50 @@ create_descriptor(void *desc,
 	buff += sizeof(uint32_t);
 
 	*((uint8_t *)buff) = usage;
+
+	return 0;
+}
+
+/*
+ * __wrap_mmap -- mmap() mock
+ */
+void *
+__wrap_mmap(void *__addr, size_t __len, int __prot,
+		int __flags, int __fd, off_t __offset)
+{
+	void *ret = mock_type(void *);
+	if (ret != (void *)MOCK_OK)
+		return MAP_FAILED;
+
+	struct mmap_args *args = mock_type(struct mmap_args *);
+
+	void *memptr = __real__test_malloc(__len);
+
+	/*
+	 * Save the address and length of the allocated memory
+	 * in order to verify it later.
+	 */
+	args->addr = memptr;
+	args->len = __len;
+
+	return memptr;
+}
+
+/*
+ * __wrap_munmap -- munmap() mock
+ */
+int
+__wrap_munmap(void *__addr, size_t __len)
+{
+	struct mmap_args *args = mock_type(struct mmap_args *);
+	assert_ptr_equal(__addr, args->addr);
+	assert_int_equal(__len, args->len);
+
+	test_free(__addr);
+
+	errno = mock_type(int);
+	if (errno)
+		return -1;
 
 	return 0;
 }

--- a/tests/integration/common/mocks.h
+++ b/tests/integration/common/mocks.h
@@ -1,5 +1,5 @@
 /* SPDX-License-Identifier: BSD-3-Clause */
-/* Copyright 2020, Intel Corporation */
+/* Copyright 2020-2021, Intel Corporation */
 
 /*
  * mocks.h -- common mocks for integration tests
@@ -60,6 +60,11 @@ extern struct ibv_odp_caps Ibv_odp_capable_caps;
 
 struct posix_memalign_args {
 	void *ptr;
+};
+
+struct mmap_args {
+	void *addr;
+	size_t len;
 };
 
 #ifdef ON_DEMAND_PAGING_SUPPORTED

--- a/tests/integration/example-01-connection/CMakeLists.txt
+++ b/tests/integration/example-01-connection/CMakeLists.txt
@@ -1,6 +1,6 @@
 #
 # SPDX-License-Identifier: BSD-3-Clause
-# Copyright 2020, Intel Corporation
+# Copyright 2020-2021, Intel Corporation
 #
 
 include(../../cmake/ctest_helpers.cmake)
@@ -34,7 +34,7 @@ target_include_directories(${TARGET} PRIVATE
 
 set_target_properties(${TARGET}
        PROPERTIES
-       LINK_FLAGS "-Wl,--wrap=_test_malloc,--wrap=posix_memalign,--wrap=fprintf")
+       LINK_FLAGS "-Wl,--wrap=_test_malloc,--wrap=mmap,--wrap=munmap,--wrap=fprintf")
 
 target_compile_definitions(${TARGET}
        PUBLIC TEST_MOCK_MAIN

--- a/tests/integration/example-01-connection/example-01-connection.c
+++ b/tests/integration/example-01-connection/example-01-connection.c
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: BSD-3-Clause
-/* Copyright 2020, Intel Corporation */
+/* Copyright 2020-2021, Intel Corporation */
 
 /*
  * example-01-connection.c -- connection integration tests
@@ -92,13 +92,14 @@ test_client__success(void **unused)
 	expect_value(rdma_migrate_id, channel, MOCK_EVCH);
 	will_return(rdma_migrate_id, MOCK_OK);
 
-	struct posix_memalign_args allocated_raw = {0};
-	will_return(__wrap_posix_memalign, &allocated_raw);
+	struct mmap_args allocated_raw = {0};
+	will_return(__wrap_mmap, MOCK_OK);
+	will_return(__wrap_mmap, &allocated_raw);
 
 	expect_value(ibv_reg_mr, pd, MOCK_IBV_PD);
 	expect_value(ibv_reg_mr, length, MOCK_RAW_SIZE);
 	expect_value(ibv_reg_mr, access, IBV_ACCESS_LOCAL_WRITE);
-	will_return(ibv_reg_mr, &allocated_raw.ptr);
+	will_return(ibv_reg_mr, &allocated_raw.addr);
 	will_return(ibv_reg_mr, MOCK_MR);
 
 	expect_value(rdma_connect, id, &id);
@@ -133,6 +134,8 @@ test_client__success(void **unused)
 	/* configure mocks for rpma_conn_delete() */
 	expect_value(ibv_dereg_mr, mr, MOCK_MR);
 	will_return(ibv_dereg_mr, MOCK_OK);
+	will_return(__wrap_munmap, &allocated_raw);
+	will_return(__wrap_munmap, MOCK_OK);
 
 	expect_value(rdma_destroy_qp, id, &id);
 
@@ -244,13 +247,14 @@ test_server__success(void **unused)
 	expect_value(rdma_migrate_id, channel, MOCK_EVCH);
 	will_return(rdma_migrate_id, MOCK_OK);
 
-	struct posix_memalign_args allocated_raw = {0};
-	will_return(__wrap_posix_memalign, &allocated_raw);
+	struct mmap_args allocated_raw = {0};
+	will_return(__wrap_mmap, MOCK_OK);
+	will_return(__wrap_mmap, &allocated_raw);
 
 	expect_value(ibv_reg_mr, pd, MOCK_IBV_PD);
 	expect_value(ibv_reg_mr, length, MOCK_RAW_SIZE);
 	expect_value(ibv_reg_mr, access, IBV_ACCESS_LOCAL_WRITE);
-	will_return(ibv_reg_mr, &allocated_raw.ptr);
+	will_return(ibv_reg_mr, &allocated_raw.addr);
 	will_return(ibv_reg_mr, MOCK_MR);
 
 	/* configure mocks for rpma_conn_next_event() */
@@ -283,6 +287,8 @@ test_server__success(void **unused)
 	/* configure mocks for rpma_conn_delete() */
 	expect_value(ibv_dereg_mr, mr, MOCK_MR);
 	will_return(ibv_dereg_mr, MOCK_OK);
+	will_return(__wrap_munmap, &allocated_raw);
+	will_return(__wrap_munmap, MOCK_OK);
 
 	expect_value(rdma_destroy_qp, id, &id);
 

--- a/tests/integration/example-02-read-to-volatile/CMakeLists.txt
+++ b/tests/integration/example-02-read-to-volatile/CMakeLists.txt
@@ -1,6 +1,6 @@
 #
 # SPDX-License-Identifier: BSD-3-Clause
-# Copyright 2020, Intel Corporation
+# Copyright 2020-2021, Intel Corporation
 #
 
 include(../../cmake/ctest_helpers.cmake)
@@ -35,7 +35,7 @@ target_include_directories(${TARGET} PRIVATE
 
 set_target_properties(${TARGET}
        PROPERTIES
-       LINK_FLAGS "-Wl,--wrap=_test_malloc,--wrap=posix_memalign,--wrap=fprintf")
+       LINK_FLAGS "-Wl,--wrap=_test_malloc,--wrap=posix_memalign,--wrap=fprintf,--wrap=mmap,--wrap=munmap")
 
 target_compile_definitions(${TARGET}
        PUBLIC TEST_MOCK_MAIN

--- a/tests/integration/example-02-read-to-volatile/example-02-read-to-volatile.c
+++ b/tests/integration/example-02-read-to-volatile/example-02-read-to-volatile.c
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: BSD-3-Clause
-/* Copyright 2020, Intel Corporation */
+/* Copyright 2020-2021, Intel Corporation */
 
 /*
  * example-02-read-to-volatile.c -- 'read to volatile' integration tests
@@ -107,13 +107,14 @@ test_client__success(void **unused)
 	expect_value(rdma_migrate_id, channel, MOCK_EVCH);
 	will_return(rdma_migrate_id, MOCK_OK);
 
-	struct posix_memalign_args allocated_raw = {0};
-	will_return(__wrap_posix_memalign, &allocated_raw);
+	struct mmap_args allocated_raw = {0};
+	will_return(__wrap_mmap, MOCK_OK);
+	will_return(__wrap_mmap, &allocated_raw);
 
 	expect_value(ibv_reg_mr, pd, MOCK_IBV_PD);
 	expect_value(ibv_reg_mr, length, MOCK_RAW_SIZE);
 	expect_value(ibv_reg_mr, access, IBV_ACCESS_LOCAL_WRITE);
-	will_return(ibv_reg_mr, &allocated_raw.ptr);
+	will_return(ibv_reg_mr, &allocated_raw.addr);
 	will_return(ibv_reg_mr, MOCK_MR_RAW);
 
 	expect_value(rdma_connect, id, &Cm_id);
@@ -180,6 +181,8 @@ test_client__success(void **unused)
 	/* configure mocks for rpma_conn_delete() */
 	expect_value(ibv_dereg_mr, mr, MOCK_MR_RAW);
 	will_return(ibv_dereg_mr, MOCK_OK);
+	will_return(__wrap_munmap, &allocated_raw);
+	will_return(__wrap_munmap, MOCK_OK);
 
 	expect_value(rdma_destroy_qp, id, &Cm_id);
 
@@ -304,13 +307,14 @@ test_server__success(void **unused)
 	expect_value(rdma_migrate_id, channel, MOCK_EVCH);
 	will_return(rdma_migrate_id, MOCK_OK);
 
-	struct posix_memalign_args allocated_raw = {0};
-	will_return(__wrap_posix_memalign, &allocated_raw);
+	struct mmap_args allocated_raw = {0};
+	will_return(__wrap_mmap, MOCK_OK);
+	will_return(__wrap_mmap, &allocated_raw);
 
 	expect_value(ibv_reg_mr, pd, MOCK_IBV_PD);
 	expect_value(ibv_reg_mr, length, MOCK_RAW_SIZE);
 	expect_value(ibv_reg_mr, access, IBV_ACCESS_LOCAL_WRITE);
-	will_return(ibv_reg_mr, &allocated_raw.ptr);
+	will_return(ibv_reg_mr, &allocated_raw.addr);
 	will_return(ibv_reg_mr, MOCK_MR_RAW);
 
 	/* configure mocks for rpma_conn_next_event() */
@@ -343,6 +347,8 @@ test_server__success(void **unused)
 	/* configure mocks for rpma_conn_delete() */
 	expect_value(ibv_dereg_mr, mr, MOCK_MR_RAW);
 	will_return(ibv_dereg_mr, MOCK_OK);
+	will_return(__wrap_munmap, &allocated_raw);
+	will_return(__wrap_munmap, MOCK_OK);
 
 	expect_value(rdma_destroy_qp, id, &Cm_id);
 

--- a/tests/integration/example-04-write-to-persistent/CMakeLists.txt
+++ b/tests/integration/example-04-write-to-persistent/CMakeLists.txt
@@ -1,6 +1,6 @@
 #
 # SPDX-License-Identifier: BSD-3-Clause
-# Copyright 2020, Intel Corporation
+# Copyright 2020-2021, Intel Corporation
 #
 
 include(../../cmake/ctest_helpers.cmake)
@@ -35,7 +35,7 @@ target_include_directories(${TARGET} PRIVATE
 
 set_target_properties(${TARGET}
        PROPERTIES
-       LINK_FLAGS "-Wl,--wrap=_test_malloc,--wrap=posix_memalign,--wrap=fprintf")
+       LINK_FLAGS "-Wl,--wrap=_test_malloc,--wrap=posix_memalign,--wrap=fprintf,--wrap=mmap,--wrap=munmap")
 
 target_compile_definitions(${TARGET}
        PUBLIC TEST_MOCK_MAIN

--- a/tests/integration/example-04-write-to-persistent/example-04-write-to-persistent.c
+++ b/tests/integration/example-04-write-to-persistent/example-04-write-to-persistent.c
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: BSD-3-Clause
-/* Copyright 2020, Intel Corporation */
+/* Copyright 2020-2021, Intel Corporation */
 
 /*
  * example-04-write-to-persistent.c -- 'write to persistent' integration tests
@@ -111,13 +111,14 @@ test_client__success(void **unused)
 	will_return(rdma_migrate_id, MOCK_OK);
 
 	/* allocate memory for the rpma_flush_apm_new */
-	struct posix_memalign_args flush = {0};
-	will_return(__wrap_posix_memalign, &flush);
+	struct mmap_args flush = {0};
+	will_return(__wrap_mmap, MOCK_OK);
+	will_return(__wrap_mmap, &flush);
 
 	expect_value(ibv_reg_mr, pd, MOCK_IBV_PD);
 	expect_value(ibv_reg_mr, length, MOCK_RAW_SIZE);
 	expect_value(ibv_reg_mr, access, IBV_ACCESS_LOCAL_WRITE);
-	will_return(ibv_reg_mr, &flush.ptr);
+	will_return(ibv_reg_mr, &flush.addr);
 	will_return(ibv_reg_mr, MOCK_MR_FLUSH);
 
 	expect_value(rdma_connect, id, &Cm_id);
@@ -219,6 +220,8 @@ test_client__success(void **unused)
 	/* configure mocks for rpma_conn_delete() */
 	expect_value(ibv_dereg_mr, mr, MOCK_MR_FLUSH);
 	will_return(ibv_dereg_mr, MOCK_OK);
+	will_return(__wrap_munmap, &flush);
+	will_return(__wrap_munmap, MOCK_OK);
 
 	expect_value(rdma_destroy_qp, id, &Cm_id);
 
@@ -341,13 +344,14 @@ test_server__success(void **unused)
 	expect_value(rdma_migrate_id, channel, MOCK_EVCH);
 	will_return(rdma_migrate_id, MOCK_OK);
 
-	struct posix_memalign_args allocated_raw = {0};
-	will_return(__wrap_posix_memalign, &allocated_raw);
+	struct mmap_args allocated_raw = {0};
+	will_return(__wrap_mmap, MOCK_OK);
+	will_return(__wrap_mmap, &allocated_raw);
 
 	expect_value(ibv_reg_mr, pd, MOCK_IBV_PD);
 	expect_value(ibv_reg_mr, length, MOCK_RAW_SIZE);
 	expect_value(ibv_reg_mr, access, IBV_ACCESS_LOCAL_WRITE);
-	will_return(ibv_reg_mr, &allocated_raw.ptr);
+	will_return(ibv_reg_mr, &allocated_raw.addr);
 	will_return(ibv_reg_mr, MOCK_MR_RAW);
 
 	/* configure mocks for rpma_conn_next_event() */
@@ -380,6 +384,8 @@ test_server__success(void **unused)
 	/* configure mocks for rpma_conn_delete() */
 	expect_value(ibv_dereg_mr, mr, MOCK_MR_RAW);
 	will_return(ibv_dereg_mr, MOCK_OK);
+	will_return(__wrap_munmap, &allocated_raw);
+	will_return(__wrap_munmap, MOCK_OK);
 
 	expect_value(rdma_destroy_qp, id, &Cm_id);
 

--- a/tests/unit/common/mocks-rpma-mr.c
+++ b/tests/unit/common/mocks-rpma-mr.c
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: BSD-3-Clause
-/* Copyright 2020, Intel Corporation */
+/* Copyright 2020-2021, Intel Corporation */
 
 /*
  * mocks-rpma-mr.c -- librpma mr.c module mocks
@@ -99,8 +99,14 @@ rpma_mr_dereg(struct rpma_mr_local **mr_ptr)
 	assert_non_null(mr_ptr);
 	check_expected_ptr(*mr_ptr);
 
+	int ret = mock_type(int);
+	/* XXX validate the errno handling */
+	if (ret == RPMA_E_PROVIDER)
+		errno = mock_type(int);
+
 	*mr_ptr = NULL;
-	return 0;
+
+	return ret;
 }
 
 /*

--- a/tests/unit/common/mocks-stdlib.h
+++ b/tests/unit/common/mocks-stdlib.h
@@ -1,5 +1,5 @@
 /* SPDX-License-Identifier: BSD-3-Clause */
-/* Copyright 2020, Intel Corporation */
+/* Copyright 2020-2021, Intel Corporation */
 
 /*
  * mocks-stdlib.h -- the stdlib mocks' header
@@ -8,8 +8,9 @@
 #ifndef MOCKS_STDLIB_H
 #define MOCKS_STDLIB_H
 
-struct posix_memalign_args {
-	void *ptr;
+struct mmap_args {
+	void *addr;
+	size_t len;
 };
 
 #endif /* MOCKS_STDLIB_H */

--- a/tests/unit/flush/CMakeLists.txt
+++ b/tests/unit/flush/CMakeLists.txt
@@ -1,6 +1,6 @@
 #
 # SPDX-License-Identifier: BSD-3-Clause
-# Copyright 2020, Intel Corporation
+# Copyright 2020-2021, Intel Corporation
 #
 
 include(../../cmake/ctest_helpers.cmake)
@@ -22,7 +22,7 @@ function(add_test_flush name)
 
 	set_target_properties(${name}
 		PROPERTIES
-		LINK_FLAGS "-Wl,--wrap=_test_malloc,--wrap=posix_memalign,--wrap=sysconf")
+		LINK_FLAGS "-Wl,--wrap=_test_malloc,--wrap=mmap,--wrap=munmap,--wrap=sysconf")
 
 	add_test_generic(NAME ${name} TRACERS none)
 endfunction()

--- a/tests/unit/flush/flush-common.h
+++ b/tests/unit/flush/flush-common.h
@@ -1,5 +1,5 @@
 /* SPDX-License-Identifier: BSD-3-Clause */
-/* Copyright 2020, Intel Corporation */
+/* Copyright 2020-2021, Intel Corporation */
 
 /*
  * flush-common.h -- header of the common part of unit tests
@@ -8,6 +8,8 @@
 
 #ifndef FLUSH_COMMON_H
 #define FLUSH_COMMON_H 1
+
+#include "mocks-stdlib.h"
 
 #define MOCK_RPMA_MR_REMOTE	(struct rpma_mr_remote *)0xC412
 #define MOCK_RPMA_MR_LOCAL	(struct rpma_mr_local *)0xC411
@@ -22,6 +24,7 @@
  */
 struct flush_test_state {
 	struct rpma_flush *flush;
+	struct mmap_args allocated_raw;
 };
 
 int setup__flush_new(void **fstate_ptr);

--- a/tests/unit/flush/flush-new.c
+++ b/tests/unit/flush/flush-new.c
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: BSD-3-Clause
-/* Copyright 2020, Intel Corporation */
+/* Copyright 2020-2021, Intel Corporation */
 
 /*
  * flush-new.c -- unit tests of the flush module
@@ -14,6 +14,7 @@
 #include "flush-common.h"
 #include "mocks-stdlib.h"
 #include "test-common.h"
+#include <sys/mman.h>
 
 /*
  * new__malloc_ENOMEM -- malloc() fail with ENOMEM
@@ -53,15 +54,15 @@ new__apm_sysconf_EINVAL(void **unused)
 }
 
 /*
- * new__apm_posix_memalign_ENOMEM -- malloc() fail with ENOMEM
+ * new__apm_mmap_ENOMEM -- mmap() fails with ENOMEM
  */
 static void
-new__apm_posix_memalign_ENOMEM(void **unused)
+new__apm_mmap_ENOMEM(void **unused)
 {
 	/* configure mocks */
 	will_return_always(__wrap__test_malloc, MOCK_OK);
 	will_return(__wrap_sysconf, MOCK_OK);
-	will_return(__wrap_posix_memalign, ENOMEM);
+	will_return(__wrap_mmap, MAP_FAILED);
 
 	/* run test */
 	struct rpma_flush *flush = NULL;
@@ -82,15 +83,17 @@ new__apm_mr_reg_RPMA_E_NOMEM(void **unused)
 	will_return_always(__wrap__test_malloc, MOCK_OK);
 	will_return(__wrap_sysconf, MOCK_OK);
 
-	will_return(__wrap_posix_memalign, MOCK_OK);
-	struct posix_memalign_args allocated_raw = {0};
-	will_return(__wrap_posix_memalign, &allocated_raw);
+	struct mmap_args allocated_raw = {0};
+	will_return(__wrap_mmap, MOCK_OK);
+	will_return(__wrap_mmap, &allocated_raw);
 	expect_value(rpma_mr_reg, peer, MOCK_PEER);
 	expect_value(rpma_mr_reg, size, 8);
 	expect_value(rpma_mr_reg, usage, RPMA_MR_USAGE_READ_DST);
-	will_return(rpma_mr_reg, &allocated_raw.ptr);
+	will_return(rpma_mr_reg, &allocated_raw.addr);
 	will_return(rpma_mr_reg, NULL);
 	will_return(rpma_mr_reg, RPMA_E_NOMEM);
+	will_return(__wrap_munmap, &allocated_raw);
+	will_return(__wrap_munmap, EINVAL);
 
 	/* run test */
 	struct rpma_flush *flush = NULL;
@@ -111,15 +114,18 @@ new__apm_malloc_ENOMEM(void **unused)
 	will_return(__wrap__test_malloc, MOCK_OK);
 	will_return(__wrap_sysconf, MOCK_OK);
 
-	will_return(__wrap_posix_memalign, MOCK_OK);
-	struct posix_memalign_args allocated_raw = {0};
-	will_return(__wrap_posix_memalign, &allocated_raw);
+	struct mmap_args allocated_raw = {0};
+	will_return(__wrap_mmap, MOCK_OK);
+	will_return(__wrap_mmap, &allocated_raw);
 	expect_value(rpma_mr_reg, peer, MOCK_PEER);
 	expect_value(rpma_mr_reg, size, 8);
 	expect_value(rpma_mr_reg, usage, RPMA_MR_USAGE_READ_DST);
-	will_return(rpma_mr_reg, &allocated_raw.ptr);
+	will_return(rpma_mr_reg, &allocated_raw.addr);
 	will_return(rpma_mr_reg, MOCK_RPMA_MR_LOCAL);
 	will_return(__wrap__test_malloc, ENOMEM);
+	will_return(rpma_mr_dereg, MOCK_OK);
+	will_return(__wrap_munmap, &allocated_raw);
+	will_return(__wrap_munmap, MOCK_OK);
 	expect_value(rpma_mr_dereg, *mr_ptr, MOCK_RPMA_MR_LOCAL);
 
 	/* run test */
@@ -143,18 +149,71 @@ new__apm_success(void **unused)
 	 */
 }
 
+/*
+ * delete__apm_dereg_E_PROVIDER -- rpma_mr_dereg() failed with RPMA_E_PROVIDER
+ */
+static void
+delete__apm_dereg_E_PROVIDER(void **unused)
+{
+	struct flush_test_state *fstate;
+
+	setup__flush_new((void **)&fstate);
+
+	/* configure mocks */
+	expect_value(rpma_mr_dereg, *mr_ptr, MOCK_RPMA_MR_LOCAL);
+	will_return(__wrap_munmap, &fstate->allocated_raw);
+	will_return_maybe(__wrap_munmap, MOCK_OK);
+	will_return(rpma_mr_dereg, RPMA_E_PROVIDER);
+	will_return(rpma_mr_dereg, MOCK_ERRNO);
+
+	/* delete the object */
+	int ret = rpma_flush_delete(&fstate->flush);
+
+	/* verify the results */
+	assert_int_equal(ret, RPMA_E_PROVIDER);
+	assert_null(fstate->flush);
+}
+
+/*
+ * delete__apm_munmap_E_INVAL -- munmap() failed with EINVAL
+ */
+static void
+delete__apm_munmap_E_INVAL(void **unused)
+{
+	struct flush_test_state *fstate;
+
+	setup__flush_new((void **)&fstate);
+
+	/* configure mocks */
+	expect_value(rpma_mr_dereg, *mr_ptr, MOCK_RPMA_MR_LOCAL);
+	will_return_maybe(rpma_mr_dereg, MOCK_OK);
+	will_return(__wrap_munmap, &fstate->allocated_raw);
+	will_return(__wrap_munmap, EINVAL);
+
+	/* delete the object */
+	int ret = rpma_flush_delete(&fstate->flush);
+
+	/* verify the results */
+	assert_int_equal(ret, RPMA_E_INVAL);
+	assert_null(fstate->flush);
+}
+
 int
 main(int argc, char *argv[])
 {
 	const struct CMUnitTest tests[] = {
-		/* rpma__new() unit tests */
+		/* rpma_flush_new() unit tests */
 		cmocka_unit_test(new__malloc_ENOMEM),
 		cmocka_unit_test(new__apm_sysconf_EINVAL),
-		cmocka_unit_test(new__apm_posix_memalign_ENOMEM),
+		cmocka_unit_test(new__apm_mmap_ENOMEM),
 		cmocka_unit_test(new__apm_mr_reg_RPMA_E_NOMEM),
 		cmocka_unit_test(new__apm_malloc_ENOMEM),
 		cmocka_unit_test_setup_teardown(new__apm_success,
 			setup__flush_new, teardown__flush_delete),
+
+		/* rpma_flush_delete() unit tests */
+		cmocka_unit_test(delete__apm_dereg_E_PROVIDER),
+		cmocka_unit_test(delete__apm_munmap_E_INVAL),
 	};
 
 	return cmocka_run_group_tests(tests, NULL, NULL);


### PR DESCRIPTION
The memory region passed to `rpma_mr_reg()` (`ibv_mr_reg()`)
cannot be allocated from the heap (using `malloc()`
or `posix_memalign()`), but should be mapped using `mmap()`.

Rationale:

If `ibv_fork_init()` was called, the memory region
passed to `ibv_mr_reg()` is marked by this function
with the DC (“do not copy on fork”) flag
and after having called `fork()`, the child process
does not receive this range of virtual addresses.
If this memory region was allocated from the heap,
the child process receives a corrupted heap
with a “hole” of inaccessible addresses inside.
A memory allocator knows nothing about this “hole”
and if it tries to access (read or write)
that range of virtual addresses, it causes a segfault.

Ref: #751

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/pmem/rpma/866)
<!-- Reviewable:end -->
