### PR TITLE
test: increase MAX_ADDR in rpma_utils_get_ibv_context.c

### DIFF
--- a/tests/multithreaded/utils/rpma_utils_get_ibv_context.c
+++ b/tests/multithreaded/utils/rpma_utils_get_ibv_context.c
@@ -13,7 +13,7 @@
 
 #include <librpma.h>
 
-#define MAX_ADDR (4 * 4 - 1)
+#define MAX_ADDR (4 * 4)
 
 struct thread_args {
 	int thread_num;


### PR DESCRIPTION
addr[MAX_ADDR] is too small to store the whole IP address
so that running rpma_utils_get_ibv_context always failed.
For example: ./rpma_utils_get_ibv_context 32 192.168.122.189

Signed-off-by: Xiao Yang <yangx.jy@cn.fujitsu.com>

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/pmem/rpma/908)
<!-- Reviewable:end -->
