### PR TITLE
common: CircleCI: remove unneeded rdma-core package

### DIFF
--- a/.circleci/install-pkgs-ubuntu.sh
+++ b/.circleci/install-pkgs-ubuntu.sh
@@ -34,8 +34,7 @@ RPMA_DEPS="\
 	librdmacm-dev \
 	libunwind-dev \
 	linux-modules-extra-$(uname -r) \
-	pandoc \
-	rdma-core"
+	pandoc"
 
 # Install all required packages
 sudo apt-get update


### PR DESCRIPTION
Ubuntu uses libibverbs-dev and librdmacm-dev packages
instead of the rdma-core package.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/pmem/rpma/985)
<!-- Reviewable:end -->
