### PR TITLE
common: CI: move Fedora Rawhide with sanitizers build to Nightly_Experimental

### DIFF
--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -94,7 +94,8 @@ jobs:
                  "N=DebianS      OS=debian  OS_VER=stable",
                  # Rolling/testing/experimental distributions:
                  "N=Ubuntu_Rolling       OS=ubuntu               OS_VER=rolling",
-                 "N=Fedora_Rawhide       OS=fedora               OS_VER=rawhide",
+                 # the build Fedora_Rawhide with sanitizers was moved to Nightly_Experimental
+                 "N=Fedora_Rawhide_no_SANITS  OS=fedora          OS_VER=rawhide  CI_SANITS=OFF",
                  "N=Debian_Testing       OS=debian               OS_VER=testing",
                  "N=Debian_Experimental  OS=debian               OS_VER=experimental",
                  "N=Arch_Linux_Latest    OS=archlinux-base       OS_VER=latest",

--- a/.github/workflows/nightly_experimental.yml
+++ b/.github/workflows/nightly_experimental.yml
@@ -1,0 +1,41 @@
+
+# This build is run at 00:00 UTC every day
+name: Nightly_Experimental
+
+on:
+  schedule:
+    - cron:  '0 0 * * *'
+
+env:
+    GITHUB_REPO: pmem/rpma
+    # use GitHub Container Registry as a repository of docker images
+    GH_CR_ADDR:  ghcr.io
+    DOCKER_REPO: ghcr.io/pmem/rpma
+    # use org's Private Access Token to log in to GitHub Container Registry
+    GH_CR_USER:  ${{ secrets.GH_CR_USER }}
+    GH_CR_PAT:   ${{ secrets.GH_CR_PAT }}
+    DOC_UPDATE_GITHUB_TOKEN: ${{ secrets.DOC_UPDATE_GITHUB_TOKEN }}
+    HOST_WORKDIR: /home/runner/work/rpma/rpma
+    WORKDIR:      utils/docker
+    TYPE:         normal
+
+jobs:
+  experimental:
+    name: experimental
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        CONFIG: ["N=Fedora_Rawhide_ASAN  OS=fedora  OS_VER=rawhide  CC=clang  CI_SANITS=ON  PUSH_IMAGE=0"]
+    steps:
+       - name: Clone the git repo
+         uses: actions/checkout@v1
+
+       - name: Pull or rebuild the image
+         run: cd $WORKDIR && ${{ matrix.CONFIG }} ./pull-or-rebuild-image.sh
+
+       - name: Run the build
+         run: cd $WORKDIR && ${{ matrix.CONFIG }} ./build.sh
+
+       - name: Push the image
+         run: cd $WORKDIR && source ./set-vars.sh && ${{ matrix.CONFIG }} /bin/bash -c "if [[ -f ${CI_FILE_PUSH_IMAGE_TO_REPO} ]]; then images/push-image.sh; fi"

--- a/utils/docker/build.sh
+++ b/utils/docker/build.sh
@@ -104,6 +104,7 @@ docker run --privileged=true --name=$containerName -i $TTY \
 	--env CI_BRANCH=$CI_BRANCH \
 	--env CI_EVENT_TYPE=$CI_EVENT_TYPE \
 	--env CI_RUN=$CI_RUN \
+	--env CI_SANITS=$CI_SANITS \
 	--env TRAVIS=$TRAVIS \
 	--env COVERITY_SCAN_TOKEN=$COVERITY_SCAN_TOKEN \
 	--env COVERITY_SCAN_NOTIFICATION_EMAIL=$COVERITY_SCAN_NOTIFICATION_EMAIL \

--- a/utils/docker/run-build.sh
+++ b/utils/docker/run-build.sh
@@ -17,6 +17,9 @@ CHECK_CSTYLE=${CHECK_CSTYLE:-ON}
 TEST_DIR=${RPMA_TEST_DIR:-${DEFAULT_TEST_DIR}}
 EXAMPLE_TEST_DIR="/tmp/rpma_example_build"
 
+# turn off sanitizers only if (CI_SANITS == OFF)
+[ "$CI_SANITS" != "OFF" ] && CI_SANITS=ON
+
 if [ "$WORKDIR" == "" ]; then
 	echo "Error: WORKDIR is not set"
 	exit 1
@@ -146,8 +149,8 @@ cmake .. -DCMAKE_BUILD_TYPE=Debug \
 	-DCHECK_CSTYLE=${CHECK_CSTYLE} \
 	-DTESTS_SOFT_ROCE=OFF \
 	-DDEVELOPER_MODE=1 \
-	-DUSE_ASAN=ON \
-	-DUSE_UBSAN=ON
+	-DUSE_ASAN=${CI_SANITS} \
+	-DUSE_UBSAN=${CI_SANITS}
 
 make -j$(nproc)
 ctest --output-on-failure

--- a/utils/docker/set-ci-vars.sh
+++ b/utils/docker/set-ci-vars.sh
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
 #
 # SPDX-License-Identifier: BSD-3-Clause
-# Copyright 2020, Intel Corporation
+# Copyright 2020-2021, Intel Corporation
 
 #
 # set-ci-vars.sh -- set CI variables common for both:
@@ -90,6 +90,7 @@ export CI_BRANCH=$CI_BRANCH
 export CI_EVENT_TYPE=$CI_EVENT_TYPE
 export CI_REPO_SLUG=$CI_REPO_SLUG
 export CI_CPU_ARCH=$CI_CPU_ARCH
+export CI_SANITS=$CI_SANITS
 export IMG_VER=$IMG_VER
 
 echo CI_COMMIT=$CI_COMMIT
@@ -98,4 +99,5 @@ echo CI_BRANCH=$CI_BRANCH
 echo CI_EVENT_TYPE=$CI_EVENT_TYPE
 echo CI_REPO_SLUG=$CI_REPO_SLUG
 echo CI_CPU_ARCH=$CI_CPU_ARCH
+echo CI_SANITS=$CI_SANITS
 echo IMG_VER=$IMG_VER


### PR DESCRIPTION
Move the Fedora Rawhide with sanitizers build to Nightly_Experimental,
because sanitizers fail all tests for unknown reason for a long time.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/pmem/rpma/1004)
<!-- Reviewable:end -->
