### PR TITLE
test: use simulated errno on all ep unit tests

### DIFF
--- a/tests/unit/common/test-common.h
+++ b/tests/unit/common/test-common.h
@@ -1,5 +1,6 @@
 /* SPDX-License-Identifier: BSD-3-Clause */
 /* Copyright 2020, Intel Corporation */
+/* Copyright 2021, Fujitsu */
 
 /*
  * test-common.h -- a test's common header
@@ -35,6 +36,7 @@
 
 #define MOCK_OK			0
 #define MOCK_ERRNO		123456
+#define MOCK_ERRNO2		234567
 
 #define MOCK_PASSTHROUGH	0
 #define MOCK_VALIDATE		1

--- a/tests/unit/ep/ep-listen.c
+++ b/tests/unit/ep/ep-listen.c
@@ -1,5 +1,6 @@
 // SPDX-License-Identifier: BSD-3-Clause
 /* Copyright 2020, Intel Corporation */
+/* Copyright 2021, Fujitsu */
 
 /*
  * ep-listen.c -- the endpoint unit tests
@@ -87,18 +88,18 @@ listen__peer_addr_port_ep_ptr_NULL(void **unused)
 }
 
 /*
- * listen__create_evch_EAGAIN - rdma_create_event_channel() fails
- * with EAGAIN
+ * listen__create_evch_ERRNO - rdma_create_event_channel() fails
+ * with MOCK_ERRNO
  */
 static void
-listen__create_evch_EAGAIN(void **unused)
+listen__create_evch_ERRNO(void **unused)
 {
 	/*
 	 * configure mocks for:
 	 * - constructing:
 	 */
 	will_return(rdma_create_event_channel, NULL);
-	will_return(rdma_create_event_channel, EAGAIN);
+	will_return(rdma_create_event_channel, MOCK_ERRNO);
 	/* - things which may happen: */
 	will_return_maybe(rpma_info_new, MOCK_INFO);
 	will_return_maybe(__wrap__test_malloc, MOCK_OK);
@@ -113,10 +114,10 @@ listen__create_evch_EAGAIN(void **unused)
 }
 
 /*
- * listen__create_id_EAGAIN - rdma_create_id() fails with EAGAIN
+ * listen__create_id_ERRNO - rdma_create_id() fails with MOCK_ERRNO
  */
 static void
-listen__create_id_EAGAIN(void **unused)
+listen__create_id_ERRNO(void **unused)
 {
 	/*
 	 * configure mocks:
@@ -125,7 +126,7 @@ listen__create_id_EAGAIN(void **unused)
 	struct rdma_event_channel evch;
 	will_return(rdma_create_event_channel, &evch);
 	will_return(rdma_create_id, NULL);
-	will_return(rdma_create_id, EAGAIN);
+	will_return(rdma_create_id, MOCK_ERRNO);
 	/* - things which may happen: */
 	will_return_maybe(rpma_info_new, MOCK_INFO);
 	will_return_maybe(__wrap__test_malloc, MOCK_OK);
@@ -140,8 +141,7 @@ listen__create_id_EAGAIN(void **unused)
 }
 
 /*
- * listen__info_new_E_NOMEM - rpma_info_new() fails with
- * RPMA_E_NOMEM
+ * listen__info_new_E_NOMEM - rpma_info_new() returns RPMA_E_NOMEM
  */
 static void
 listen__info_new_E_NOMEM(void **unused)
@@ -169,8 +169,8 @@ listen__info_new_E_NOMEM(void **unused)
 }
 
 /*
- * listen__info_bind_addr_E_PROVIDER - rpma_info_bind_addr() fails
- * with RPMA_E_PROVIDER
+ * listen__info_bind_addr_E_PROVIDER - rpma_info_bind_addr() returns
+ * RPMA_E_PROVIDER
  */
 static void
 listen__info_bind_addr_E_PROVIDER(void **unused)
@@ -198,10 +198,10 @@ listen__info_bind_addr_E_PROVIDER(void **unused)
 }
 
 /*
- * listen__listen_EAGAIN - rdma_listen() fails with EAGAIN
+ * listen__listen_ERRNO - rdma_listen() fails with MOCK_ERRNO
  */
 static void
-listen__listen_EAGAIN(void **unused)
+listen__listen_ERRNO(void **unused)
 {
 	/*
 	 * configure mocks for:
@@ -213,7 +213,7 @@ listen__listen_EAGAIN(void **unused)
 	will_return(rdma_create_id, &id);
 	will_return(rpma_info_new, MOCK_INFO);
 	will_return(rpma_info_bind_addr, MOCK_OK);
-	will_return(rdma_listen, EAGAIN);
+	will_return(rdma_listen, MOCK_ERRNO);
 	/* - deconstructing */
 	will_return(rdma_destroy_id, MOCK_OK);
 
@@ -227,16 +227,16 @@ listen__listen_EAGAIN(void **unused)
 }
 
 /*
- * listen__malloc_ENOMEM - malloc() fails with ENOMEM
+ * listen__malloc_ERRNO - malloc() fails with MOCK_ERRNO
  */
 static void
-listen__malloc_ENOMEM(void **unused)
+listen__malloc_ERRNO(void **unused)
 {
 	/*
 	 * configure mocks for:
 	 * - constructing
 	 */
-	will_return(__wrap__test_malloc, ENOMEM);
+	will_return(__wrap__test_malloc, MOCK_ERRNO);
 	/* - things which may happen: */
 	struct rdma_event_channel evch;
 	will_return_maybe(rdma_create_event_channel, &evch);
@@ -257,14 +257,15 @@ listen__malloc_ENOMEM(void **unused)
 }
 
 /*
- * listen__malloc_ENOMEM_destroy_id_EAGAIN - malloc() fails with ENOMEM
- * rdma_destroy_id() fails consequently during the handling of the first error
+ * listen__malloc_ERRNO_destroy_id_ERRNO2 - malloc() fails with MOCK_ERRNO
+ * rdma_destroy_id() fails with MOCK_ERRNO2 consequently during the handling
+ * of the first error
  *
  * Note: test assumes rdma_create_id() is called before the first failing
  * malloc()
  */
 static void
-listen__malloc_ENOMEM_destroy_id_EAGAIN(void **unused)
+listen__malloc_ERRNO_destroy_id_ERRNO2(void **unused)
 {
 	/*
 	 * configure mocks for:
@@ -277,9 +278,9 @@ listen__malloc_ENOMEM_destroy_id_EAGAIN(void **unused)
 	will_return(rpma_info_new, MOCK_INFO);
 	will_return(rpma_info_bind_addr, MOCK_OK);
 	will_return(rdma_listen, MOCK_OK);
-	will_return(__wrap__test_malloc, ENOMEM); /* first error */
+	will_return(__wrap__test_malloc, MOCK_ERRNO); /* first error */
 	/* - deconstructing */
-	will_return(rdma_destroy_id, MOCK_ERRNO); /* second error */
+	will_return(rdma_destroy_id, MOCK_ERRNO2); /* second error */
 
 	/* run test */
 	struct rpma_ep *ep = NULL;
@@ -331,16 +332,16 @@ ep__lifecycle(void **unused)
 }
 
 /*
- * shutdown__destroy_id_EAGAIN -- rdma_destroy_id() fails with EAGAIN
+ * shutdown__destroy_id_ERRNO -- rdma_destroy_id() fails with MOCK_ERRNO
  */
 static void
-shutdown__destroy_id_EAGAIN(void **estate_ptr)
+shutdown__destroy_id_ERRNO(void **estate_ptr)
 {
 	struct ep_test_state *estate = *estate_ptr;
 
 	/* configure mocks */
 	expect_value(rdma_destroy_id, id, &estate->cmid);
-	will_return(rdma_destroy_id, EAGAIN);
+	will_return(rdma_destroy_id, MOCK_ERRNO);
 
 	/* run test */
 	int ret = rpma_ep_shutdown(&estate->ep);
@@ -368,14 +369,14 @@ main(int argc, char *argv[])
 		cmocka_unit_test(listen__port_NULL),
 		cmocka_unit_test(listen__ep_ptr_NULL),
 		cmocka_unit_test(listen__peer_addr_port_ep_ptr_NULL),
-		cmocka_unit_test(listen__create_evch_EAGAIN),
-		cmocka_unit_test(listen__create_id_EAGAIN),
+		cmocka_unit_test(listen__create_evch_ERRNO),
+		cmocka_unit_test(listen__create_id_ERRNO),
 		cmocka_unit_test(listen__info_new_E_NOMEM),
 		cmocka_unit_test(listen__info_bind_addr_E_PROVIDER),
-		cmocka_unit_test(listen__listen_EAGAIN),
-		cmocka_unit_test(listen__malloc_ENOMEM),
+		cmocka_unit_test(listen__listen_ERRNO),
+		cmocka_unit_test(listen__malloc_ERRNO),
 		cmocka_unit_test(
-			listen__malloc_ENOMEM_destroy_id_EAGAIN),
+			listen__malloc_ERRNO_destroy_id_ERRNO2),
 
 		/* rpma_ep_listen()/_shutdown() lifecycle */
 		cmocka_unit_test_prestate_setup_teardown(ep__lifecycle,
@@ -386,7 +387,7 @@ main(int argc, char *argv[])
 		cmocka_unit_test(shutdown__ep_ptr_NULL),
 		cmocka_unit_test(shutdown__ep_NULL),
 		cmocka_unit_test_prestate_setup_teardown(
-			shutdown__destroy_id_EAGAIN,
+			shutdown__destroy_id_ERRNO,
 			setup__ep_listen, teardown__ep_shutdown,
 			&prestate_conn_cfg_default),
 	};

--- a/tests/unit/ep/ep-next_conn_req.c
+++ b/tests/unit/ep/ep-next_conn_req.c
@@ -1,5 +1,6 @@
 // SPDX-License-Identifier: BSD-3-Clause
 /* Copyright 2020, Intel Corporation */
+/* Copyright 2021, Fujitsu */
 
 /*
  * ep-next_conn_req.c -- the endpoint unit tests
@@ -58,17 +59,17 @@ next_conn_req__ep_NULL_req_NULL(void **unused)
 }
 
 /*
- * next_conn_req__get_cm_event_EAGAIN -
- * rdma_get_cm_event() fails with EAGAIN
+ * next_conn_req__get_cm_event_ERRNO -
+ * rdma_get_cm_event() fails with MOCK_ERRNO
  */
 static void
-next_conn_req__get_cm_event_EAGAIN(void **estate_ptr)
+next_conn_req__get_cm_event_ERRNO(void **estate_ptr)
 {
 	struct ep_test_state *estate = *estate_ptr;
 
 	expect_value(rdma_get_cm_event, channel, &estate->evch);
 	will_return(rdma_get_cm_event, NULL);
-	will_return(rdma_get_cm_event, EAGAIN);
+	will_return(rdma_get_cm_event, MOCK_ERRNO);
 
 	/* run test */
 	struct rpma_conn_req *req = NULL;
@@ -128,12 +129,12 @@ next_conn_req__event_REJECTED(void **estate_ptr)
 }
 
 /*
- * next_conn_req__event_REJECTED_ack_EINVAL -
- * rdma_ack_cm_event() fails with EINVAL after obtaining
+ * next_conn_req__event_REJECTED_ack_ERRNO -
+ * rdma_ack_cm_event() fails with MOCK_ERRNO after obtaining
  * an RDMA_CM_EVENT_REJECTED event (!= RDMA_CM_EVENT_CONNECT_REQUEST)
  */
 static void
-next_conn_req__event_REJECTED_ack_EINVAL(void **estate_ptr)
+next_conn_req__event_REJECTED_ack_ERRNO(void **estate_ptr)
 {
 	struct ep_test_state *estate = *estate_ptr;
 
@@ -143,7 +144,7 @@ next_conn_req__event_REJECTED_ack_EINVAL(void **estate_ptr)
 	will_return(rdma_get_cm_event, &event);
 
 	expect_value(rdma_ack_cm_event, event, &event);
-	will_return(rdma_ack_cm_event, EINVAL);
+	will_return(rdma_ack_cm_event, MOCK_ERRNO);
 
 	/* run test */
 	struct rpma_conn_req *req = NULL;
@@ -155,11 +156,11 @@ next_conn_req__event_REJECTED_ack_EINVAL(void **estate_ptr)
 }
 
 /*
- * next_conn_req__conn_req_from_cm_event_ENOMEM -
- * rpma_conn_req_from_cm_event() fails with ENOMEM
+ * next_conn_req__from_cm_event_E_NOMEM -
+ * rpma_conn_req_from_cm_event() returns RPMA_E_NOMEM
  */
 static void
-next_conn_req__conn_req_from_cm_event_ENOMEM(void **estate_ptr)
+next_conn_req__from_cm_event_E_NOMEM(void **estate_ptr)
 {
 	struct ep_test_state *estate = *estate_ptr;
 
@@ -187,12 +188,12 @@ next_conn_req__conn_req_from_cm_event_ENOMEM(void **estate_ptr)
 }
 
 /*
- * next_conn_req__from_cm_event_ENOMEM_ack_EINVAL -
- * rpma_conn_req_from_cm_event() fails and
- * rdma_ack_cm_event() fails with EINVAL
+ * next_conn_req__from_cm_event_E_NOMEM_ack_ERRNO -
+ * rpma_conn_req_from_cm_event() returns RPMA_E_NOMEM
+ * and rdma_ack_cm_event() fails with MOCK_ERRNO
  */
 static void
-next_conn_req__from_cm_event_ENOMEM_ack_EINVAL(void **estate_ptr)
+next_conn_req__from_cm_event_E_NOMEM_ack_ERRNO(void **estate_ptr)
 {
 	struct ep_test_state *estate = *estate_ptr;
 
@@ -208,7 +209,7 @@ next_conn_req__from_cm_event_ENOMEM_ack_EINVAL(void **estate_ptr)
 	will_return(rpma_conn_req_from_cm_event, RPMA_E_NOMEM);
 
 	expect_value(rdma_ack_cm_event, event, &event);
-	will_return(rdma_ack_cm_event, EINVAL);
+	will_return(rdma_ack_cm_event, MOCK_ERRNO);
 
 	/* run test */
 	struct rpma_conn_req *req = NULL;
@@ -266,11 +267,11 @@ main(int argc, char *argv[])
 			&prestate_conn_cfg_default),
 		cmocka_unit_test(next_conn_req__ep_NULL_req_NULL),
 		cmocka_unit_test_prestate_setup_teardown(
-			next_conn_req__get_cm_event_ENODATA,
+			next_conn_req__get_cm_event_ERRNO,
 			setup__ep_listen, teardown__ep_shutdown,
 			&prestate_conn_cfg_default),
 		cmocka_unit_test_prestate_setup_teardown(
-			next_conn_req__get_cm_event_EAGAIN,
+			next_conn_req__get_cm_event_ENODATA,
 			setup__ep_listen, teardown__ep_shutdown,
 			&prestate_conn_cfg_default),
 		cmocka_unit_test_prestate_setup_teardown(
@@ -278,15 +279,15 @@ main(int argc, char *argv[])
 			setup__ep_listen, teardown__ep_shutdown,
 			&prestate_conn_cfg_default),
 		cmocka_unit_test_prestate_setup_teardown(
-			next_conn_req__event_REJECTED_ack_EINVAL,
+			next_conn_req__event_REJECTED_ack_ERRNO,
 			setup__ep_listen, teardown__ep_shutdown,
 			&prestate_conn_cfg_default),
 		cmocka_unit_test_prestate_setup_teardown(
-			next_conn_req__conn_req_from_cm_event_ENOMEM,
+			next_conn_req__from_cm_event_E_NOMEM,
 			setup__ep_listen, teardown__ep_shutdown,
 			&prestate_conn_cfg_default),
 		cmocka_unit_test_prestate_setup_teardown(
-			next_conn_req__from_cm_event_ENOMEM_ack_EINVAL,
+			next_conn_req__from_cm_event_E_NOMEM_ack_ERRNO,
 			setup__ep_listen, teardown__ep_shutdown,
 			&prestate_conn_cfg_default),
 		{"next_conn_req__success_conn_cfg_default",


### PR DESCRIPTION
replace real errno (e.g. EAGAIN, ENOMEM) with simulated
errno (e.g. MOCK_ERRNO, MOCK_ERRNO2) on all ep unit tests.

Note:
except ENODATA because it is processed by librpma specially.

Signed-off-by: Xiao Yang <yangx.jy@fujitsu.com>

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/pmem/rpma/1061)
<!-- Reviewable:end -->
