### PR TITLE
rpma: fix indentation of the 'if' conditions

### DIFF
--- a/src/conn.c
+++ b/src/conn.c
@@ -423,7 +423,7 @@ rpma_send(struct rpma_conn *conn,
     int flags, const void *op_context)
 {
 	if (conn == NULL || flags == 0 ||
-			(src == NULL && (offset != 0 || len != 0)))
+	    (src == NULL && (offset != 0 || len != 0)))
 		return RPMA_E_INVAL;
 
 	return rpma_mr_send(conn->id->qp,
@@ -441,7 +441,7 @@ rpma_send_with_imm(struct rpma_conn *conn,
 	int flags, uint32_t imm, const void *op_context)
 {
 	if (conn == NULL || flags == 0 ||
-			(src == NULL && (offset != 0 || len != 0)))
+	    (src == NULL && (offset != 0 || len != 0)))
 		return RPMA_E_INVAL;
 
 	return rpma_mr_send(conn->id->qp,


### PR DESCRIPTION
The continuation line of the 'if' condition
should be indented by 4 spaces, not by tabs.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/pmem/rpma/884)
<!-- Reviewable:end -->
