### PR TITLE
test: remove duplicate macros in info-common.h

### DIFF
--- a/tests/unit/ep/ep-common.c
+++ b/tests/unit/ep/ep-common.c
@@ -159,7 +159,7 @@ int
 rpma_info_new(const char *addr, const char *port, enum rpma_info_side side,
 		struct rpma_info **info_ptr)
 {
-	assert_string_equal(addr, MOCK_ADDR);
+	assert_string_equal(addr, MOCK_IP_ADDRESS);
 	assert_string_equal(port, MOCK_PORT);
 	assert_int_equal(side, RPMA_INFO_PASSIVE);
 	assert_non_null(info_ptr);
@@ -324,7 +324,7 @@ setup__ep_listen(void **estate_ptr)
 	expect_value(rpma_info_delete, *info_ptr, MOCK_INFO);
 
 	/* prepare an object */
-	int ret = rpma_ep_listen(MOCK_PEER, MOCK_ADDR, MOCK_PORT,
+	int ret = rpma_ep_listen(MOCK_PEER, MOCK_IP_ADDRESS, MOCK_PORT,
 		&estate->ep);
 
 	/* verify the results */

--- a/tests/unit/ep/ep-common.h
+++ b/tests/unit/ep/ep-common.h
@@ -10,9 +10,6 @@
 
 #include <rdma/rdma_cma.h>
 
-#define MOCK_ADDR	"127.0.0.1"
-#define MOCK_PORT	"1234"
-#define MOCK_PEER	(struct rpma_peer *)0xFEEF
 #define MOCK_CONN_REQ	(struct rpma_conn_req *)0xCFEF
 #define MOCK_FD		0x00FD
 

--- a/tests/unit/ep/ep-listen.c
+++ b/tests/unit/ep/ep-listen.c
@@ -23,7 +23,7 @@ listen__peer_NULL(void **unused)
 {
 	/* run test */
 	struct rpma_ep *ep = NULL;
-	int ret = rpma_ep_listen(NULL, MOCK_ADDR, MOCK_PORT, &ep);
+	int ret = rpma_ep_listen(NULL, MOCK_IP_ADDRESS, MOCK_PORT, &ep);
 
 	/* verify the results */
 	assert_int_equal(ret, RPMA_E_INVAL);
@@ -53,7 +53,7 @@ listen__port_NULL(void **unused)
 {
 	/* run test */
 	struct rpma_ep *ep = NULL;
-	int ret = rpma_ep_listen(MOCK_PEER, MOCK_ADDR, NULL, &ep);
+	int ret = rpma_ep_listen(MOCK_PEER, MOCK_IP_ADDRESS, NULL, &ep);
 
 	/* verify the results */
 	assert_int_equal(ret, RPMA_E_INVAL);
@@ -67,7 +67,7 @@ static void
 listen__ep_ptr_NULL(void **unused)
 {
 	/* run test */
-	int ret = rpma_ep_listen(MOCK_PEER, MOCK_ADDR, MOCK_PORT, NULL);
+	int ret = rpma_ep_listen(MOCK_PEER, MOCK_IP_ADDRESS, MOCK_PORT, NULL);
 
 	/* verify the results */
 	assert_int_equal(ret, RPMA_E_INVAL);
@@ -106,7 +106,7 @@ listen__create_evch_ERRNO(void **unused)
 
 	/* run test */
 	struct rpma_ep *ep = NULL;
-	int ret = rpma_ep_listen(MOCK_PEER, MOCK_ADDR, MOCK_PORT, &ep);
+	int ret = rpma_ep_listen(MOCK_PEER, MOCK_IP_ADDRESS, MOCK_PORT, &ep);
 
 	/* verify the results */
 	assert_int_equal(ret, RPMA_E_PROVIDER);
@@ -133,7 +133,7 @@ listen__create_id_ERRNO(void **unused)
 
 	/* run test */
 	struct rpma_ep *ep = NULL;
-	int ret = rpma_ep_listen(MOCK_PEER, MOCK_ADDR, MOCK_PORT, &ep);
+	int ret = rpma_ep_listen(MOCK_PEER, MOCK_IP_ADDRESS, MOCK_PORT, &ep);
 
 	/* verify the results */
 	assert_int_equal(ret, RPMA_E_PROVIDER);
@@ -161,7 +161,7 @@ listen__info_new_E_NOMEM(void **unused)
 
 	/* run test */
 	struct rpma_ep *ep = NULL;
-	int ret = rpma_ep_listen(MOCK_PEER, MOCK_ADDR, MOCK_PORT, &ep);
+	int ret = rpma_ep_listen(MOCK_PEER, MOCK_IP_ADDRESS, MOCK_PORT, &ep);
 
 	/* verify the results */
 	assert_int_equal(ret, RPMA_E_NOMEM);
@@ -190,7 +190,7 @@ listen__info_bind_addr_E_PROVIDER(void **unused)
 
 	/* run test */
 	struct rpma_ep *ep = NULL;
-	int ret = rpma_ep_listen(MOCK_PEER, MOCK_ADDR, MOCK_PORT, &ep);
+	int ret = rpma_ep_listen(MOCK_PEER, MOCK_IP_ADDRESS, MOCK_PORT, &ep);
 
 	/* verify the results */
 	assert_int_equal(ret, RPMA_E_PROVIDER);
@@ -219,7 +219,7 @@ listen__listen_ERRNO(void **unused)
 
 	/* run test */
 	struct rpma_ep *ep = NULL;
-	int ret = rpma_ep_listen(MOCK_PEER, MOCK_ADDR, MOCK_PORT, &ep);
+	int ret = rpma_ep_listen(MOCK_PEER, MOCK_IP_ADDRESS, MOCK_PORT, &ep);
 
 	/* verify the results */
 	assert_int_equal(ret, RPMA_E_PROVIDER);
@@ -249,7 +249,7 @@ listen__malloc_ERRNO(void **unused)
 
 	/* run test */
 	struct rpma_ep *ep = NULL;
-	int ret = rpma_ep_listen(MOCK_PEER, MOCK_ADDR, MOCK_PORT, &ep);
+	int ret = rpma_ep_listen(MOCK_PEER, MOCK_IP_ADDRESS, MOCK_PORT, &ep);
 
 	/* verify the results */
 	assert_int_equal(ret, RPMA_E_NOMEM);
@@ -284,7 +284,7 @@ listen__malloc_ERRNO_destroy_id_ERRNO2(void **unused)
 
 	/* run test */
 	struct rpma_ep *ep = NULL;
-	int ret = rpma_ep_listen(MOCK_PEER, MOCK_ADDR, MOCK_PORT, &ep);
+	int ret = rpma_ep_listen(MOCK_PEER, MOCK_IP_ADDRESS, MOCK_PORT, &ep);
 
 	/* verify the results */
 	assert_int_equal(ret, RPMA_E_NOMEM);

--- a/tests/unit/info/info-common.c
+++ b/tests/unit/info/info-common.c
@@ -13,6 +13,7 @@
 #include "info.h"
 #include "librpma.h"
 #include "info-common.h"
+#include "test-common.h"
 #include "mocks-rdma_cm.h"
 
 #include <infiniband/verbs.h>
@@ -37,7 +38,7 @@ setup__new_passive(void **info_state_ptr)
 	expect_value(rdma_getaddrinfo, hints->ai_flags, RAI_PASSIVE);
 	will_return(__wrap__test_malloc, MOCK_OK);
 
-	int ret = rpma_info_new(MOCK_ADDR, MOCK_PORT, RPMA_INFO_PASSIVE,
+	int ret = rpma_info_new(MOCK_IP_ADDRESS, MOCK_PORT, RPMA_INFO_PASSIVE,
 			&istate.info);
 	assert_int_equal(ret, 0);
 	assert_non_null(istate.info);
@@ -67,7 +68,7 @@ setup__new_active(void **info_state_ptr)
 	expect_value(rdma_getaddrinfo, hints->ai_flags, 0);
 	will_return(__wrap__test_malloc, MOCK_OK);
 
-	int ret = rpma_info_new(MOCK_ADDR, MOCK_PORT, RPMA_INFO_ACTIVE,
+	int ret = rpma_info_new(MOCK_IP_ADDRESS, MOCK_PORT, RPMA_INFO_ACTIVE,
 			&istate.info);
 	assert_int_equal(ret, 0);
 	assert_non_null(istate.info);

--- a/tests/unit/info/info-common.h
+++ b/tests/unit/info/info-common.h
@@ -18,15 +18,8 @@
 
 #include <infiniband/verbs.h>
 
-#define MOCK_ADDR	"127.0.0.1"
-#define MOCK_PORT	"1234"
 #define MOCK_SRC_ADDR	(struct sockaddr *)0x0ADD
 #define MOCK_DST_ADDR	(struct sockaddr *)0x0ADE
-
-#define MOCK_PASSTHROUGH	0
-#define MOCK_VALIDATE		1
-
-#define MOCK_OK		0
 
 /*
  * All the resources used between setup__new_* and teardown__delete.

--- a/tests/unit/info/info-new.c
+++ b/tests/unit/info/info-new.c
@@ -115,8 +115,8 @@ new__getaddrinfo_ERRNO_ACTIVE(void **unused)
 
 		/* run test */
 		struct rpma_info *info = NULL;
-		int ret = rpma_info_new(MOCK_ADDR, MOCK_PORT, RPMA_INFO_ACTIVE,
-				&info);
+		int ret = rpma_info_new(MOCK_IP_ADDRESS, MOCK_PORT,
+				RPMA_INFO_ACTIVE, &info);
 
 		/* verify the results */
 		assert_int_equal(ret, RPMA_E_PROVIDER);
@@ -154,8 +154,8 @@ new__getaddrinfo_ERRNO_PASSIVE(void **unused)
 
 		/* run test */
 		struct rpma_info *info = NULL;
-		int ret = rpma_info_new(MOCK_ADDR, MOCK_PORT, RPMA_INFO_PASSIVE,
-				&info);
+		int ret = rpma_info_new(MOCK_IP_ADDRESS, MOCK_PORT,
+				RPMA_INFO_PASSIVE, &info);
 
 		/* verify the results */
 		assert_int_equal(ret, RPMA_E_PROVIDER);
@@ -178,7 +178,7 @@ new__malloc_ERRNO(void **unused)
 
 	/* run test */
 	struct rpma_info *info = NULL;
-	int ret = rpma_info_new(MOCK_ADDR, MOCK_PORT, RPMA_INFO_PASSIVE,
+	int ret = rpma_info_new(MOCK_IP_ADDRESS, MOCK_PORT, RPMA_INFO_PASSIVE,
 			&info);
 
 	/* verify the results */
@@ -205,7 +205,7 @@ new__lifecycle(void **unused)
 
 	/* run test - step 1 */
 	struct rpma_info *info = NULL;
-	int ret = rpma_info_new(MOCK_ADDR, MOCK_PORT, RPMA_INFO_PASSIVE,
+	int ret = rpma_info_new(MOCK_IP_ADDRESS, MOCK_PORT, RPMA_INFO_PASSIVE,
 			&info);
 
 	/* verify the results */


### PR DESCRIPTION
some macros in info-common.h has been defined by test-common.h.

Signed-off-by: Xiao Yang <yangx.jy@fujitsu.com>

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/pmem/rpma/1198)
<!-- Reviewable:end -->
