### PR TITLE
examples/04-write-to-persistent: correct the return value

### DIFF
--- a/examples/04-write-to-persistent/client.c
+++ b/examples/04-write-to-persistent/client.c
@@ -215,6 +215,7 @@ main(int argc, char *argv[])
 	if (ret) {
 		goto err_mr_dereg;
 	} else if (dst_size < KILOBYTE) {
+		ret = -1;
 		fprintf(stderr,
 				"Remote memory region size too small for writing the data of the assumed size (%zu < %d)\n",
 				dst_size, KILOBYTE);
@@ -244,12 +245,14 @@ main(int argc, char *argv[])
 		goto err_mr_remote_delete;
 
 	if (cmpl.op != RPMA_OP_READ) {
+		ret = -1;
 		(void) fprintf(stderr,
 				"unexpected cmpl.op value (%d != %d)\n",
 				cmpl.op, RPMA_OP_READ);
 		goto err_mr_remote_delete;
 	}
 	if (cmpl.op_status != IBV_WC_SUCCESS) {
+		ret = -1;
 		(void) fprintf(stderr, "rpma_read failed with %d\n",
 				cmpl.op_status);
 		goto err_mr_remote_delete;

--- a/examples/common/common-conn.c
+++ b/examples/common/common-conn.c
@@ -88,6 +88,7 @@ client_connect(struct rpma_peer *peer, const char *addr, const char *port,
 		fprintf(stderr,
 			"rpma_conn_next_event returned an unexpected event: %s\n",
 			rpma_utils_conn_event_2str(conn_event));
+		ret = -1;
 		goto err_conn_delete;
 	}
 


### PR DESCRIPTION
Generally, program should exit with non-zero if there is something wrong

Signed-off-by: Li Zhijian <lizhijian@cn.fujitsu.com>

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/pmem/rpma/1140)
<!-- Reviewable:end -->
