### PR TITLE
test: include cmocka only #ifdef TEST_USE_CMOCKA

### DIFF
--- a/examples/02-read-to-volatile/client.c
+++ b/examples/02-read-to-volatile/client.c
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: BSD-3-Clause
-/* Copyright 2020, Intel Corporation */
+/* Copyright 2020-2021, Intel Corporation */
 
 /*
  * client.c -- a client of the read-to-volatile example
@@ -15,9 +15,12 @@
 
 #include "common-conn.h"
 
-#ifdef TEST_MOCK_MAIN
+#ifdef TEST_USE_CMOCKA
 #include "cmocka_headers.h"
 #include "cmocka_alloc.h"
+#endif
+
+#ifdef TEST_MOCK_MAIN
 #define main client_main
 #endif
 

--- a/examples/02-read-to-volatile/server.c
+++ b/examples/02-read-to-volatile/server.c
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: BSD-3-Clause
-/* Copyright 2020, Intel Corporation */
+/* Copyright 2020-2021, Intel Corporation */
 
 /*
  * server.c -- a server of the read-to-volatile example
@@ -18,9 +18,12 @@
 
 #define HELLO_STR "Hello client!"
 
-#ifdef TEST_MOCK_MAIN
+#ifdef TEST_USE_CMOCKA
 #include "cmocka_headers.h"
 #include "cmocka_alloc.h"
+#endif
+
+#ifdef TEST_MOCK_MAIN
 #define main server_main
 #endif
 

--- a/examples/04-write-to-persistent/client.c
+++ b/examples/04-write-to-persistent/client.c
@@ -37,9 +37,12 @@ translate(struct hello_t *hello)
 	write_hello_str(hello, lang);
 }
 
-#ifdef TEST_MOCK_MAIN
+#ifdef TEST_USE_CMOCKA
 #include "cmocka_headers.h"
 #include "cmocka_alloc.h"
+#endif
+
+#ifdef TEST_MOCK_MAIN
 #define main client_main
 #endif
 

--- a/examples/04-write-to-persistent/server.c
+++ b/examples/04-write-to-persistent/server.c
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: BSD-3-Clause
-/* Copyright 2020, Intel Corporation */
+/* Copyright 2020-2021, Intel Corporation */
 
 /*
  * server.c -- a server of the write-to-persistent example
@@ -21,9 +21,12 @@
 
 #include "common-conn.h"
 
-#ifdef TEST_MOCK_MAIN
+#ifdef TEST_USE_CMOCKA
 #include "cmocka_headers.h"
 #include "cmocka_alloc.h"
+#endif
+
+#ifdef TEST_MOCK_MAIN
 #define main server_main
 #endif
 

--- a/tests/integration/example-02-read-to-volatile/CMakeLists.txt
+++ b/tests/integration/example-02-read-to-volatile/CMakeLists.txt
@@ -38,6 +38,7 @@ set_target_properties(${TARGET}
        LINK_FLAGS "-Wl,--wrap=_test_malloc,--wrap=posix_memalign,--wrap=fprintf,--wrap=mmap,--wrap=munmap")
 
 target_compile_definitions(${TARGET}
+       PUBLIC TEST_USE_CMOCKA
        PUBLIC TEST_MOCK_MAIN
        PRIVATE TEST_MOCK_ALLOC
        PRIVATE SRCVERSION="0.0")

--- a/tests/integration/example-04-write-to-persistent/CMakeLists.txt
+++ b/tests/integration/example-04-write-to-persistent/CMakeLists.txt
@@ -38,6 +38,7 @@ set_target_properties(${TARGET}
        LINK_FLAGS "-Wl,--wrap=_test_malloc,--wrap=posix_memalign,--wrap=fprintf,--wrap=mmap,--wrap=munmap")
 
 target_compile_definitions(${TARGET}
+       PUBLIC TEST_USE_CMOCKA
        PUBLIC TEST_MOCK_MAIN
        PRIVATE TEST_MOCK_ALLOC
        PRIVATE SRCVERSION="0.0")


### PR DESCRIPTION
Separate mocking main() from including cmocka headers,
because one can want to mock the main() function
without using the cmocka framework.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/pmem/rpma/910)
<!-- Reviewable:end -->
