### PR TITLE
examples: change the default port for examples

### DIFF
--- a/examples/run-all-on-SoftRoCE.sh
+++ b/examples/run-all-on-SoftRoCE.sh
@@ -58,7 +58,7 @@ function verify_SoftRoCE() {
 	fi
 
 	if [ "$PORT" == "" ]; then
-		PORT="8765"
+		PORT="7204"
 	fi
 
 	echo "Running examples for IP address $IP_ADDRESS and port $PORT"


### PR DESCRIPTION
Change the default port for examples from 8765 to 7204.
- port 8765 can be used by Ultraseek HTTP, while
https://www.speedguide.net/port.php?port=8765
- port 7204 is unassigned yet:
https://www.speedguide.net/port.php?port=7204

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/pmem/rpma/885)
<!-- Reviewable:end -->
