### PR TITLE
tools: fix invalid escape sequence + fix typo

### DIFF
--- a/tools/perf/lib/Figure.py
+++ b/tools/perf/lib/Figure.py
@@ -198,7 +198,7 @@ class Figure:
         # rows
         for oneseries in self.series:
             # since the output is processed as markdown, special characters have to be escaped
-            html += "<tr><td>" + oneseries['label'].replace('_', '\_') + "</td>"
+            html += "<tr><td>" + oneseries['label'].replace('_', '\\_') + "</td>"
             for point in oneseries['points']:
                 html += "<td>" + str(point[1]) + "</td>"
             html += "</tr>"

--- a/tools/perf/tests/lib/figure/test_html_data_table.py
+++ b/tools/perf/tests/lib/figure/test_html_data_table.py
@@ -4,7 +4,7 @@
 # Copyright 2021, Intel Corporation
 #
 
-"""test_html_data_table.py.py -- lib.Figure.html_data_table() tests"""
+"""test_html_data_table.py -- lib.Figure.html_data_table() tests"""
 
 import pytest
 from lib.common import json_from_file
@@ -33,5 +33,5 @@ DATA = {
 HTML = "<table><thead><tr><th></th><th>0</th><th>1</th><th>2</th></tr></thead><tbody><tr><td>label\\_1</td><td>3</td><td>4</td><td>5</td></tr><tr><td>label\\_2</td><td>6</td><td>7</td><td>8</td></tr></tbody></table>"
 
 def test_html_data_table_basic():
-    """ basic lib.Figure.html_data_table() test """
+    """basic lib.Figure.html_data_table() test"""
     assert Figure(DATA).html_data_table() == HTML

--- a/tools/perf/tests/lib/figure/test_html_data_table.py
+++ b/tools/perf/tests/lib/figure/test_html_data_table.py
@@ -30,7 +30,7 @@ DATA = {
     ]
 }
 
-HTML = "<table><thead><tr><th></th><th>0</th><th>1</th><th>2</th></tr></thead><tbody><tr><td>label\_1</td><td>3</td><td>4</td><td>5</td></tr><tr><td>label\_2</td><td>6</td><td>7</td><td>8</td></tr></tbody></table>"
+HTML = "<table><thead><tr><th></th><th>0</th><th>1</th><th>2</th></tr></thead><tbody><tr><td>label\\_1</td><td>3</td><td>4</td><td>5</td></tr><tr><td>label\\_2</td><td>6</td><td>7</td><td>8</td></tr></tbody></table>"
 
 def test_html_data_table_basic():
     """ basic lib.Figure.html_data_table() test """


### PR DESCRIPTION
lib/Figure.py:201
  /rpma/tools/perf/lib/Figure.py:201: DeprecationWarning: invalid escape sequence \_
    html += "<tr><td>" + oneseries['label'].replace('_', '\_') + "</td>"

-- Docs: https://docs.pytest.org/en/stable/warnings.html

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/pmem/rpma/1183)
<!-- Reviewable:end -->
