### PR TITLE
test: remove unnecessary cstyle and whitespace checks

### DIFF
--- a/tests/multithreaded/conn/CMakeLists.txt
+++ b/tests/multithreaded/conn/CMakeLists.txt
@@ -5,9 +5,6 @@
 
 include(../../cmake/ctest_helpers.cmake)
 
-add_cstyle(conn-all ${CMAKE_CURRENT_SOURCE_DIR}/*.[ch])
-add_check_whitespace(conn-all ${CMAKE_CURRENT_SOURCE_DIR}/*.[ch])
-
 add_multithreaded(NAME conn BIN rpma_conn_get_private_data
 	# XXX Examples are used only as a proof of concept.
 	# Please do not use examples for any other future tests.

--- a/tests/multithreaded/ep/CMakeLists.txt
+++ b/tests/multithreaded/ep/CMakeLists.txt
@@ -5,9 +5,6 @@
 
 include(../../cmake/ctest_helpers.cmake)
 
-add_cstyle(ep-all ${CMAKE_CURRENT_SOURCE_DIR}/*.[ch])
-add_check_whitespace(ep-all ${CMAKE_CURRENT_SOURCE_DIR}/*.[ch])
-
 add_multithreaded(NAME ep BIN rpma_ep_get_fd
 	SRCS rpma_ep_get_fd.c)
 add_multithreaded(NAME ep BIN rpma_ep_listen

--- a/tests/multithreaded/example/CMakeLists.txt
+++ b/tests/multithreaded/example/CMakeLists.txt
@@ -5,7 +5,4 @@
 
 include(../../cmake/ctest_helpers.cmake)
 
-add_cstyle(example-all ${CMAKE_CURRENT_SOURCE_DIR}/*.[ch])
-add_check_whitespace(example-all ${CMAKE_CURRENT_SOURCE_DIR}/*.[ch])
-
 add_multithreaded(NAME example BIN example SRCS example.c)

--- a/tests/multithreaded/mr/CMakeLists.txt
+++ b/tests/multithreaded/mr/CMakeLists.txt
@@ -5,9 +5,6 @@
 
 include(../../cmake/ctest_helpers.cmake)
 
-add_cstyle(mr-all ${CMAKE_CURRENT_SOURCE_DIR}/*.[ch])
-add_check_whitespace(mr-all ${CMAKE_CURRENT_SOURCE_DIR}/*.[ch])
-
 add_multithreaded(NAME mr BIN rpma_mr_get_descriptor
 	SRCS rpma_mr_get_descriptor.c)
 add_multithreaded(NAME mr BIN rpma_mr_get_ptr

--- a/tests/multithreaded/peer/CMakeLists.txt
+++ b/tests/multithreaded/peer/CMakeLists.txt
@@ -5,9 +5,6 @@
 
 include(../../cmake/ctest_helpers.cmake)
 
-add_cstyle(peer-all ${CMAKE_CURRENT_SOURCE_DIR}/*.[ch])
-add_check_whitespace(peer-all ${CMAKE_CURRENT_SOURCE_DIR}/*.[ch])
-
 add_multithreaded(NAME peer BIN rpma_peer_cfg_new
 	SRCS rpma_peer_cfg_new.c)
 add_multithreaded(NAME peer BIN rpma_peer_cfg_from_descriptor

--- a/tests/multithreaded/utils/CMakeLists.txt
+++ b/tests/multithreaded/utils/CMakeLists.txt
@@ -5,9 +5,6 @@
 
 include(../../cmake/ctest_helpers.cmake)
 
-add_cstyle(utils-all ${CMAKE_CURRENT_SOURCE_DIR}/*.[ch])
-add_check_whitespace(utils-all ${CMAKE_CURRENT_SOURCE_DIR}/*.[ch])
-
 add_multithreaded(NAME utils BIN rpma_utils_get_ibv_context
 	SRCS rpma_utils_get_ibv_context.c)
 add_multithreaded(NAME utils BIN rpma_utils_ibv_context_is_odp_capable


### PR DESCRIPTION
All *.c and *.h test files are already covered:
https://github.com/pmem/rpma/blob/a1423529eec21119b426ed4f097a741446b0396f/tests/CMakeLists.txt#L26