### PR TITLE
rpma: increase cq_size to one automatically if it is zero

### DIFF
--- a/src/conn_cfg.c
+++ b/src/conn_cfg.c
@@ -53,7 +53,8 @@ rpma_conn_cfg_default()
 /*
  * rpma_conn_cfg_get_cqe -- ibv_create_cq(..., int cqe, ...) compatible variant
  * of rpma_conn_cfg_get_cq_size(). Round down the cq_size when it is too big
- * for storing into an int type of value. Convert otherwise.
+ * for storing into an int type of value. Round up the cq_size when it is zero.
+ * Convert otherwise.
  */
 int
 rpma_conn_cfg_get_cqe(const struct rpma_conn_cfg *cfg, int *cqe)
@@ -68,6 +69,8 @@ rpma_conn_cfg_get_cqe(const struct rpma_conn_cfg *cfg, int *cqe)
 
 	if (cq_size > INT_MAX)
 		*cqe = INT_MAX;
+	else if (cq_size == 0)
+		*cqe = 1;
 	else
 		*cqe = (int)cq_size;
 

--- a/tests/unit/conn_cfg/conn_cfg-cqe.c
+++ b/tests/unit/conn_cfg/conn_cfg-cqe.c
@@ -81,6 +81,25 @@ cqe__clipped(void **cstate_ptr)
 	assert_int_equal(cqe, INT_MAX);
 }
 
+/*
+ * cqe__increased -- cq_size = 0
+ */
+static void
+cqe__increased(void **cstate_ptr)
+{
+	struct conn_cfg_test_state *cstate = *cstate_ptr;
+
+	/* run test */
+	int ret = rpma_conn_cfg_set_cq_size(cstate->cfg, 0);
+
+	/* verify the results */
+	assert_int_equal(ret, MOCK_OK);
+	int cqe;
+	ret = rpma_conn_cfg_get_cqe(cstate->cfg, &cqe);
+	assert_int_equal(ret, MOCK_OK);
+	assert_int_equal(cqe, 1);
+}
+
 static const struct CMUnitTest test_cqe[] = {
 	cmocka_unit_test(get__cfg_NULL),
 	cmocka_unit_test_setup_teardown(get__cqe_NULL,
@@ -90,7 +109,9 @@ static const struct CMUnitTest test_cqe[] = {
 	cmocka_unit_test_setup_teardown(cqe__lifecycle,
 		setup__conn_cfg, teardown__conn_cfg),
 	cmocka_unit_test_setup_teardown(cqe__clipped,
-			setup__conn_cfg, teardown__conn_cfg),
+		setup__conn_cfg, teardown__conn_cfg),
+	cmocka_unit_test_setup_teardown(cqe__increased,
+		setup__conn_cfg, teardown__conn_cfg),
 };
 
 int


### PR DESCRIPTION
cq_size with zero value is invalid for ibv_create_cq().

Signed-off-by: Xiao Yang <yangx.jy@cn.fujitsu.com>

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/pmem/rpma/923)
<!-- Reviewable:end -->
