### PR TITLE
rpma: ack the received cq event

### DIFF
--- a/src/conn.c
+++ b/src/conn.c
@@ -500,7 +500,7 @@ rpma_conn_completion_wait(struct rpma_conn *conn)
 		return RPMA_E_INVAL;
 
 	/* wait for the completion event */
-	struct ibv_cq *ev_cq;	/* unused */
+	struct ibv_cq *ev_cq;
 	void *ev_ctx;		/* unused */
 	if (ibv_get_cq_event(conn->channel, &ev_cq, &ev_ctx))
 		return RPMA_E_NO_COMPLETION;
@@ -511,7 +511,7 @@ rpma_conn_completion_wait(struct rpma_conn *conn)
 	 * XXX for performance reasons, it may be beneficial to ACK more than
 	 * one CQ event at the same time.
 	 */
-	ibv_ack_cq_events(conn->cq, 1 /* # of CQ events */);
+	ibv_ack_cq_events(ev_cq, 1 /* # of CQ events */);
 
 	/* request for the next event on the CQ channel */
 	errno = ibv_req_notify_cq(conn->cq,


### PR DESCRIPTION
See the ibv_get_cq_event(3) manual:

_"All completion events that ibv_get_cq_event() returns
**MUST BE** acknowledged using ibv_ack_cq_events().
To avoid races, destroying a CQ will wait
for all completion events to be acknowledged;
this guarantees a one-to-one correspondence
between acks and successful gets."_

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/pmem/rpma/905)
<!-- Reviewable:end -->
