### PR TITLE
 tools: add --create_on_open=1 for the DRAM mode 

### DIFF
--- a/tools/perf/rpma_fio_bench.sh
+++ b/tools/perf/rpma_fio_bench.sh
@@ -277,7 +277,13 @@ function benchmark_one() {
 
 		# pick either a DRAM/DeviceDAX or a FileSystemDAX mode
 		case "$REMOTE_JOB_DEST" in
-			malloc|/dev/dax*)
+			malloc)
+				# create_on_open prevents FIO from creating files
+				# where the engines won't make use of them anyways
+				# since they are using DRAM instead
+				FILE_NAME="--filename=${REMOTE_JOB_DEST} --create_on_open=1"
+				;;
+			/dev/dax*)
 				FILE_NAME="--filename=${REMOTE_JOB_DEST}"
 				;;
 			*)


### PR DESCRIPTION
When we run server ioengine with DRAM, setup_files() in fio will create the unused 'malloc' file by some operations (e.g. fallocate, ftruncate). This behavior makes server spend more time to prepare the connection so that client always triggers the "The maximum number of retries exceeded" error.  See the detailed output:
```
Thread [7]: The maximum number of retries exceeded. Closing. IOPS][eta 01m:00s]
Thread [7]: Connected after retry #10
Thread [29]: Connected after retry #9
Thread [2]: The maximum number of retries exceeded. Closing.
Thread [9]: The maximum number of retries exceeded. Closing.
Thread [2]: Connected after retry #10
Thread [9]: Connected after retry #10
Thread [15]: The maximum number of retries exceeded. Closing.
Thread [15]: Connected after retry #10
Thread [19]: The maximum number of retries exceeded. Closing.
Thread [19]: Connected after retry #10
fio: io engine librpma_apm_client init failed. Perhaps try reducing io depth?
fio: io engine librpma_apm_client init failed. Perhaps try reducing io depth?
fio: pid=15279, err=-1/
fio: io engine librpma_apm_client init failed. Perhaps try reducing io depth?
fio: pid=15284, err=-1/
fio: pid=15292, err=-1/
fio: io engine librpma_apm_client init failed. Perhaps try reducing io depth?
fio: io engine librpma_apm_client init failed. Perhaps try reducing io depth?
fio: pid=15286, err=-1/
fio: pid=15296, err=-1/
Thread [30]: The maximum number of retries exceeded. Closing.
Thread [30]: Connected after retry #10
fio: io engine librpma_apm_client init failed. Perhaps try reducing io depth?
fio: pid=15307, err=-1/
```

disallow setup_files() to create the unused 'malloc' file by adding --create_on_open=1.

Ref: https://github.com/pmem/fio/pull/257

Note: This path is based on #1144

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/pmem/rpma/1157)
<!-- Reviewable:end -->
