### PR TITLE
test: replace SUCCESS with MOCK_OK

### DIFF
--- a/tests/unit/private_data/private_data-common.c
+++ b/tests/unit/private_data/private_data-common.c
@@ -1,5 +1,6 @@
 // SPDX-License-Identifier: BSD-3-Clause
 /* Copyright 2020, Intel Corporation */
+/* Copyright 2021, Fujitsu */
 
 /*
  * private_data-common.c -- the private_data unit tests common functions
@@ -45,11 +46,11 @@ setup__private_data(void **pdata_ptr)
 	edata.param.conn.private_data_len = DEFAULT_LEN;
 
 	/* configure mocks */
-	will_return(__wrap__test_malloc, SUCCESS);
+	will_return(__wrap__test_malloc, MOCK_OK);
 
 	static struct rpma_conn_private_data pdata = {0};
 	int ret = rpma_private_data_store(&edata, &pdata);
-	assert_int_equal(ret, SUCCESS);
+	assert_int_equal(ret, MOCK_OK);
 	assert_non_null(pdata.ptr);
 	assert_string_equal(pdata.ptr, DEFAULT_VALUE);
 	assert_int_equal(pdata.len, DEFAULT_LEN);

--- a/tests/unit/private_data/private_data-common.h
+++ b/tests/unit/private_data/private_data-common.h
@@ -1,5 +1,6 @@
 /* SPDX-License-Identifier: BSD-3-Clause */
 /* Copyright 2020, Intel Corporation */
+/* Copyright 2021, Fujitsu */
 
 /*
  * private_data-common.h -- the private_data unit tests common functions
@@ -15,6 +16,7 @@
 #include "cmocka_headers.h"
 #include "private_data.h"
 #include "librpma.h"
+#include "test-common.h"
 
 /*
  * Both RDMA_CM_EVENT_CONNECT_REQUEST and RDMA_CM_EVENT_ESTABLISHED are valid.
@@ -24,8 +26,6 @@
 
 #define DEFAULT_VALUE	"The default one"
 #define DEFAULT_LEN	(strlen(DEFAULT_VALUE) + 1)
-
-#define SUCCESS		0
 
 int setup__cm_event(void **edata_ptr);
 

--- a/tests/unit/private_data/private_data-store.c
+++ b/tests/unit/private_data/private_data-store.c
@@ -1,5 +1,6 @@
 // SPDX-License-Identifier: BSD-3-Clause
 /* Copyright 2020, Intel Corporation */
+/* Copyright 2021, Fujitsu */
 
 /*
  * private_data-store.c -- the rpma_private_data_store() unit tests
@@ -30,7 +31,7 @@ store__data_NULL(void **edata_ptr)
 	int ret = rpma_private_data_store(*edata_ptr, &pdata);
 
 	/* verify the result */
-	assert_int_equal(ret, SUCCESS);
+	assert_int_equal(ret, MOCK_OK);
 	assert_ptr_equal(pdata.ptr, NULL);
 	assert_int_equal(pdata.len, 0);
 }
@@ -50,7 +51,7 @@ store__data_len_0(void **edata_ptr)
 	int ret = rpma_private_data_store(*edata_ptr, &pdata);
 
 	/* verify the result */
-	assert_int_equal(ret, SUCCESS);
+	assert_int_equal(ret, MOCK_OK);
 	assert_ptr_equal(pdata.ptr, NULL);
 	assert_int_equal(pdata.len, 0);
 }
@@ -71,7 +72,7 @@ store__data_NULL_data_len_0(void **edata_ptr)
 	int ret = rpma_private_data_store(*edata_ptr, &pdata);
 
 	/* verify the result */
-	assert_int_equal(ret, SUCCESS);
+	assert_int_equal(ret, MOCK_OK);
 	assert_ptr_equal(pdata.ptr, NULL);
 	assert_int_equal(pdata.len, 0);
 }


### PR DESCRIPTION
Use unified MOCK_OK for return value.

Signed-off-by: Xiao Yang <yangx.jy@fujitsu.com>

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/pmem/rpma/1024)
<!-- Reviewable:end -->
