### PR TITLE
tools: remove the useless backslash (\)

### DIFF
--- a/tools/perf/BENCHMARKING.md
+++ b/tools/perf/BENCHMARKING.md
@@ -2,20 +2,20 @@
 
 This document describes how to automate collection, processing and presentation of performance numbers (latency and bandwidth) from the RPMA-dedicated FIO engine.
 
-As a baseline the generally accepted tools like `ib\_read\_lat`, `ib\_read\_bw` etc. are used which execution, processing and presentation are also automated.
+As a baseline the generally accepted tools like `ib_read_lat`, `ib_read_bw` etc. are used which execution, processing and presentation are also automated.
 
 ## Requirements
 
-To use the benchmarking tools (e.g. ib\_read.sh, rpma\_fio\_bench.sh), you must have several components installed in your system:
+To use the benchmarking tools (e.g. `ib_read.sh`, `rpma_fio_bench.sh`), you must have several components installed in your system:
  - python3
  - python3-pip
  - pandas
  - matplotlib
- - perftest (providing ib tools like `ib\_read\_lat`, `ib\_read\_bw` etc)
+ - perftest (providing ib tools like `ib_read_lat`, `ib_read_bw` etc)
  - fio (supporting the librpma fio engine)
  - numactl
  - sshpass
- - pciutils (for ddio.sh which may be invoked from rpma\_fio\_bench.sh)
+ - pciutils (for ddio.sh which may be invoked from `rpma_fio_bench.sh`)
 
 *Note*: Currently only https://github.com/pmem/fio.git supports the librpma fio engine.
 
@@ -40,7 +40,7 @@ $ make
 $ sudo make install
 ```
 
-To use the reporting tools (e.g. csv\_compare.py, report\_bench.sh, create\_report\_figures.sh, create\_report.py, fio-histogram.py), you must additionally install:
+To use the reporting tools (e.g. `csv_compare.py`, `report_bench.sh`, `create_report_figures.sh`, `create_report.py`, `fio-histogram.py`), you must additionally install:
  - jinja2
  - markdown2
  - PIL
@@ -58,12 +58,12 @@ $ pip3 install --user PIL
 
 There are a few tools that can be used for automatic running RPMA-related workloads:
 
-- `ib\_read.sh` - a tool using `ib\_read\_lat` and `ib\_read\_bw` to benchmark the baseline performance of RDMA read operation
-- `rpma\_fio\_bench.sh` - a tool using librpma-dedicated FIO engines for benchmarking remote memory manipulation (reading, writing APM-style, writing GPSPM-style, mixed). These workloads can be run against PMem and DRAM as well.
+- `ib_read.sh` - a tool using `ib_read_lat` and `ib_read_bw` to benchmark the baseline performance of RDMA read operation
+- `rpma_fio_bench.sh` - a tool using librpma-dedicated FIO engines for benchmarking remote memory manipulation (reading, writing APM-style, writing GPSPM-style, mixed). These workloads can be run against PMem and DRAM as well.
 
-### Example of `ib\_read.sh` use
+### Example of `ib_read.sh` use
 
-Generate the baseline latency numbers using `./ib\_read.sh` tool:
+Generate the baseline latency numbers using `./ib_read.sh` tool:
 
 ```sh
 $ export JOB_NUMA=0
@@ -80,9 +80,9 @@ To see all available configuration options please take a look at the help:
 $ ./ib_read.sh
 ```
 
-### Example of `rpma\_fio\_bench.sh` use
+### Example of `rpma_fio_bench.sh` use
 
-Generate latency numbers from the RPMA-dedicated FIO engine using `./rpma\_fio\_bench.sh`:
+Generate latency numbers from the RPMA-dedicated FIO engine using `./rpma_fio_bench.sh`:
 
 ```sh
 $ export JOB_NUMA=0
@@ -102,7 +102,7 @@ $ ./rpma_fio_bench.sh
 
 ## Analyzing the results
 
-All of the benchmarking tools described above generate standardized CSV format output files, which can be further processed using `csv\_compare.py` to generate comparative charts.
+All of the benchmarking tools described above generate standardized CSV format output files, which can be further processed using `csv_compare.py` to generate comparative charts.
 
 ### Example of comparing the obtained results
 


### PR DESCRIPTION
1) remove the useless backslash (\) because it doesn't work if the word
is enclosed by backquote (``)
2) also enclose other commands/scripts by backquote (``)

Signed-off-by: Xiao Yang <yangx.jy@fujitsu.com>

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/pmem/rpma/1136)
<!-- Reviewable:end -->
