### PR TITLE
test: disable the multithreaded-conn-rpma_conn_get_private_data test

### DIFF
--- a/tests/multithreaded/conn/CMakeLists.txt
+++ b/tests/multithreaded/conn/CMakeLists.txt
@@ -23,7 +23,12 @@ add_multithreaded(NAME conn BIN rpma_conn_cfg_set_sq_size
 	SRCS rpma_conn_cfg_set_sq_size.c rpma_conn_cfg_common.c)
 add_multithreaded(NAME conn BIN rpma_conn_cfg_set_timeout
 	SRCS rpma_conn_cfg_set_timeout.c)
-add_multithreaded(NAME conn BIN rpma_conn_get_private_data
-	SRCS rpma_conn_get_private_data.c server_rpma_conn_get_private_data.c)
+#
+# XXX Disable the multithreaded-conn-rpma_conn_get_private_data_0_none test
+# temporarily, because it fails very often. Enable it again,
+# when the interprocess synchronization is implemented in MT-tests.
+#
+#add_multithreaded(NAME conn BIN rpma_conn_get_private_data
+#	SRCS rpma_conn_get_private_data.c server_rpma_conn_get_private_data.c)
 add_multithreaded(NAME conn BIN rpma_conn_req_new
 	SRCS rpma_conn_req_new.c)


### PR DESCRIPTION
Disable the `multithreaded-conn-rpma_conn_get_private_data_0_none` test
temporarily, because it fails very often:
```
*NOTE*  conn_req.c: 317: rpma_conn_req_new: Requesting a connection to 10.142.2.219:7204
*NOTE*  conn.c: 189: rpma_conn_next_event: Connection rejected
error: rpma_conn_get_private_data.c:74 prestate_init() -> rpma_conn_next_event returned an unexpected event
```
Enable it again, when the correct synchronization in MT-tests is implemented

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/pmem/rpma/1175)
<!-- Reviewable:end -->
