### PR TITLE
common: force removing txt2man directory in install-txt2man.sh

### DIFF
--- a/utils/docker/images/install-txt2man.sh
+++ b/utils/docker/images/install-txt2man.sh
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
 #
 # SPDX-License-Identifier: BSD-3-Clause
-# Copyright 2020, Intel Corporation
+# Copyright 2020-2021, Intel Corporation
 #
 
 #
@@ -19,4 +19,4 @@ git checkout txt2man-1.7.0
 make -j$(nproc)
 sudo make -j$(nproc) install prefix=/usr
 cd ..
-rm -r txt2man
+rm -rf txt2man


### PR DESCRIPTION
Force removing txt2man directory in install-txt2man.sh to suppress the following questions:

```
rm: remove write-protected regular file 'txt2man/.git/objects/pack/pack-28804f9ef8a7e6b537d8fd2abae16c2ec7e91c92.pack'? y
rm: remove write-protected regular file 'txt2man/.git/objects/pack/pack-28804f9ef8a7e6b537d8fd2abae16c2ec7e91c92.idx'? y
```

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/pmem/rpma/1092)
<!-- Reviewable:end -->
