### PR TITLE
rpma: call rdma_destroy_qp() when rpma_flush_delete() gets an error

### DIFF
--- a/src/conn.c
+++ b/src/conn.c
@@ -248,7 +248,7 @@ rpma_conn_delete(struct rpma_conn **conn_ptr)
 
 	ret = rpma_flush_delete(&conn->flush);
 	if (ret)
-		goto err_rpma_cq_delete;
+		goto err_destroy_qp;
 
 	rdma_destroy_qp(conn->id);
 
@@ -270,7 +270,8 @@ rpma_conn_delete(struct rpma_conn **conn_ptr)
 
 	return 0;
 
-err_rpma_cq_delete:
+err_destroy_qp:
+	rdma_destroy_qp(conn->id);
 	(void) rpma_cq_delete(&conn->cq);
 err_destroy_id:
 	(void) rdma_destroy_id(conn->id);

--- a/tests/unit/conn/conn-new.c
+++ b/tests/unit/conn/conn-new.c
@@ -242,6 +242,7 @@ delete__flush_delete_ERRNO(void **unused)
 	/* configure mocks: */
 	will_return(rpma_flush_delete, RPMA_E_PROVIDER);
 	will_return(rpma_flush_delete, MOCK_ERRNO);
+	expect_value(rdma_destroy_qp, id, MOCK_CM_ID);
 	will_return_maybe(rpma_cq_delete, MOCK_OK);
 	expect_value(rdma_destroy_id, id, MOCK_CM_ID);
 	will_return_maybe(rdma_destroy_id, MOCK_OK);
@@ -273,6 +274,7 @@ delete__flush_delete_E_INVAL(void **unused)
 
 	/* configure mocks: */
 	will_return(rpma_flush_delete, RPMA_E_INVAL);
+	expect_value(rdma_destroy_qp, id, MOCK_CM_ID);
 	will_return_maybe(rpma_cq_delete, MOCK_OK);
 	expect_value(rdma_destroy_id, id, MOCK_CM_ID);
 	will_return_maybe(rdma_destroy_id, MOCK_OK);


### PR DESCRIPTION
rpma_conn_delete() cannot call rdma_destroy_qp() before rdma_destroy_id() when rpma_flush_delete() gets an error so fix the issue.

Signed-off-by: Xiao Yang <yangx.jy@fujitsu.com>

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/pmem/rpma/1160)
<!-- Reviewable:end -->
