### PR TITLE
common: add circleci nop build

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,0 +1,13 @@
+version: 2.1
+workflows:
+  main:
+    jobs:
+      - nop
+jobs:
+  nop:
+    machine:
+      image: ubuntu-2004:202101-01
+    steps:
+      - run:
+          name: NOP
+          command: echo "Nothing to do. Thank you."

--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,5 @@
 .*
+!.circleci
 !.gitignore
 !.gitattributes
 build/


### PR DESCRIPTION
To prevent gh-pages CircleCI builds from failing.
Lack of the CircleCI configuration causes a fail.

<!-- Reviewable:start -->
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/pmem/rpma/1085)
<!-- Reviewable:end -->
