### PR TITLE
tools: replace '_' with '\_' in oneseries['label']

### DIFF
--- a/tools/perf/lib/Figure.py
+++ b/tools/perf/lib/Figure.py
@@ -192,7 +192,8 @@ class Figure:
 
         # rows
         for oneseries in self.series:
-            html += "<tr><td>" + oneseries['label'] + "</td>"
+            # since the output is processed as markdown, special characters have to be escaped
+            html += "<tr><td>" + oneseries['label'].replace('_', '\_') + "</td>"
             for point in oneseries['points']:
                 html += "<td>" + str(point[1]) + "</td>"
             html += "</tr>"

--- a/tools/perf/tests/lib/figure/test_html_data_table.py
+++ b/tools/perf/tests/lib/figure/test_html_data_table.py
@@ -30,7 +30,7 @@ DATA = {
     ]
 }
 
-HTML = "<table><thead><tr><th></th><th>0</th><th>1</th><th>2</th></tr></thead><tbody><tr><td>label_1</td><td>3</td><td>4</td><td>5</td></tr><tr><td>label_2</td><td>6</td><td>7</td><td>8</td></tr></tbody></table>"
+HTML = "<table><thead><tr><th></th><th>0</th><th>1</th><th>2</th></tr></thead><tbody><tr><td>label\_1</td><td>3</td><td>4</td><td>5</td></tr><tr><td>label\_2</td><td>6</td><td>7</td><td>8</td></tr></tbody></table>"
 
 def test_html_data_table_basic():
     """ basic lib.Figure.html_data_table() test """


### PR DESCRIPTION
Replace `_` with `\_` in `oneseries['label']` to prevent converting strings to italics.

Requires:
- [x] #1168

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/pmem/rpma/1172)
<!-- Reviewable:end -->
