### PR TITLE
common: add "-Werror=discarded-qualifiers" for the "cc" symlink 

### DIFF
--- a/cmake/functions.cmake
+++ b/cmake/functions.cmake
@@ -197,9 +197,10 @@ endfunction()
 
 # check if librdmacm has correct signature of rdma_getaddrinfo()
 function(check_signature_rdma_getaddrinfo var)
-	if(${CMAKE_C_COMPILER} MATCHES "gcc")
+	get_filename_component(REAL_CMAKE_C_COMPILER ${CMAKE_C_COMPILER} REALPATH)
+	if(${REAL_CMAKE_C_COMPILER} MATCHES "gcc")
 		set(DISCARDED_QUALIFIERS_FLAG "-Werror=discarded-qualifiers")
-	elseif(${CMAKE_C_COMPILER} MATCHES "clang")
+	elseif(${REAL_CMAKE_C_COMPILER} MATCHES "clang")
 		set(DISCARDED_QUALIFIERS_FLAG "-Werror;-Wincompatible-pointer-types-discards-qualifiers")
 	endif()
 


### PR DESCRIPTION
For the default C compiler ("cc"), check_signature_rdma_getaddrinfo()
doesn't catch it and doesn't add "-Werror=discarded-qualifiers" to
check the version of rdma_getaddrinfo().  In this case,
RDMA_GETADDRINFO_NEW_SIGNATURE cannot show the correct value.

Ref: #1138

Signed-off-by: Xiao Yang <yangx.jy@fujitsu.com>

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/pmem/rpma/1139)
<!-- Reviewable:end -->
