### PR TITLE
tools: perf: add preamble to the report

### DIFF
--- a/tools/perf/lib/Report.py
+++ b/tools/perf/lib/Report.py
@@ -16,10 +16,18 @@ class Report:
     """A report object"""
 
     def _load_parts(self, loader, env, bench):
-        self.parts = []
-        # XXX add an ordered list of parts to the Bench and bench.json
-        for part in bench.parts:
-            self.parts.append(Part(loader, env, part))
+        preamble = Part(loader, env, 'preamble')
+        # XXX a dummy set of variables
+        preamble.set_variables({
+            'configuration': {
+                'bios': 'XXX bios'
+            }
+        })
+        self.parts = [preamble]
+        for partname in bench.parts:
+            part = Part(loader, env, partname)
+            part.set_variables({'figure': self.figures})
+            self.parts.append(part)
 
     def _load_figures(self, bench):
         self.figures = {}
@@ -33,15 +41,15 @@ class Report:
     def __init__(self, loader, env, bench):
         self.env = env # jinja2.Environment
         self.result_dir = bench.result_dir
-        self._load_parts(loader, env, bench)
         self._load_figures(bench)
+        self._load_parts(loader, env, bench)
         self.config = bench.config
 
     def _create_menu(self):
         return "".join([part.menu() for part in self.parts])
 
     def _create_content(self):
-        return "".join([part.content(self.figures) for part in self.parts])
+        return "".join([part.content() for part in self.parts])
 
     def _create_header(self):
         # XXX both *_header.md files can be integrated directly into

--- a/tools/perf/templates/part_preamble.md
+++ b/tools/perf/templates/part_preamble.md
@@ -1,0 +1,78 @@
+{# XXX make obsolete: authors.md.copyme, audience.md, disclaimer.md,
+configuration_common.md.copyme, configuration_target.md.copyme, bios.md.copyme,
+security.md.copyme, introduction.md, #}
+
+{% if menu is true %}
+<a class="pure-menu-heading" href="#test-setup">Test Setup</a>
+<ul class="pure-menu-list">
+    <li class="pure-menu-item"><a href="#common-cfg" class="pure-menu-link">Common Configuration</a></li>
+    <li class="pure-menu-item"><a href="#target-cfg" class="pure-menu-link">Target Configuration</a></li>
+    <li class="pure-menu-item"><a href="#bios-settings" class="pure-menu-link">BIOS Settings</a></li>
+    <li class="pure-menu-item"><a href="#security" class="pure-menu-link">Security</a></li>
+</ul>
+<a class="pure-menu-heading" href="#introduction">Introduction</a>
+{% else %}
+
+**Testing Date**: {{test_date}}
+
+{{authors}}
+
+## Audience and Purpose
+
+This report is intended for people who are interested in evaluating RPMA performance.
+
+The purpose of the report is not to imply a single "correct" approach, but rather to provide a baseline of well-tested configurations and procedures that produce repeatable results. This report can also be viewed as information regarding best-known methods/practices when testing the RPMA performance.
+
+## Disclaimer
+
+Performance varies by use, configuration and other factors. Learn more at [www.Intel.com/PerformanceIndex​​](http://www.intel.com/PerformanceIndex).
+
+Performance results are based on testing as of dates shown in configurations and may not reflect all publicly available ​updates. See backup for configuration details. No product or component can be absolutely secure.
+
+Intel technologies may require enabled hardware, software or service activation.
+
+Your costs and results may vary.
+
+Intel does not control or audit third-party data.  You should consult other sources to evaluate accuracy.
+
+&copy; Intel Corporation. Intel, the Intel logo, and other Intel marks are trademarks of Intel Corporation or its subsidiaries.  Other names and brands may be claimed as the property of others.
+
+<h2 id="test-setup">Test Setup</h2>
+
+<h3 id="common-cfg">Common Configuration (both initiator and target)</h3>
+
+{{configuration.common}}
+
+<h3 id="target-cfg">Target Configuration</h3>
+
+Description of applied configuration.
+
+{{configuration.target}}
+
+<h3 id="bios-settings">BIOS Settings</h3>
+
+{{configuration.bios.settings}}
+
+Excerpt:
+
+{{configuration.bios.excerpt}}
+
+<h3 id="security">Kernel & BIOS spectre-meltdown information</h3>
+
+{{configuration.security}}
+
+<h2 id="introduction">Introduction to RPMA</h2>
+
+The Remote Persistent Memory Access (RPMA) library (librpma) uses Remote Direct Memory Access (RDMA) to provide easy to use interface for accessing Persistent Memory (PMem) on the remote system. It is a user-space library which may be used with all available RDMA implementations (InfiniBand&trade;, iWARP, RoCE, RoCEv2) from various providers as long as they support the standard RDMA user-space Linux interface namely the libiverbs library.
+
+The RPMA-dedicated FIO engines are created as complementary pairs namely librpma\_apm\_client along with librpma\_apm\_server and librpma\_gpspm\_client along with librpma\_gpspm\_server. For the simplicity sake, both parts are implemented independently without any out-of-band communication or daemons allowing to prepare the target memory for I/O requests. The server engine prepares memory according to provided job file (either DRAM or PMem), registers it in the local RDMA-capable network interface (RNIC) and waits for the preconfigured (via the job file) number of incoming client's connections. The client engine establishes the preconfigured number of connections with the server. After these setup steps the client engine starts executing I/O requests against the memory exposed on the server side.
+
+The RPMA library and any application using it (including FIO with dedicated engines) should work on all flavours of RDMA transport but it is currently tested against RoCEv2.
+
+The FIO should be configured in a way that guarantees running all its threads and allocating all its buffers from a single NUMA node, the same the used RDMA interface is attached to, to avoid costly cross-NUMA synchronizations (e.g. using Ultra Path Interconnect).
+
+Please see a high-level schematic of the systems used for testing in the rest of this report. {{configuration.description}}
+
+{% if configuration.schematic %}<img src="{{configuration.schematic}}"/>{% endif %}
+
+{% endif %}

--- a/tools/perf/templates/part_read.md
+++ b/tools/perf/templates/part_read.md
@@ -1,13 +1,14 @@
 {# XXX make obsolete: tc1_read.md and tc_read_*_config.md.copyme #}
 
 {% if menu is true %}
-<a class="pure-menu-heading" href="#introduction">Introduction</a>
 <a class="pure-menu-heading" href="#read">Read from PMem</a>
 <ul class="pure-menu-list">
     <li class="pure-menu-item"><a href="#read-lat" class="pure-menu-link">Latency</a></li>
     <li class="pure-menu-item"><a href="#read-bw" class="pure-menu-link">Bandwidth</a></li>
 </ul>
 {% else %}
+
+<h2 id="read">Read from PMem</h2>
 
 Benchmarking the `rpma_read()` operation against various data sources (PMem, DRAM) and comparing the obtained results to standard RDMA benchmarking tools: `ib_read_lat` and `ib_read_bw`.
 

--- a/tools/perf/tests/lib/part/test_init.py
+++ b/tools/perf/tests/lib/part/test_init.py
@@ -41,16 +41,16 @@ def object_cmp(obj1, obj2):
     dump2 = json.dumps(obj2, sort_keys=True)
     return dump1 == dump2
 
-@pytest.mark.parametrize('input_json,expected_variables',
+@pytest.mark.parametrize('input_json,expected_constants',
     [({}, {}), ({'common': {}}, {})])
-def test_empty(input_json, expected_variables, monkeypatch):
+def test_empty(input_json, expected_constants, monkeypatch):
     """provide an (almost) empty input"""
     def loads_mock(arg):
         assert arg == SOURCE_DUMMY
         return input_json
     monkeypatch.setattr(json, 'loads', loads_mock)
     part = Part(LoaderMock(), EnvMock(), NAME_DUMMY)
-    assert object_cmp(part.variables, expected_variables)
+    assert object_cmp(part.constants, expected_constants)
 
 JSON_NESTED = {
     'a': {
@@ -118,7 +118,7 @@ def json_nested(common=None, inner_e=None, inner_i=None):
         nested['f']['g']['h']['i'] = inner_i
     return nested
 
-@pytest.mark.parametrize('input_json,expected_variables', [
+@pytest.mark.parametrize('input_json,expected_constants', [
     # a simple nested dictionary
     (json_nested(), json_nested()),
     # a simple nested dictionary with various strings inside
@@ -139,16 +139,16 @@ def json_nested(common=None, inner_e=None, inner_i=None):
             COMMON_DUMMY, '{' + VAR_DUMMY_2 + '}...{' + VAR_DUMMY_1 + '}'),
         json_nested(None, STRING_DUMMY_2 + '...' + STRING_DUMMY_1))
     ])
-def test_nested_misc(input_json, expected_variables, monkeypatch):
+def test_nested_misc(input_json, expected_constants, monkeypatch):
     """processing miscellaneous nested dictionaries"""
     def loads_mock(arg):
         assert arg == SOURCE_DUMMY
         return input_json
     monkeypatch.setattr(json, 'loads', loads_mock)
     part = Part(LoaderMock(), EnvMock(), NAME_DUMMY)
-    assert object_cmp(part.variables, expected_variables)
+    assert object_cmp(part.constants, expected_constants)
 
-@pytest.mark.parametrize('input_json,expected_variables', [
+@pytest.mark.parametrize('input_json,expected_constants', [
     # a list of strings inside a nested dictionary
     (json_nested(None, STR_LIST_DUMMY_3),
         json_nested(None, STRING_DUMMY_3_CONCAT)),
@@ -161,7 +161,7 @@ def test_nested_misc(input_json, expected_variables, monkeypatch):
             COMMON_DUMMY_WITH_LIST, '{' + VAR_DUMMY_3 + '}', STR_LIST_DUMMY_3),
         json_nested(None, STRING_DUMMY_3_CONCAT, STRING_DUMMY_3_CONCAT))
     ])
-def test_nested_lines_misc(input_json, expected_variables, monkeypatch):
+def test_nested_lines_misc(input_json, expected_constants, monkeypatch):
     """processing miscellaneous nested dictionaries with lists of strings"""
     def loads_mock(arg):
         assert arg == SOURCE_DUMMY
@@ -175,7 +175,7 @@ def test_nested_lines_misc(input_json, expected_variables, monkeypatch):
     # imported instead of the source module.
     monkeypatch.setattr(lib.Part, 'lines2str', lines2str_mock)
     part = Part(LoaderMock(), EnvMock(), NAME_DUMMY)
-    assert object_cmp(part.variables, expected_variables)
+    assert object_cmp(part.constants, expected_constants)
 
 TYPE_INVALID = {
     **JSON_NESTED,
@@ -201,7 +201,7 @@ KVTABLE_DUMMY = {
 
 KVTABLE_OUTPUT_DUMMY = '<dummy>invalid</dummy>'
 
-@pytest.mark.parametrize('input_json,expected_env,expected_variables', [
+@pytest.mark.parametrize('input_json,expected_env,expected_constants', [
     # a simple kvtable nested inside a dictionary (an empty common)
     (json_nested(None, KVTABLE_DUMMY),
         {},
@@ -216,7 +216,7 @@ KVTABLE_OUTPUT_DUMMY = '<dummy>invalid</dummy>'
         COMMON_DUMMY_WITH_LIST_PROCESSED,
         json_nested(None, KVTABLE_OUTPUT_DUMMY)),
     ])
-def test_nested_kvtable_misc(input_json, expected_env, expected_variables,
+def test_nested_kvtable_misc(input_json, expected_env, expected_constants,
         monkeypatch):
     """processing miscellaneous nested dictionaries with kvtables"""
     def loads_mock(arg):
@@ -234,4 +234,4 @@ def test_nested_kvtable_misc(input_json, expected_env, expected_variables,
     monkeypatch.setattr(lib.Part, 'lines2str', lines2str_mock)
     monkeypatch.setattr(lib.Part, 'dict2kvtable', dict2kvtable_mock)
     part = Part(LoaderMock(), EnvMock(), NAME_DUMMY)
-    assert object_cmp(part.variables, expected_variables)
+    assert object_cmp(part.constants, expected_constants)


### PR DESCRIPTION
- lib.Part:
	- call items read from part_*.json as constants
	- add set_variables() for variables
	- skip markdown processing for menu() (unnecessary `<p/>`)
	- allow calling content() without custom arguments
- lib.Report:
	- add preamble as the first part of the report
	- provide a dummy variables required for it to render
- templates/part_preamble.md:
	- a slighly adopted copy of various templates/* files
	- updated disclaimer
	- refer variables as it seems to be convenient in the future
- templates/part_read.md:
	- move `<a>Introduction</a>` to part_preamble.md (fix)
	- add missing `<h2>Read from PMem</h2>`

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/pmem/rpma/1176)
<!-- Reviewable:end -->
