### PR TITLE
tools: perf: do not cache result_dir in bench.json

### DIFF
--- a/tools/perf/lib/Bench.py
+++ b/tools/perf/lib/Bench.py
@@ -37,10 +37,12 @@ class Bench:
 
     @classmethod
     def carry_on(cls, bench):
+        result_dir, _ = os.path.split(os.path.realpath(bench['input_file']))
         bench = bench['json']
-        figures = [Figure(f, bench['result_dir']) for f in bench['figures']]
+        figures = [Figure(f, result_dir) for f in bench['figures']]
         requirements = {id: Requirement(r) for id, r in bench['requirements'].items()}
-        return cls(bench['config'], bench['parts'], figures, requirements, bench['result_dir'])
+        return cls(bench['config'], bench['parts'], figures, requirements, \
+            result_dir)
 
     def cache(self):
         """Cache the current state of execution to a file"""
@@ -48,8 +50,7 @@ class Bench:
             'config': self.config,
             'parts': self.parts,
             'figures': [f.cache() for f in self.figures],
-            'requirements': {id: r.cache() for id, r in self.requirements.items()},
-            'result_dir': self.result_dir
+            'requirements': {id: r.cache() for id, r in self.requirements.items()}
         }
 
         output_path = os.path.join(self.result_dir, 'bench.json')

--- a/tools/perf/tests/lib/bench/test_carry_on.py
+++ b/tools/perf/tests/lib/bench/test_carry_on.py
@@ -1,0 +1,42 @@
+#!/usr/bin/env python3
+#
+# SPDX-License-Identifier: BSD-3-Clause
+# Copyright 2021, Intel Corporation
+#
+
+"""test_carry_on.py -- lib.Bench.carry_on() tests"""
+
+import os
+
+from lib.Bench import Bench
+
+DUMMY_INPUT_PATH = 'dummy'
+
+BENCH_IN = {
+    'input_file': DUMMY_INPUT_PATH,
+    'json': {
+        'figures': {},
+        'requirements': {},
+        'config': {},
+        'parts': {}
+    }
+}
+
+REALPATH_OUT = 'realpath_out_dummy'
+SPLIT_OUT_1 = 'split_out_1_dummy'
+
+def test_result_dir(monkeypatch):
+    """
+    assert the result dir_is calculated from /input/path/bench.json using
+    os.path.realpath() and os.path.split()
+    """
+    def realpath_mock(path_in):
+        assert path_in == DUMMY_INPUT_PATH
+        return REALPATH_OUT
+    def split_mock(path_in):
+        assert path_in == REALPATH_OUT
+        return SPLIT_OUT_1, None
+    monkeypatch.setattr(os.path, 'realpath', realpath_mock)
+    monkeypatch.setattr(os.path, 'split', split_mock)
+    bench_out = Bench.carry_on(BENCH_IN)
+    assert bench_out.result_dir == SPLIT_OUT_1


### PR DESCRIPTION
- result_dir is calculated each time from the bench.json location
- it allows moving freely and using bench.json from various locations

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/pmem/rpma/1189)
<!-- Reviewable:end -->
