### PR TITLE
tools: fix setting CORES_PER_SOCKET

### DIFF
--- a/tools/perf/rpma_fio_bench.sh
+++ b/tools/perf/rpma_fio_bench.sh
@@ -568,7 +568,7 @@ fi
 
 export CORES_PER_SOCKET=$(sshpass -p "$REMOTE_PASS" -v ssh -o StrictHostKeyChecking=no \
 			$REMOTE_USER@$SERVER_IP \
-			"lscpu | egrep 'Core' | sed 's/[^0-9]*//g'")
+			"lscpu | egrep 'Core\(s\) per socket:' | sed 's/[^0-9]*//g'")
 # validate the output
 [[ "$CORES_PER_SOCKET" =~ ^[0-9]+$ ]]
 if [ -z "${BASH_REMATCH[0]}" ]; then


### PR DESCRIPTION
There is on my machine:

```
$ lscpu | egrep 'Core'
Core(s) per socket:              6
Model name:                      Intel(R) Core(TM) i7-3960X CPU @ 3.30GHz

$ lscpu | egrep 'Core' | sed 's/[^0-9]*//g'
6
73960330
```

So the command should be:
```
$ lscpu | egrep 'Core\(s\) per socket:' | sed 's/[^0-9]*//g'
6
```
in order to get the correct number of cores per socker.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/pmem/rpma/957)
<!-- Reviewable:end -->
