### PR TITLE
rpma: handle success in rpma_err_2str()

### DIFF
--- a/src/rpma_err.c
+++ b/src/rpma_err.c
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: BSD-3-Clause
-/* Copyright 2019-2020, Intel Corporation */
+/* Copyright 2019-2021, Intel Corporation */
 
 /*
  * rpma_err.c -- error-handling related librpma definitions
@@ -17,6 +17,8 @@ const char *
 rpma_err_2str(int ret)
 {
 	switch (ret) {
+	case 0:
+		return "Success";
 	case RPMA_E_NOSUPP:
 		return "Not supported";
 	case RPMA_E_PROVIDER:

--- a/tests/unit/error/error.c
+++ b/tests/unit/error/error.c
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: BSD-3-Clause
-/* Copyright 2020, Intel Corporation */
+/* Copyright 2020-2021, Intel Corporation */
 
 /*
  * error.c -- unit tests for error-handling rpma-err module
@@ -10,6 +10,15 @@
 
 #include "cmocka_headers.h"
 #include "librpma.h"
+
+/*
+ * err_2str__SUCCESS - sanity test for rpma_err_2str()
+ */
+static void
+err_2str__SUCCESS(void **unused)
+{
+	assert_string_equal(rpma_err_2str(0), "Success");
+}
 
 /*
  * err_2str__E_NOSUPP - sanity test for rpma_err_2str()
@@ -81,6 +90,7 @@ int
 main(int argc, char *argv[])
 {
 	const struct CMUnitTest tests[] = {
+		cmocka_unit_test(err_2str__SUCCESS),
 		cmocka_unit_test(err_2str__E_NOSUPP),
 		cmocka_unit_test(err_2str__E_PROVIDER),
 		cmocka_unit_test(err_2str__E_NOMEM),


### PR DESCRIPTION
Print out "Success" instead of "Unknown error" when ret == 0.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/pmem/rpma/904)
<!-- Reviewable:end -->
