### PR TITLE
common: add Rocky Linux and VzLinux to the nightly CI builds

### DIFF
--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -46,6 +46,9 @@ jobs:
                  # Debian9 was moved to per-PR builds
                  # because it has older Python v3.5.3
                  "N=DebianS      OS=debian  OS_VER=stable",
+                 # successors of CentOS:
+                 "N=RockyLinux8.4  OS=rockylinux OS_VER=8.4",
+                 "N=VzLinux8       OS=vzlinux    OS_VER=latest",
                  # Rolling/testing/experimental distributions:
                  "N=Ubuntu_Rolling       OS=ubuntu               OS_VER=rolling",
                  "N=Fedora_Rawhide       OS=fedora               OS_VER=rawhide",
@@ -93,6 +96,9 @@ jobs:
                  "N=DebianS      OS=debian  OS_VER=stable",
                  # Rolling/testing/experimental distributions:
                  "N=Ubuntu_Rolling       OS=ubuntu               OS_VER=rolling",
+                 # successors of CentOS:
+                 "N=RockyLinux8.4  OS=rockylinux OS_VER=8.4",
+                 "N=VzLinux8       OS=vzlinux    OS_VER=latest",
                  # the build Fedora_Rawhide with sanitizers was moved to Nightly_Experimental
                  "N=Fedora_Rawhide_no_SANITS  OS=fedora          OS_VER=rawhide  CI_SANITS=OFF",
                  "N=Debian_Testing       OS=debian               OS_VER=testing",

--- a/utils/docker/images/Dockerfile.rockylinux-8.4
+++ b/utils/docker/images/Dockerfile.rockylinux-8.4
@@ -1,0 +1,78 @@
+#
+# SPDX-License-Identifier: BSD-3-Clause
+# Copyright 2020-2021, Intel Corporation
+#
+
+#
+# Dockerfile - a 'recipe' for Docker to build an image of RedHat-based
+#              environment prepared for running tests of librpma.
+#
+
+# Pull base image
+FROM rockylinux/rockylinux:8.4
+MAINTAINER tomasz.gromadzki@intel.com
+
+RUN dnf update -y
+RUN dnf install -y epel-release
+RUN dnf install -y 'dnf-command(config-manager)'
+RUN dnf config-manager --set-enabled powertools
+
+# base deps
+ENV BASE_DEPS "\
+	clang \
+	gcc \
+	git \
+	make \
+	passwd \
+	pkg-config \
+	rpm-build \
+	sudo \
+	which"
+
+ENV TOOLS_DEPS "\
+	python3-jinja2"
+
+ENV TESTS_DEPS "\
+	python3-pylint"
+
+# RPMA deps
+ENV RPMA_DEPS "\
+	cmake \
+	diffutils \
+	file \
+	gawk \
+	groff \
+	graphviz \
+	libunwind-devel \
+	pandoc \
+	rdma-core-devel"
+
+# Install all required packages
+RUN dnf install -y \
+	$BASE_DEPS \
+	$TOOLS_DEPS \
+	$TESTS_DEPS \
+	$RPMA_DEPS \
+&& dnf clean all
+
+# Install cmocka
+COPY install-cmocka.sh install-cmocka.sh
+RUN ./install-cmocka.sh
+
+# Install txt2man
+COPY install-txt2man.sh install-txt2man.sh
+RUN ./install-txt2man.sh
+
+# Add user
+ENV USER user
+ENV USERPASS p1a2s3s4
+RUN useradd -m $USER
+RUN echo $USERPASS | passwd $USER --stdin
+RUN gpasswd wheel -a $USER
+USER $USER
+
+# Set required environment variables
+ENV OS rockylinux/rockylinux
+ENV OS_VER 8.4
+ENV PACKAGE_MANAGER rpm
+ENV NOTTY 1

--- a/utils/docker/images/Dockerfile.vzlinux-latest
+++ b/utils/docker/images/Dockerfile.vzlinux-latest
@@ -1,0 +1,78 @@
+#
+# SPDX-License-Identifier: BSD-3-Clause
+# Copyright 2020-2021, Intel Corporation
+#
+
+#
+# Dockerfile - a 'recipe' for Docker to build an image of RedHat-based
+#              environment prepared for running tests of librpma.
+#
+
+# Pull base image
+FROM virtuozzo/vzlinux8:latest
+MAINTAINER tomasz.gromadzki@intel.com
+
+RUN dnf update -y
+RUN dnf install -y epel-release
+RUN dnf install -y 'dnf-command(config-manager)'
+RUN dnf config-manager --set-enabled powertools
+
+# base deps
+ENV BASE_DEPS "\
+	clang \
+	gcc \
+	git \
+	make \
+	passwd \
+	pkg-config \
+	rpm-build \
+	sudo \
+	which"
+
+ENV TOOLS_DEPS "\
+	python3-jinja2"
+
+ENV TESTS_DEPS "\
+	python3-pylint"
+
+# RPMA deps
+ENV RPMA_DEPS "\
+	cmake \
+	diffutils \
+	file \
+	gawk \
+	groff \
+	graphviz \
+	libunwind-devel \
+	pandoc \
+	rdma-core-devel"
+
+# Install all required packages
+RUN dnf install -y \
+	$BASE_DEPS \
+	$TOOLS_DEPS \
+	$TESTS_DEPS \
+	$RPMA_DEPS \
+&& dnf clean all
+
+# Install cmocka
+COPY install-cmocka.sh install-cmocka.sh
+RUN ./install-cmocka.sh
+
+# Install txt2man
+COPY install-txt2man.sh install-txt2man.sh
+RUN ./install-txt2man.sh
+
+# Add user
+ENV USER user
+ENV USERPASS p1a2s3s4
+RUN useradd -m $USER
+RUN echo $USERPASS | passwd $USER --stdin
+RUN gpasswd wheel -a $USER
+USER $USER
+
+# Set required environment variables
+ENV OS virtuozzo/vzlinux8
+ENV OS_VER latest
+ENV PACKAGE_MANAGER rpm
+ENV NOTTY 1


### PR DESCRIPTION
Add Rocky Linux and VzLinux (successors of CentOS) to the nightly CI builds.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/pmem/rpma/1205)
<!-- Reviewable:end -->
