### PR TITLE
examples: zero the common_data data structure

### DIFF
--- a/examples/02-read-to-volatile/server.c
+++ b/examples/02-read-to-volatile/server.c
@@ -88,7 +88,7 @@ main(int argc, char *argv[])
 	if (ret)
 		goto err_mr_dereg;
 
-	struct common_data data;
+	struct common_data data = {0};
 	data.mr_desc_size = mr_desc_size;
 
 	/* get the memory region's descriptor */

--- a/examples/03-read-to-persistent/client.c
+++ b/examples/03-read-to-persistent/client.c
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: BSD-3-Clause
-/* Copyright 2020, Intel Corporation */
+/* Copyright 2020-2021, Intel Corporation */
 
 /*
  * client.c -- a client of the read-to-persistent example
@@ -164,7 +164,7 @@ main(int argc, char *argv[])
 		goto err_mr_dereg;
 
 	/* calculate data for the server read */
-	struct common_data data;
+	struct common_data data = {0};
 	data.data_offset = data_offset + offsetof(struct hello_t, str);
 	data.mr_desc_size = mr_desc_size;
 

--- a/examples/04-write-to-persistent/server.c
+++ b/examples/04-write-to-persistent/server.c
@@ -160,7 +160,7 @@ main(int argc, char *argv[])
 		goto err_mr_dereg;
 
 	/* calculate data for the client write */
-	struct common_data data;
+	struct common_data data = {0};
 	data.data_offset = data_offset;
 	data.mr_desc_size = mr_desc_size;
 

--- a/examples/05-flush-to-persistent/server.c
+++ b/examples/05-flush-to-persistent/server.c
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: BSD-3-Clause
-/* Copyright 2020, Intel Corporation */
+/* Copyright 2020-2021, Intel Corporation */
 
 /*
  * server.c -- a server of the flush-to-persistent example
@@ -185,7 +185,7 @@ main(int argc, char *argv[])
 		goto err_mr_dereg;
 
 	/* calculate data for the client write */
-	struct common_data data;
+	struct common_data data = {0};
 	data.data_offset = data_offset;
 	data.mr_desc_size = mr_desc_size;
 	data.pcfg_desc_size = pcfg_desc_size;

--- a/examples/06-multiple-connections/client.c
+++ b/examples/06-multiple-connections/client.c
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: BSD-3-Clause
-/* Copyright 2020, Intel Corporation */
+/* Copyright 2020-2021, Intel Corporation */
 
 /*
  * client.c -- a client of the multiple-connections example
@@ -102,7 +102,7 @@ main(int argc, char *argv[])
 	if (ret)
 		goto err_mr_dereg;
 
-	struct common_data data;
+	struct common_data data = {0};
 	data.mr_desc_size = mr_desc_size;
 
 	/* get the memory region's descriptor */

--- a/examples/07-atomic-write/server.c
+++ b/examples/07-atomic-write/server.c
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: BSD-3-Clause
-/* Copyright 2020, Intel Corporation */
+/* Copyright 2020-2021, Intel Corporation */
 
 /*
  * server.c -- a server of the atomic-write example
@@ -167,7 +167,7 @@ main(int argc, char *argv[])
 		goto err_mr_dereg;
 
 	/* calculate data for the client write */
-	struct common_data data;
+	struct common_data data = {0};
 	data.data_offset = offsetof(struct log, used);
 	data.mr_desc_size = mr_desc_size;
 

--- a/examples/09-flush-to-persistent-GPSPM/server.c
+++ b/examples/09-flush-to-persistent-GPSPM/server.c
@@ -186,7 +186,7 @@ main(int argc, char *argv[])
 		goto err_mr_dereg;
 
 	/* calculate data for the server read */
-	struct common_data data;
+	struct common_data data = {0};
 	data.data_offset = data_offset;
 	data.mr_desc_size = mr_desc_size;
 


### PR DESCRIPTION
Zero the common_data data structure,
so that the whole 'descriptors' array:
```
   char descriptors[DESCRIPTORS_MAX_SIZE];
```
was initialized.

See: https://github.com/pmem/fio/pull/236

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/pmem/rpma/913)
<!-- Reviewable:end -->
