### PR TITLE
tools: do not print out REMOTE_ANOTHER_NUMA in '--env'

### DIFF
--- a/tools/perf/rpma_fio_bench.sh
+++ b/tools/perf/rpma_fio_bench.sh
@@ -72,7 +72,6 @@ function show_environment() {
 	echo "export REMOTE_JOB_PATH=$REMOTE_JOB_PATH"
 	echo "export REMOTE_JOB_MEM_PATH=$REMOTE_JOB_MEM_PATH"
 	echo
-	echo "export REMOTE_ANOTHER_NUMA=$REMOTE_ANOTHER_NUMA"
 	echo "export REMOTE_CMD_PRE='$REMOTE_CMD_PRE'"
 	echo "export REMOTE_CMD_POST='$REMOTE_CMD_POST'"
 	echo


### PR DESCRIPTION
Both `REMOTE_CMD_PRE` and `REMOTE_CMD_POST` can use
any user-defined environment variables.
`REMOTE_ANOTHER_NUMA` is used only inside `REMOTE_CMD_PRE`,
not by the script itself.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/pmem/rpma/936)
<!-- Reviewable:end -->
