### PR TITLE
examples: make common functions accept conn_cfg

### DIFF
--- a/examples/02-read-to-volatile/client.c
+++ b/examples/02-read-to-volatile/client.c
@@ -77,7 +77,7 @@ main(int argc, char *argv[])
 		goto err_mr_free;
 
 	/* establish a new connection to a server listening at addr:port */
-	ret = client_connect(peer, addr, port, NULL, &conn);
+	ret = client_connect(peer, addr, port, NULL, NULL, &conn);
 	if (ret)
 		goto err_mr_dereg;
 

--- a/examples/02-read-to-volatile/server.c
+++ b/examples/02-read-to-volatile/server.c
@@ -104,7 +104,7 @@ main(int argc, char *argv[])
 	 * Wait for an incoming connection request, accept it and wait for its
 	 * establishment.
 	 */
-	ret = server_accept_connection(ep, &pdata, &conn);
+	ret = server_accept_connection(ep, NULL, &pdata, &conn);
 	if (ret)
 		goto err_mr_dereg;
 

--- a/examples/03-read-to-persistent/client.c
+++ b/examples/03-read-to-persistent/client.c
@@ -177,7 +177,7 @@ main(int argc, char *argv[])
 	struct rpma_conn_private_data pdata;
 	pdata.ptr = &data;
 	pdata.len = sizeof(struct common_data);
-	ret = client_connect(peer, addr, port, &pdata, &conn);
+	ret = client_connect(peer, addr, port, NULL, &pdata, &conn);
 	if (ret)
 		goto err_mr_dereg;
 

--- a/examples/03-read-to-persistent/server.c
+++ b/examples/03-read-to-persistent/server.c
@@ -144,7 +144,7 @@ main(int argc, char *argv[])
 	 * Wait for an incoming connection request, accept it and wait for its
 	 * establishment.
 	 */
-	ret = server_accept_connection(ep, NULL, &conn);
+	ret = server_accept_connection(ep, NULL, NULL, &conn);
 	if (ret)
 		goto err_mr_dereg;
 

--- a/examples/04-write-to-persistent/client.c
+++ b/examples/04-write-to-persistent/client.c
@@ -178,7 +178,7 @@ main(int argc, char *argv[])
 		goto err_free;
 
 	/* establish a new connection to a server listening at addr:port */
-	ret = client_connect(peer, addr, port, NULL, &conn);
+	ret = client_connect(peer, addr, port, NULL, NULL, &conn);
 	if (ret)
 		goto err_peer_delete;
 

--- a/examples/04-write-to-persistent/server.c
+++ b/examples/04-write-to-persistent/server.c
@@ -176,7 +176,7 @@ main(int argc, char *argv[])
 	struct rpma_conn_private_data pdata;
 	pdata.ptr = &data;
 	pdata.len = sizeof(struct common_data);
-	ret = server_accept_connection(ep, &pdata, &conn);
+	ret = server_accept_connection(ep, NULL, &pdata, &conn);
 	if (ret)
 		goto err_mr_dereg;
 

--- a/examples/05-flush-to-persistent/client.c
+++ b/examples/05-flush-to-persistent/client.c
@@ -164,7 +164,7 @@ main(int argc, char *argv[])
 		goto err_free;
 
 	/* establish a new connection to a server listening at addr:port */
-	ret = client_connect(peer, addr, port, NULL, &conn);
+	ret = client_connect(peer, addr, port, NULL, NULL, &conn);
 	if (ret)
 		goto err_peer_delete;
 

--- a/examples/05-flush-to-persistent/server.c
+++ b/examples/05-flush-to-persistent/server.c
@@ -212,7 +212,7 @@ main(int argc, char *argv[])
 	struct rpma_conn_private_data pdata;
 	pdata.ptr = &data;
 	pdata.len = sizeof(struct common_data);
-	ret = server_accept_connection(ep, &pdata, &conn);
+	ret = server_accept_connection(ep, NULL, &pdata, &conn);
 	if (ret)
 		goto err_mr_dereg;
 

--- a/examples/06-multiple-connections/client.c
+++ b/examples/06-multiple-connections/client.c
@@ -115,7 +115,7 @@ main(int argc, char *argv[])
 	pdata.len = sizeof(struct common_data);
 
 	/* establish a new connection to a server listening at addr:port */
-	ret = client_connect(peer, addr, port, &pdata, &conn);
+	ret = client_connect(peer, addr, port, NULL, &pdata, &conn);
 	if (ret)
 		goto err_mr_dereg;
 

--- a/examples/07-atomic-write/client.c
+++ b/examples/07-atomic-write/client.c
@@ -63,7 +63,7 @@ main(int argc, char *argv[])
 		goto err_free;
 
 	/* establish a new connection to a server listening at addr:port */
-	if ((ret = client_connect(peer, addr, port, NULL, &conn)))
+	if ((ret = client_connect(peer, addr, port, NULL, NULL, &conn)))
 		goto err_peer_delete;
 
 	/*

--- a/examples/07-atomic-write/server.c
+++ b/examples/07-atomic-write/server.c
@@ -183,7 +183,7 @@ main(int argc, char *argv[])
 	struct rpma_conn_private_data pdata;
 	pdata.ptr = &data;
 	pdata.len = sizeof(struct common_data);
-	if ((ret = server_accept_connection(ep, &pdata, &conn)))
+	if ((ret = server_accept_connection(ep, NULL, &pdata, &conn)))
 		goto err_mr_dereg;
 
 	/*

--- a/examples/08-messages-ping-pong/client.c
+++ b/examples/08-messages-ping-pong/client.c
@@ -90,7 +90,7 @@ main(int argc, char *argv[])
 	}
 
 	/* establish a new connection to a server listening at addr:port */
-	if ((ret = client_connect(peer, addr, port, NULL, &conn)))
+	if ((ret = client_connect(peer, addr, port, NULL, NULL, &conn)))
 		goto err_mr_dereg;
 
 	while (--rounds) {

--- a/examples/09-flush-to-persistent-GPSPM/client.c
+++ b/examples/09-flush-to-persistent-GPSPM/client.c
@@ -182,7 +182,7 @@ main(int argc, char *argv[])
 		goto err_free;
 
 	/* establish a new connection to a server listening at addr:port */
-	if ((ret = client_connect(peer, addr, port, NULL, &conn)))
+	if ((ret = client_connect(peer, addr, port, NULL, NULL, &conn)))
 		goto err_peer_delete;
 
 	/* register the memory RDMA write */

--- a/examples/10-send-with-imm/client.c
+++ b/examples/10-send-with-imm/client.c
@@ -91,7 +91,7 @@ main(int argc, char *argv[])
 	struct rpma_conn_private_data pdata;
 	pdata.ptr = (uint32_t *)&imm;
 	pdata.len = sizeof(uint32_t);
-	ret = client_connect(peer, addr, port, &pdata, &conn);
+	ret = client_connect(peer, addr, port, NULL, &pdata, &conn);
 	if (ret)
 		goto err_mr_dereg;
 

--- a/examples/11-write-with-imm/client.c
+++ b/examples/11-write-with-imm/client.c
@@ -75,7 +75,7 @@ main(int argc, char *argv[])
 		goto err_peer_delete;
 
 	/* establish a new connection to a server */
-	ret = client_connect(peer, addr, port, NULL, &conn);
+	ret = client_connect(peer, addr, port, NULL, NULL, &conn);
 	if (ret)
 		goto err_mr_dereg;
 

--- a/examples/common/common-conn.c
+++ b/examples/common/common-conn.c
@@ -62,14 +62,14 @@ common_peer_via_address(const char *addr, enum rpma_util_ibv_context_type type,
  */
 int
 client_connect(struct rpma_peer *peer, const char *addr, const char *port,
-		struct rpma_conn_private_data *pdata,
+		struct rpma_conn_cfg *cfg, struct rpma_conn_private_data *pdata,
 		struct rpma_conn **conn_ptr)
 {
 	struct rpma_conn_req *req = NULL;
 	enum rpma_conn_event conn_event = RPMA_CONN_UNDEFINED;
 
 	/* create a connection request */
-	int ret = rpma_conn_req_new(peer, addr, port, NULL, &req);
+	int ret = rpma_conn_req_new(peer, addr, port, cfg, &req);
 	if (ret)
 		return ret;
 
@@ -104,7 +104,7 @@ err_conn_delete:
  * accept it and wait for its establishment
  */
 int
-server_accept_connection(struct rpma_ep *ep,
+server_accept_connection(struct rpma_ep *ep, struct rpma_conn_cfg *cfg,
 		struct rpma_conn_private_data *pdata,
 		struct rpma_conn **conn_ptr)
 {
@@ -112,7 +112,7 @@ server_accept_connection(struct rpma_ep *ep,
 	enum rpma_conn_event conn_event = RPMA_CONN_UNDEFINED;
 
 	/* receive an incoming connection request */
-	int ret = rpma_ep_next_conn_req(ep, NULL, &req);
+	int ret = rpma_ep_next_conn_req(ep, cfg, &req);
 	if (ret)
 		return ret;
 

--- a/examples/common/common-conn.h
+++ b/examples/common/common-conn.h
@@ -51,11 +51,11 @@ int common_peer_via_address(const char *addr,
 		common_peer_via_address(addr, RPMA_UTIL_IBV_CONTEXT_LOCAL, \
 				peer_ptr)
 
-int client_connect(struct rpma_peer *peer, const char *addr,
-		const char *port, struct rpma_conn_private_data *pdata,
+int client_connect(struct rpma_peer *peer, const char *addr, const char *port,
+		struct rpma_conn_cfg *cfg, struct rpma_conn_private_data *pdata,
 		struct rpma_conn **conn_ptr);
 
-int server_accept_connection(struct rpma_ep *ep,
+int server_accept_connection(struct rpma_ep *ep, struct rpma_conn_cfg *cfg,
 		struct rpma_conn_private_data *pdata,
 		struct rpma_conn **conn_ptr);
 


### PR DESCRIPTION
pass conn_cfg into client_connect() and server_accept_connection().

Signed-off-by: Xiao Yang <yangx.jy@fujitsu.com>

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/pmem/rpma/1067)
<!-- Reviewable:end -->
