### PR TITLE
rpma_info_new: log the real error message

### DIFF
--- a/src/info.c
+++ b/src/info.c
@@ -7,6 +7,7 @@
 
 #include <errno.h>
 #include <stdlib.h>
+#include <netdb.h>
 
 #include "conn_req.h"
 #include "info.h"
@@ -53,10 +54,13 @@ rpma_info_new(const char *addr, const char *port, enum rpma_info_side side,
 	int ret = rdma_getaddrinfo(addr, port, &hints, &rai);
 #endif
 	if (ret) {
-		RPMA_LOG_ERROR_WITH_ERRNO(errno,
-			"rdma_getaddrinfo(node=%s, service=%s, ai_flags=%s, ai_qp_type=IBV_QPT_RC, ai_port_space=RDMA_PS_TCP)",
+		const char *err = (ret == -1 || ret == EAI_SYSTEM) ?
+				strerror(errno) : gai_strerror(ret);
+		RPMA_LOG_ERROR(
+			"rdma_getaddrinfo(node=%s, service=%s, ai_flags=%s, ai_qp_type=IBV_QPT_RC, ai_port_space=RDMA_PS_TCP): %s",
 			addr, port,
-			(hints.ai_flags & RAI_PASSIVE) ? "passive" : "active");
+			(hints.ai_flags & RAI_PASSIVE) ? "passive" : "active",
+			err);
 		return RPMA_E_PROVIDER;
 	}
 

--- a/tests/unit/common/mocks-netdb.c
+++ b/tests/unit/common/mocks-netdb.c
@@ -1,0 +1,20 @@
+// SPDX-License-Identifier: BSD-3-Clause
+/* Copyright 2021, Fujitsu */
+
+/*
+ * mocks-netdb.c -- netdb mocks
+ */
+
+#include "cmocka_headers.h"
+#include "mocks-netdb.h"
+
+/*
+ * __wrap_gai_strerror -- gai_strerror() mock
+ */
+const char *
+__wrap_gai_strerror(int errcode)
+{
+	check_expected(errcode);
+
+	return mock_type(const char *);
+}

--- a/tests/unit/common/mocks-netdb.h
+++ b/tests/unit/common/mocks-netdb.h
@@ -1,0 +1,14 @@
+/* SPDX-License-Identifier: BSD-3-Clause */
+/* Copyright 2021, Fujitsu */
+
+/*
+ * mocks-netdb.h -- the netdb mocks' header
+ */
+
+#ifndef MOCKS_NETDB_H
+#define MOCKS_NETDB_H
+
+#define MOCK_EAI_ERRNO	345678
+#define MOCK_EAI_ERROR	"mock eai error"
+
+#endif /* MOCKS_NETDB_H */

--- a/tests/unit/common/mocks-rdma_cm.c
+++ b/tests/unit/common/mocks-rdma_cm.c
@@ -1,5 +1,6 @@
 // SPDX-License-Identifier: BSD-3-Clause
 /* Copyright 2020, Intel Corporation */
+/* Copyright 2021, Fujitsu */
 
 /*
  * mocks-rdma_cm.c -- librdmacm mocks
@@ -317,9 +318,11 @@ rdma_getaddrinfo(const char *node, const char *port,
 	if (*res != NULL)
 		return 0;
 
+	int ret = mock_type(int);
+	assert_int_not_equal(ret, 0);
 	errno = mock_type(int);
 
-	return -1;
+	return ret;
 }
 
 /*

--- a/tests/unit/common/mocks-string.c
+++ b/tests/unit/common/mocks-string.c
@@ -1,0 +1,20 @@
+// SPDX-License-Identifier: BSD-3-Clause
+/* Copyright 2021, Fujitsu */
+
+/*
+ * mocks-string.c -- string mocks
+ */
+
+#include "cmocka_headers.h"
+#include "mocks-string.h"
+
+/*
+ * __wrap_strerror -- strerror() mock
+ */
+char *
+__wrap_strerror(int errnum)
+{
+	check_expected(errnum);
+
+	return mock_type(char *);
+}

--- a/tests/unit/common/mocks-string.h
+++ b/tests/unit/common/mocks-string.h
@@ -1,0 +1,13 @@
+/* SPDX-License-Identifier: BSD-3-Clause */
+/* Copyright 2021, Fujitsu */
+
+/*
+ * mocks-string.h -- the string mocks' header
+ */
+
+#ifndef MOCKS_STRING_H
+#define MOCKS_STRING_H
+
+#define MOCK_ERROR	"mock error"
+
+#endif /* MOCKS_STRING_H */

--- a/tests/unit/info/CMakeLists.txt
+++ b/tests/unit/info/CMakeLists.txt
@@ -1,6 +1,7 @@
 #
 # SPDX-License-Identifier: BSD-3-Clause
 # Copyright 2020-2021, Intel Corporation
+# Copyright 2021, Fujitsu
 #
 
 include(../../cmake/ctest_helpers.cmake)
@@ -14,6 +15,8 @@ function(add_test_info name)
 		${TEST_UNIT_COMMON_DIR}/mocks-rdma_cm.c
 		${TEST_UNIT_COMMON_DIR}/mocks-rpma-log.c
 		${TEST_UNIT_COMMON_DIR}/mocks-stdlib.c
+		${TEST_UNIT_COMMON_DIR}/mocks-string.c
+		${TEST_UNIT_COMMON_DIR}/mocks-netdb.c
 		${LIBRPMA_SOURCE_DIR}/rpma_err.c
 		${LIBRPMA_SOURCE_DIR}/info.c)
 
@@ -21,7 +24,7 @@ function(add_test_info name)
 
 	set_target_properties(${name}
 		PROPERTIES
-		LINK_FLAGS "-Wl,--wrap=_test_malloc")
+		LINK_FLAGS "-Wl,--wrap=_test_malloc,--wrap=strerror,--wrap=gai_strerror")
 
 	add_test_generic(NAME ${name} TRACERS none)
 endfunction()

--- a/tests/unit/info/info-bind_addr.c
+++ b/tests/unit/info/info-bind_addr.c
@@ -19,6 +19,7 @@
 #include "librpma.h"
 #include "info-common.h"
 #include "mocks-rdma_cm.h"
+#include "mocks-string.h"
 
 #include <infiniband/verbs.h>
 
@@ -79,6 +80,8 @@ bind_addr__bind_addr_ERRNO(void **info_state_ptr)
 	expect_value(rdma_bind_addr, id, &cmid);
 	expect_value(rdma_bind_addr, addr, MOCK_SRC_ADDR);
 	will_return(rdma_bind_addr, MOCK_ERRNO);
+	expect_value(__wrap_strerror, errnum, MOCK_ERRNO);
+	will_return(__wrap_strerror, MOCK_ERROR);
 
 	/* run test */
 	int ret = rpma_info_bind_addr(istate->info, &cmid);

--- a/tests/unit/info/info-new.c
+++ b/tests/unit/info/info-new.c
@@ -19,8 +19,14 @@
 #include "librpma.h"
 #include "info-common.h"
 #include "mocks-rdma_cm.h"
+#include "mocks-string.h"
+#include "mocks-netdb.h"
 
 #include <infiniband/verbs.h>
+#include <netdb.h>
+
+static int rets[] = {EAI_SYSTEM, -1, MOCK_EAI_ERRNO};
+static int num_rets = sizeof(rets) / sizeof(rets[0]);
 
 /*
  * new__addr_NULL -- NULL addr is not valid
@@ -92,19 +98,30 @@ new__getaddrinfo_ERRNO_ACTIVE(void **unused)
 	 * rdma_getaddrinfo() has failed.
 	 */
 	struct rdma_addrinfo_args get_args = {MOCK_VALIDATE, NULL};
-	will_return(rdma_getaddrinfo, &get_args);
-	expect_value(rdma_getaddrinfo, hints->ai_flags, 0);
-	will_return(rdma_getaddrinfo, MOCK_ERRNO);
 	will_return_maybe(__wrap__test_malloc, MOCK_OK);
+	for (int i = 0; i < num_rets; i++) {
+		will_return(rdma_getaddrinfo, &get_args);
+		expect_value(rdma_getaddrinfo, hints->ai_flags, 0);
+		will_return(rdma_getaddrinfo, rets[i]);
+		will_return(rdma_getaddrinfo, MOCK_ERRNO);
+		if (rets[i] == -1 || rets[i] == EAI_SYSTEM) {
+			expect_value(__wrap_strerror, errnum, MOCK_ERRNO);
+			will_return(__wrap_strerror, MOCK_ERROR);
+		} else {
+			expect_value(__wrap_gai_strerror, errcode,
+				MOCK_EAI_ERRNO);
+			will_return(__wrap_gai_strerror, MOCK_EAI_ERROR);
+		}
 
-	/* run test */
-	struct rpma_info *info = NULL;
-	int ret = rpma_info_new(MOCK_ADDR, MOCK_PORT, RPMA_INFO_ACTIVE,
-			&info);
+		/* run test */
+		struct rpma_info *info = NULL;
+		int ret = rpma_info_new(MOCK_ADDR, MOCK_PORT, RPMA_INFO_ACTIVE,
+				&info);
 
-	/* verify the results */
-	assert_int_equal(ret, RPMA_E_PROVIDER);
-	assert_null(info);
+		/* verify the results */
+		assert_int_equal(ret, RPMA_E_PROVIDER);
+		assert_null(info);
+	}
 }
 
 /*
@@ -120,19 +137,30 @@ new__getaddrinfo_ERRNO_PASSIVE(void **unused)
 	 * rdma_getaddrinfo() has failed.
 	 */
 	struct rdma_addrinfo_args get_args = {MOCK_VALIDATE, NULL};
-	will_return(rdma_getaddrinfo, &get_args);
-	expect_value(rdma_getaddrinfo, hints->ai_flags, RAI_PASSIVE);
-	will_return(rdma_getaddrinfo, MOCK_ERRNO);
 	will_return_maybe(__wrap__test_malloc, MOCK_OK);
+	for (int i = 0; i < num_rets; i++) {
+		will_return(rdma_getaddrinfo, &get_args);
+		expect_value(rdma_getaddrinfo, hints->ai_flags, RAI_PASSIVE);
+		will_return(rdma_getaddrinfo, rets[i]);
+		will_return(rdma_getaddrinfo, MOCK_ERRNO);
+		if (rets[i] == -1 || rets[i] == EAI_SYSTEM) {
+			expect_value(__wrap_strerror, errnum, MOCK_ERRNO);
+			will_return(__wrap_strerror, MOCK_ERROR);
+		} else {
+			expect_value(__wrap_gai_strerror, errcode,
+				MOCK_EAI_ERRNO);
+			will_return(__wrap_gai_strerror, MOCK_EAI_ERROR);
+		}
 
-	/* run test */
-	struct rpma_info *info = NULL;
-	int ret = rpma_info_new(MOCK_ADDR, MOCK_PORT, RPMA_INFO_PASSIVE,
-			&info);
+		/* run test */
+		struct rpma_info *info = NULL;
+		int ret = rpma_info_new(MOCK_ADDR, MOCK_PORT, RPMA_INFO_PASSIVE,
+				&info);
 
-	/* verify the results */
-	assert_int_equal(ret, RPMA_E_PROVIDER);
-	assert_null(info);
+		/* verify the results */
+		assert_int_equal(ret, RPMA_E_PROVIDER);
+		assert_null(info);
+	}
 }
 
 /*

--- a/tests/unit/info/info-resolve_addr.c
+++ b/tests/unit/info/info-resolve_addr.c
@@ -19,6 +19,7 @@
 #include "librpma.h"
 #include "info-common.h"
 #include "mocks-rdma_cm.h"
+#include "mocks-string.h"
 
 #include <infiniband/verbs.h>
 
@@ -38,6 +39,8 @@ resolve_addr__resolve_addr_ERRNO(void **info_state_ptr)
 	expect_value(rdma_resolve_addr, dst_addr, MOCK_DST_ADDR);
 	expect_value(rdma_resolve_addr, timeout_ms, RPMA_DEFAULT_TIMEOUT_MS);
 	will_return(rdma_resolve_addr, MOCK_ERRNO);
+	expect_value(__wrap_strerror, errnum, MOCK_ERRNO);
+	will_return(__wrap_strerror, MOCK_ERROR);
 
 	/* run test */
 	int ret = rpma_info_resolve_addr(istate->info, &cmid,


### PR DESCRIPTION
Per rdma_getaddrinfo man page
```
RETURN VALUE
       Returns 0 on success, or -1 on error (errno will be set to indicate the failure reason), or one of the following nonzero error codes:
...
EAI_SYSTEM  Other system error, check errno for details.  The gai_strerror() function translates these error codes to a human readable string, suitable for error reporting.
```
errno will be used when -1 or EAI_SYSTEM is returned.

Before:
$ build/examples/03-read-to-persistent/client r92.168.1.10 9999
Next value: Hello world!
Jul 14 18:33:16.543688 [93128] *ERROR* info.c:  60: rpma_info_new: rdma_getaddrinfo(node=r92.168.1.10, service=(null), ai_flags=active, ai_qp_type=IBV_QPT_RC, ai_port_space=RDMA_PS_TCP) failed: No such file or directory

After:
$ build/examples/03-read-to-persistent/client r92.168.1.10 9999
Next value: Hello world!
Jul 14 18:40:34.806909 [99115] *ERROR* info.c:  59: rpma_info_new: rdma_getaddrinfo(node=r92.168.1.10, service=(null), ai_flags=active, ai_qp_type=IBV_QPT_RC, ai_port_space=RDMA_PS_TCP): Name or service not known

Signed-off-by: Li Zhijian <lizhijian@cn.fujitsu.com>

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/pmem/rpma/1141)
<!-- Reviewable:end -->
