### PR TITLE
Update txt2man version requirement in INSTALL.md

### DIFF
--- a/INSTALL.md
+++ b/INSTALL.md
@@ -18,7 +18,7 @@ In order to build librpma, you need to have installed several components:
 - diff
 - find
 - groff
-- txt2man == 1.7.0 (please see https://github.com/pmem/rpma/blob/master/utils/docker/images/install-txt2man.sh to install the verified revision)
+- txt2man >= 1.7.0 (please see https://github.com/pmem/rpma/blob/master/utils/docker/images/install-txt2man.sh to install the verified revision)
 
 and optionally:
 


### PR DESCRIPTION
Hello.

I found when txt2man == 1.7.1 rpma can works, while txt2man == 1.7.0 it cause errors in `make` process. See issue #1069 for details.

So I update txt2man version requirement in `INSTALL.md`.

Thanks!

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/pmem/rpma/1070)
<!-- Reviewable:end -->
