### PR TITLE
common: Fix 'missing space before - operator' in first element of array

### DIFF
--- a/utils/cstyle
+++ b/utils/cstyle
@@ -534,7 +534,7 @@ line: while (<$filehandle>) {
 	if (/[^ \t]\+=/ || /\+=[^ ]/) {
 		err("missing space around += operator");
 	}
-	if (/[^ \t\-]\-[^\->]/ && !/\(\w+\)\-\w/ && !/[\(\[]\-[\w \t]+[\)\],]/) {
+	if (/[^ \t\-]\-[^\->]/ && !/\(\w+\)\-\w/ && !/[\(\[\{]\-[\w \t]+[\)\],]/) {
 		err("missing space before - operator");
 	}
 	if (/[^\-]\-[^ \-=>]/ && !/\(\-\w+\)/ &&


### PR DESCRIPTION
Previously, cstyle will complain 'missing space before - operator'
with an array like:
  static int rets[] = {-1, EAI_SYSTEM, EAI_AGAIN};
                      ^^^

Signed-off-by: Li Zhijian <lizhijian@cn.fujitsu.com>

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/pmem/rpma/1156)
<!-- Reviewable:end -->
