### PR TITLE
test: mt: introduce a mtt-framework-provided semaphores

### DIFF
--- a/tests/multithreaded/common/mtt.h
+++ b/tests/multithreaded/common/mtt.h
@@ -11,6 +11,7 @@
 #ifndef MTT
 #define MTT
 
+#include <semaphore.h>
 #include <stddef.h>
 
 /* arguments coming from the command line */
@@ -81,10 +82,12 @@ void *mtt_malloc_aligned(size_t size, struct mtt_result *tr);
  * Arguments:
  * - prestate  - a pointer to the test-provided data. It is the only function
  *               type in which the prestate is expected to be modified.
+ * - sems      - an array of semaphores dedicated for synchronization with
+ *               the child process.
  * - result    - the result. On error the test is responsible for providing
  *               the error details (using e.g. MTT_ERR or MTT_RPMA_ERR macros).
  */
-typedef void (*mtt_prestate_init_fini_func)(void *prestate,
+typedef void (*mtt_prestate_init_fini_func)(void *prestate, sem_t **sems,
 		struct mtt_result *result);
 
 /*
@@ -108,7 +111,7 @@ typedef void (*mtt_prestate_init_fini_func)(void *prestate,
  *               and thread_fini_func).
  */
 typedef void (*mtt_thread_init_fini_func)(unsigned id, void *prestate,
-		void **state_ptr, struct mtt_result *result);
+		void **state_ptr, sem_t **sems, struct mtt_result *result);
 
 /*
  * mtt_thread_func -- a function type used for the main execution step
@@ -131,7 +134,7 @@ typedef void (*mtt_thread_init_fini_func)(unsigned id, void *prestate,
  *              and thread_fini_func).
  */
 typedef void (*mtt_thread_func)(unsigned id, void *prestate, void *state,
-		struct mtt_result *result);
+		sem_t **sems, struct mtt_result *result);
 
 /*
  * mtt_child_process_func -- a function type used for the child process
@@ -140,7 +143,7 @@ typedef void (*mtt_thread_func)(unsigned id, void *prestate, void *state,
  * Arguments:
  * - prestate - a pointer to the test-provided data.
  */
-typedef int (*mtt_child_process_func)(void *prestate);
+typedef int (*mtt_child_process_func)(void *prestate, sem_t **sems);
 
 struct mtt_test {
 	/*
@@ -199,6 +202,6 @@ struct mtt_test {
 	void *child_prestate;
 };
 
-int mtt_run(struct mtt_test *test, unsigned threads_num);
+int mtt_run(struct mtt_test *test, unsigned threads_num, unsigned sems_num);
 
 #endif /* MTT */

--- a/tests/multithreaded/conn/rpma_conn_get_private_data.c
+++ b/tests/multithreaded/conn/rpma_conn_get_private_data.c
@@ -28,7 +28,7 @@ struct prestate {
  * and save it in order to verify it later.
  */
 static void
-prestate_init(void *prestate, struct mtt_result *tr)
+prestate_init(void *prestate, sem_t **sems, struct mtt_result *tr)
 {
 	struct prestate *pr = (struct prestate *)prestate;
 	struct ibv_context *dev;
@@ -103,7 +103,7 @@ err_peer_delete:
  * thread -- get and verify the private data
  */
 static void
-thread(unsigned id, void *prestate, void *state,
+thread(unsigned id, void *prestate, void *state, sem_t **sems,
 		struct mtt_result *result)
 {
 	struct prestate *pr = (struct prestate *)prestate;
@@ -136,7 +136,7 @@ thread(unsigned id, void *prestate, void *state,
  * prestate_fini -- disconnect and delete the peer object
  */
 static void
-prestate_fini(void *prestate, struct mtt_result *tr)
+prestate_fini(void *prestate, sem_t **sems, struct mtt_result *tr)
 {
 	struct prestate *pr = (struct prestate *)prestate;
 	enum rpma_conn_event conn_event = RPMA_CONN_UNDEFINED;
@@ -182,7 +182,7 @@ int server_main(int argc, char *argv[]);
  * from the 02-read-to-volatile example.
  */
 int
-server_func(void *prestate)
+server_func(void *prestate, sem_t **sems)
 {
 	struct server_prestate *pst = prestate;
 	return server_main(pst->argc, pst->argv);
@@ -214,5 +214,5 @@ main(int argc, char *argv[])
 			&server_prestate
 	};
 
-	return mtt_run(&test, args.threads_num);
+	return mtt_run(&test, args.threads_num, 0);
 }

--- a/tests/multithreaded/ep/rpma_ep_get_fd.c
+++ b/tests/multithreaded/ep/rpma_ep_get_fd.c
@@ -25,7 +25,7 @@ struct prestate {
  * get the endpoint's event file descriptor
  */
 static void
-prestate_init(void *prestate, struct mtt_result *tr)
+prestate_init(void *prestate, sem_t **sems, struct mtt_result *tr)
 {
 	struct prestate *pr = (struct prestate *)prestate;
 	int ret;
@@ -60,7 +60,7 @@ prestate_init(void *prestate, struct mtt_result *tr)
  * thread -- get the endpoint's event file descriptor
  */
 static void
-thread(unsigned id, void *prestate, void *state,
+thread(unsigned id, void *prestate, void *state, sem_t **sems,
 		struct mtt_result *result)
 {
 	struct prestate *pr = (struct prestate *)prestate;
@@ -81,7 +81,7 @@ thread(unsigned id, void *prestate, void *state,
  * prestate_fini -- shutdown the endpoint and delete the peer object
  */
 static void
-prestate_fini(void *prestate, struct mtt_result *tr)
+prestate_fini(void *prestate, sem_t **sems, struct mtt_result *tr)
 {
 	struct prestate *pr = (struct prestate *)prestate;
 	int ret;
@@ -114,5 +114,5 @@ main(int argc, char *argv[])
 			prestate_fini
 	};
 
-	return mtt_run(&test, args.threads_num);
+	return mtt_run(&test, args.threads_num, 0);
 }

--- a/tests/multithreaded/ep/rpma_ep_listen.c
+++ b/tests/multithreaded/ep/rpma_ep_listen.c
@@ -26,7 +26,7 @@ struct state {
  * and create a new peer object
  */
 static void
-prestate_init(void *prestate, struct mtt_result *tr)
+prestate_init(void *prestate, sem_t **sems, struct mtt_result *tr)
 {
 	struct prestate *pr = (struct prestate *)prestate;
 	int ret;
@@ -45,7 +45,7 @@ prestate_init(void *prestate, struct mtt_result *tr)
  * init -- allocate state
  */
 void
-init(unsigned id, void *prestate, void **state_ptr,
+init(unsigned id, void *prestate, void **state_ptr, sem_t **sems,
 		struct mtt_result *tr)
 {
 	struct state *st = (struct state *)calloc(1, sizeof(struct state));
@@ -61,7 +61,7 @@ init(unsigned id, void *prestate, void **state_ptr,
  * thread -- start a listening endpoint
  */
 static void
-thread(unsigned id, void *prestate, void *state,
+thread(unsigned id, void *prestate, void *state, sem_t **sems,
 		struct mtt_result *result)
 {
 	struct prestate *pr = (struct prestate *)prestate;
@@ -79,7 +79,7 @@ thread(unsigned id, void *prestate, void *state,
  * fini -- shutdown the endpoint and free the state
  */
 static void
-fini(unsigned id, void *prestate, void **state_ptr,
+fini(unsigned id, void *prestate, void **state_ptr, sem_t **sems,
 		struct mtt_result *tr)
 {
 	struct state *st = (struct state *)*state_ptr;
@@ -97,7 +97,7 @@ fini(unsigned id, void *prestate, void **state_ptr,
  * prestate_fini -- delete the peer object
  */
 static void
-prestate_fini(void *prestate, struct mtt_result *tr)
+prestate_fini(void *prestate, sem_t **sems, struct mtt_result *tr)
 {
 	struct prestate *pr = (struct prestate *)prestate;
 	int ret;
@@ -127,5 +127,5 @@ main(int argc, char *argv[])
 			prestate_fini
 	};
 
-	return mtt_run(&test, args.threads_num);
+	return mtt_run(&test, args.threads_num, 0);
 }

--- a/tests/multithreaded/example/example.c
+++ b/tests/multithreaded/example/example.c
@@ -59,7 +59,7 @@ struct state {
  * prestate_init -- prestate initialization called once for all threads
  */
 static void
-prestate_init(void *prestate, struct mtt_result *tr)
+prestate_init(void *prestate, sem_t **sems, struct mtt_result *tr)
 {
 	struct prestate *pr = (struct prestate *)prestate;
 	pr->seed = 5; /* an arbitrary seed */
@@ -72,7 +72,7 @@ prestate_init(void *prestate, struct mtt_result *tr)
  * should go here.
  */
 static void
-seq_init(unsigned id, void *prestate, void **state_ptr,
+seq_init(unsigned id, void *prestate, void **state_ptr, sem_t **sems,
 		struct mtt_result *tr)
 {
 	struct prestate *pr = (struct prestate *)prestate;
@@ -93,7 +93,7 @@ seq_init(unsigned id, void *prestate, void **state_ptr,
  * should go here.
  */
 void
-init(unsigned id, void *prestate, void **state_ptr,
+init(unsigned id, void *prestate, void **state_ptr, sem_t **sems,
 		struct mtt_result *tr)
 {
 	struct state *st = (struct state *)*state_ptr;
@@ -108,7 +108,7 @@ init(unsigned id, void *prestate, void **state_ptr,
  * thread -- a test itself (parallel)
  */
 static void
-thread(unsigned id, void *prestate, void *state,
+thread(unsigned id, void *prestate, void *state, sem_t **sems,
 		struct mtt_result *tr)
 {
 	struct state *st = (struct state *)state;
@@ -122,7 +122,7 @@ thread(unsigned id, void *prestate, void *state,
  * should go here.
  */
 static void
-fini(unsigned id, void *prestate, void **state_ptr,
+fini(unsigned id, void *prestate, void **state_ptr, sem_t **sems,
 		struct mtt_result *tr)
 {
 	struct state *st = (struct state *)*state_ptr;
@@ -139,7 +139,7 @@ fini(unsigned id, void *prestate, void **state_ptr,
  * should go here.
  */
 static void
-seq_fini(unsigned id, void *prestate, void **state_ptr,
+seq_fini(unsigned id, void *prestate, void **state_ptr, sem_t **sems,
 		struct mtt_result *tr)
 {
 	struct state *st = (struct state *)*state_ptr;
@@ -153,7 +153,7 @@ seq_fini(unsigned id, void *prestate, void **state_ptr,
  * prestate_fini -- prestate cleanup called once for all threads
  */
 static void
-prestate_fini(void *prestate, struct mtt_result *tr)
+prestate_fini(void *prestate, sem_t **sems, struct mtt_result *tr)
 {
 	struct prestate *pr = (struct prestate *)prestate;
 	pr->seed = 0; /* zero out the seed */
@@ -180,5 +180,5 @@ main(int argc, char *argv[])
 			prestate_fini
 	};
 
-	return mtt_run(&test, args.threads_num);
+	return mtt_run(&test, args.threads_num, 0);
 }

--- a/tests/multithreaded/mr/rpma_mr_reg.c
+++ b/tests/multithreaded/mr/rpma_mr_reg.c
@@ -29,7 +29,7 @@ struct state {
  * and create a new peer object
  */
 static void
-prestate_init(void *prestate, struct mtt_result *tr)
+prestate_init(void *prestate, sem_t **sems, struct mtt_result *tr)
 {
 	struct prestate *pr = (struct prestate *)prestate;
 	int ret;
@@ -48,7 +48,7 @@ prestate_init(void *prestate, struct mtt_result *tr)
  * init -- allocate state and memory region
  */
 void
-init(unsigned id, void *prestate, void **state_ptr,
+init(unsigned id, void *prestate, void **state_ptr, sem_t **sems,
 		struct mtt_result *tr)
 {
 	struct state *st = (struct state *)calloc(1, sizeof(struct state));
@@ -70,7 +70,7 @@ init(unsigned id, void *prestate, void **state_ptr,
  * thread -- register the memory
  */
 static void
-thread(unsigned id, void *prestate, void *state,
+thread(unsigned id, void *prestate, void *state, sem_t **sems,
 		struct mtt_result *result)
 {
 	struct prestate *pr = (struct prestate *)prestate;
@@ -86,7 +86,7 @@ thread(unsigned id, void *prestate, void *state,
  * fini -- deregister the memory region and free the state
  */
 static void
-fini(unsigned id, void *prestate, void **state_ptr,
+fini(unsigned id, void *prestate, void **state_ptr, sem_t **sems,
 		struct mtt_result *tr)
 {
 	struct state *st = (struct state *)*state_ptr;
@@ -106,7 +106,7 @@ fini(unsigned id, void *prestate, void **state_ptr,
  * prestate_fini -- delete the peer object
  */
 static void
-prestate_fini(void *prestate, struct mtt_result *tr)
+prestate_fini(void *prestate, sem_t **sems, struct mtt_result *tr)
 {
 	struct prestate *pr = (struct prestate *)prestate;
 	int ret;
@@ -136,5 +136,5 @@ main(int argc, char *argv[])
 			prestate_fini
 	};
 
-	return mtt_run(&test, args.threads_num);
+	return mtt_run(&test, args.threads_num, 0);
 }

--- a/tests/multithreaded/peer/rpma_peer_new.c
+++ b/tests/multithreaded/peer/rpma_peer_new.c
@@ -23,7 +23,7 @@ struct state {
  * prestate_init -- obtain an ibv_context for a remote IP address
  */
 static void
-prestate_init(void *prestate, struct mtt_result *tr)
+prestate_init(void *prestate, sem_t **sems, struct mtt_result *tr)
 {
 	struct prestate *pr = (struct prestate *)prestate;
 	int ret = rpma_utils_get_ibv_context(pr->addr,
@@ -36,7 +36,7 @@ prestate_init(void *prestate, struct mtt_result *tr)
  * init -- allocate state
  */
 void
-init(unsigned id, void *prestate, void **state_ptr,
+init(unsigned id, void *prestate, void **state_ptr, sem_t **sems,
 		struct mtt_result *tr)
 {
 	struct state *st = (struct state *)calloc(1, sizeof(struct state));
@@ -52,7 +52,7 @@ init(unsigned id, void *prestate, void **state_ptr,
  * thread -- create rpma_peer based on shared ibv_context
  */
 static void
-thread(unsigned id, void *prestate, void *state,
+thread(unsigned id, void *prestate, void *state, sem_t **sems,
 		struct mtt_result *result)
 {
 	struct prestate *pr = (struct prestate *)prestate;
@@ -70,7 +70,7 @@ thread(unsigned id, void *prestate, void *state,
  * fini -- delete rpma_peer and free the state
  */
 static void
-fini(unsigned id, void *prestate, void **state_ptr,
+fini(unsigned id, void *prestate, void **state_ptr, sem_t **sems,
 		struct mtt_result *tr)
 {
 	struct state *st = (struct state *)*state_ptr;
@@ -104,5 +104,5 @@ main(int argc, char *argv[])
 			NULL
 	};
 
-	return mtt_run(&test, args.threads_num);
+	return mtt_run(&test, args.threads_num, 0);
 }

--- a/tests/multithreaded/utils/rpma_utils_get_ibv_context.c
+++ b/tests/multithreaded/utils/rpma_utils_get_ibv_context.c
@@ -18,7 +18,7 @@ struct prestate {
  * address string
  */
 static void
-thread(unsigned id, void *prestate, void *state,
+thread(unsigned id, void *prestate, void *state, sem_t **sems,
 		struct mtt_result *result)
 {
 	struct prestate *ps = (struct prestate *)prestate;
@@ -53,5 +53,5 @@ main(int argc, char *argv[])
 			NULL
 	};
 
-	return mtt_run(&test, args.threads_num);
+	return mtt_run(&test, args.threads_num, 0);
 }

--- a/tests/multithreaded/utils/rpma_utils_ibv_context_is_odp_capable.c
+++ b/tests/multithreaded/utils/rpma_utils_ibv_context_is_odp_capable.c
@@ -26,7 +26,7 @@ struct prestate {
  * and check if the device supports On-Demand Paging
  */
 static void
-prestate_init(void *prestate, struct mtt_result *tr)
+prestate_init(void *prestate, sem_t **sems, struct mtt_result *tr)
 {
 	struct prestate *pr = (struct prestate *)prestate;
 	int ret;
@@ -51,7 +51,8 @@ prestate_init(void *prestate, struct mtt_result *tr)
  * and check if the device supports On-Demand Paging
  */
 static void
-thread(unsigned id, void *prestate, void *state, struct mtt_result *tr)
+thread(unsigned id, void *prestate, void *state, sem_t **sems,
+		struct mtt_result *tr)
 {
 	struct prestate *pr = (struct prestate *)prestate;
 	int is_odp_supported;
@@ -87,5 +88,5 @@ main(int argc, char *argv[])
 			NULL
 	};
 
-	return mtt_run(&test, args.threads_num);
+	return mtt_run(&test, args.threads_num, 0);
 }


### PR DESCRIPTION
These semaphores are dedicated to interprocess synchronization between the parent and the child processes.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/pmem/rpma/1050)
<!-- Reviewable:end -->
