### PR TITLE
common: remove unneeded dependencies for ndctl and pmdk from Debian 9

### DIFF
--- a/utils/docker/images/Dockerfile.debian-9
+++ b/utils/docker/images/Dockerfile.debian-9
@@ -1,6 +1,6 @@
 #
 # SPDX-License-Identifier: BSD-3-Clause
-# Copyright 2016-2020, Intel Corporation
+# Copyright 2016-2021, Intel Corporation
 #
 
 #
@@ -33,31 +33,6 @@ ENV BASE_DEPS "\
 	sudo \
 	whois"
 
-# ndctl (optional if libndctl-dev and libdaxctl-dev >= 60.1, 64.1 preferred)
-ENV NDCTL_DEPS "\
-	automake \
-	bash-completion \
-	build-essential \
-	git \
-	libjson-c-dev \
-	libkeyutils-dev \
-	libkmod-dev \
-	libtool \
-	libudev-dev \
-	pkg-config \
-	systemd \
-	uuid-dev"
-
-# PMDK deps
-ENV PMDK_DEPS "\
-	debhelper \
-	devscripts \
-	pandoc"
-
-ENV EXAMPLES_DEPS "\
-	$NDCTL_DEPS \
-	$PMDK_DEPS"
-
 # RPMA deps
 ENV RPMA_DEPS "\
 	cmake \
@@ -73,7 +48,6 @@ ENV RPMA_DEPS "\
 # Install all required packages
 RUN apt-get install -y --no-install-recommends \
 	$BASE_DEPS \
-	$EXAMPLES_DEPS \
 	$RPMA_DEPS \
 && rm -rf /var/lib/apt/lists/*
 


### PR DESCRIPTION


<!-- Reviewable:start -->
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/pmem/rpma/867)
<!-- Reviewable:end -->
