### PR TITLE
test: mt: clean up error handling

### DIFF
--- a/tests/multithreaded/common/mtt.c
+++ b/tests/multithreaded/common/mtt.c
@@ -30,8 +30,16 @@ struct mtt_thread_args {
 	unsigned id; /* a thread id */
 	void *state; /* a thread-specific state */
 	struct mtt_test *test;
-	struct mtt_thread_result ret; /* a thread return object */
+	struct mtt_result ret; /* a thread return object */
 };
+
+/*
+ * call either init or fini function (func) using the provided test object
+ * (test), the thread arguments, and the result object.
+ */
+#define MTT_CALL_INIT_FINI(test, func, thread_args, result) \
+	(test)->func((thread_args)->id, (test)->prestate, \
+		&(thread_args)->state, (result))
 
 /*
  * mtt_thread_main -- wait for the synchronization conditional and run the test
@@ -41,12 +49,12 @@ mtt_thread_main(void *arg)
 {
 	struct mtt_thread_args *ta = (struct mtt_thread_args *)arg;
 	struct mtt_test *test = ta->test;
-	struct mtt_thread_result *tr = &ta->ret;
-	struct mtt_thread_result tr_dummy = {0};
+	struct mtt_result *tr = &ta->ret;
+	struct mtt_result tr_dummy = {0};
 	int result;
 
 	if (test->thread_init_func) {
-		test->thread_init_func(ta->id, test->prestate, &ta->state, tr);
+		MTT_CALL_INIT_FINI(test, thread_init_func, ta, tr);
 		if (tr->ret) {
 			/* unblock the main thread waiting for this one */
 			++mtt_sync.threads_num_waiting;
@@ -75,14 +83,15 @@ mtt_thread_main(void *arg)
 		return tr;
 	}
 
-	ta->test->thread_func(ta->id, test->prestate, ta->state, tr);
+	test->thread_func(ta->id, test->prestate, ta->state, tr);
 
 	if (test->thread_fini_func) {
 		/*
 		 * if the thread result is already non-zero provide tr_dummy
 		 * instead to avoid overwriting the result
 		 */
-		test->thread_fini_func(&ta->state, (tr->ret ? &tr_dummy : tr));
+		MTT_CALL_INIT_FINI(test, thread_fini_func, ta,
+				(tr->ret ? &tr_dummy : tr));
 	}
 
 	return tr;
@@ -215,7 +224,8 @@ mtt_run(struct mtt_test *test, unsigned threads_num)
 	pthread_t *threads;
 	struct mtt_thread_args *threads_args;
 	struct mtt_thread_args *ta;
-	struct mtt_thread_result *tr;
+	struct mtt_result *tr;
+	struct mtt_result tr_fini = {0};
 	unsigned threads_num_to_join = 0;
 	unsigned threads_num_to_fini = 0;
 
@@ -247,10 +257,13 @@ mtt_run(struct mtt_test *test, unsigned threads_num)
 		ta->test = test;
 
 		if (test->thread_seq_init_func) {
-			result = test->thread_seq_init_func(ta->id,
-					test->prestate, &ta->state);
-			if (result)
+			MTT_CALL_INIT_FINI(test, thread_seq_init_func, ta,
+					&ta->ret);
+			if (ta->ret.ret) {
+				result = ta->ret.ret;
+				MT_TEST_ERR(ta->id, "%s", ta->ret.errmsg);
 				goto err_fini_threads_args;
+			}
 		}
 
 		++threads_num_to_fini;
@@ -303,10 +316,14 @@ err_fini_threads_args:
 	/* clean up threads' arguments */
 	if (test->thread_seq_fini_func) {
 		for (i = 0; i < threads_num_to_fini; i++) {
-			ret = test->thread_seq_fini_func(
-					&threads_args[i].state);
-			if (ret)
-				result = ret;
+			ta = &threads_args[i];
+			MTT_CALL_INIT_FINI(test, thread_seq_fini_func, ta,
+					&tr_fini);
+			if (tr_fini.ret) {
+				MT_TEST_ERR(i, "%s", tr_fini.errmsg);
+				result = tr_fini.ret;
+				tr_fini.ret = 0;
+			}
 		}
 	}
 

--- a/tests/multithreaded/common/mtt.h
+++ b/tests/multithreaded/common/mtt.h
@@ -21,7 +21,7 @@ int mtt_parse_args(int argc, char *argv[], struct mtt_args *args);
 #define MTT_ERRMSG_MAX 512
 
 /* a store for any thread error message and the return value */
-struct mtt_thread_result {
+struct mtt_result {
 	int ret;
 	char errmsg[MTT_ERRMSG_MAX];
 };
@@ -42,14 +42,10 @@ struct mtt_thread_result {
 			"%s() failed: %s", func, rpma_err_2str(err)); \
 	} while (0)
 
-typedef int (*mtt_thread_seq_init)(unsigned id, void *prestate,
-		void **state_ptr);
-typedef void (*mtt_thread_init)(unsigned id, void *prestate, void **state_ptr,
-		struct mtt_thread_result *tr);
+typedef void (*mtt_thread_init_fini)(unsigned id, void *prestate,
+		void **state_ptr, struct mtt_result *result);
 typedef void (*mtt_thread_func)(unsigned id, void *prestate, void *state,
-		struct mtt_thread_result *tr);
-typedef void (*mtt_thread_fini)(void **state, struct mtt_thread_result *tr);
-typedef int (*mtt_thread_seq_fini)(void **state);
+		struct mtt_result *result);
 
 struct mtt_test {
 	/*
@@ -61,13 +57,13 @@ struct mtt_test {
 	/*
 	 * a function called for each of threads before spawning it (sequential)
 	 */
-	mtt_thread_seq_init thread_seq_init_func;
+	mtt_thread_init_fini thread_seq_init_func;
 
 	/*
 	 * a function called at the beginning of each thread
 	 * (parallel but before synchronizing all threads)
 	 */
-	mtt_thread_init thread_init_func;
+	mtt_thread_init_fini thread_init_func;
 
 	/*
 	 * a thread main function (parallel and after synchronizing all threads)
@@ -75,13 +71,13 @@ struct mtt_test {
 	mtt_thread_func thread_func;
 
 	/* a function called at the end of each thread (parallel) */
-	mtt_thread_fini thread_fini_func;
+	mtt_thread_init_fini thread_fini_func;
 
 	/*
 	 * a function called for each of threads after its termination
 	 * (sequential)
 	 */
-	mtt_thread_seq_fini thread_seq_fini_func;
+	mtt_thread_init_fini thread_seq_fini_func;
 };
 
 int mtt_run(struct mtt_test *test, unsigned threads_num);

--- a/tests/multithreaded/common/mtt.h
+++ b/tests/multithreaded/common/mtt.h
@@ -26,20 +26,40 @@ struct mtt_result {
 	char errmsg[MTT_ERRMSG_MAX];
 };
 
+/*
+ * mtt_base_file_name -- extract the exact file name from a file name with path
+ */
+static const char *
+mtt_base_file_name(const char *file_name)
+{
+	const char *base_file_name = strrchr(file_name, '/');
+	if (!base_file_name)
+		base_file_name = file_name;
+	else
+		/* skip '/' */
+		base_file_name++;
+
+	return base_file_name;
+}
+
 /* on error populate the result and the error string */
-#define MTT_THREAD_ERR(result, func, err) \
+#define MTT_ERR(result, func, err) \
 	do { \
 		(result)->ret = err; \
 		snprintf((result)->errmsg, MTT_ERRMSG_MAX - 1, \
-			"%s() failed: %s", func, strerror(err)); \
+			"%s:%d %s() -> %s() failed: %s", \
+			mtt_base_file_name(__FILE__), __LINE__, __func__, \
+			func, strerror(err)); \
 	} while (0)
 
 /* on librpma error populate the result and the error string */
-#define MTT_THREAD_RPMA_ERR(result, func, err) \
+#define MTT_RPMA_ERR(result, func, err) \
 	do { \
 		(result)->ret = err; \
 		snprintf((result)->errmsg, MTT_ERRMSG_MAX - 1, \
-			"%s() failed: %s", func, rpma_err_2str(err)); \
+			"%s:%d %s() -> %s() failed: %s", \
+			mtt_base_file_name(__FILE__), __LINE__, __func__, \
+			func, rpma_err_2str(err)); \
 	} while (0)
 
 typedef void (*mtt_thread_init_fini)(unsigned id, void *prestate,

--- a/tests/multithreaded/utils/rpma_utils_get_ibv_context.c
+++ b/tests/multithreaded/utils/rpma_utils_get_ibv_context.c
@@ -14,11 +14,11 @@ struct prestate {
 };
 
 /*
- * get_ibv_context__thread -- try to get an ibv_context based on a shared
- * network interface address string
+ * thread -- try to get an ibv_context based on a shared network interface
+ * address string
  */
 static void
-get_ibv_context__thread(unsigned id, void *prestate, void *state,
+thread(unsigned id, void *prestate, void *state,
 		struct mtt_result *result)
 {
 	struct prestate *ps = (struct prestate *)prestate;
@@ -28,9 +28,8 @@ get_ibv_context__thread(unsigned id, void *prestate, void *state,
 	/* obtain an IBV context for a local IP address */
 	ret = rpma_utils_get_ibv_context(ps->addr, RPMA_UTIL_IBV_CONTEXT_LOCAL,
 			&dev);
-	if (ret) {
-		MTT_THREAD_RPMA_ERR(result, "rpma_utils_get_ibv_context", ret);
-	}
+	if (ret)
+		MTT_RPMA_ERR(result, "rpma_utils_get_ibv_context", ret);
 }
 
 int
@@ -47,7 +46,7 @@ main(int argc, char *argv[])
 			&prestate,
 			NULL,
 			NULL,
-			get_ibv_context__thread,
+			thread,
 			NULL,
 			NULL
 	};

--- a/tests/multithreaded/utils/rpma_utils_get_ibv_context.c
+++ b/tests/multithreaded/utils/rpma_utils_get_ibv_context.c
@@ -19,7 +19,7 @@ struct prestate {
  */
 static void
 get_ibv_context__thread(unsigned id, void *prestate, void *state,
-		struct mtt_thread_result *tr)
+		struct mtt_result *result)
 {
 	struct prestate *ps = (struct prestate *)prestate;
 	struct ibv_context *dev = NULL;
@@ -29,8 +29,7 @@ get_ibv_context__thread(unsigned id, void *prestate, void *state,
 	ret = rpma_utils_get_ibv_context(ps->addr, RPMA_UTIL_IBV_CONTEXT_LOCAL,
 			&dev);
 	if (ret) {
-		MTT_THREAD_RPMA_ERR(tr, "rpma_utils_get_ibv_context",
-				ret);
+		MTT_THREAD_RPMA_ERR(result, "rpma_utils_get_ibv_context", ret);
 	}
 }
 


### PR DESCRIPTION
- rename MTT-API macros:
	- MTT_THREAD_ERR -> MTT_ERR
	- MTT_THREAD_RPMA_ERR -> MTT_RPMA_ERR
- rename internal MTT error helpers:
	- MTT_ERR -> MTT_INTERNAL_ERR
	- MT_TEST_ERR -> MTT_TEST_ERR (fix)
- add to the error messages: file name, line, and function
	- MTT_ERR, MTT_RPMA_ERR
	
An error message after this change will look as follow:

```
[thread #31] rpma_utils_get_ibv_context.c:33 thread() -> rpma_utils_get_ibv_context() failed: Unknown error
```

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/pmem/rpma/1003)
<!-- Reviewable:end -->
