### PR TITLE
tools: set encoding in open() (fix)

### DIFF
--- a/tools/perf/lib/bench.py
+++ b/tools/perf/lib/bench.py
@@ -61,7 +61,7 @@ class Bench:
         }
 
         output_path = os.path.join(self.result_dir, 'bench.json')
-        with open(output_path, 'w') as file:
+        with open(output_path, 'w', encoding="utf-8") as file:
             json.dump(output, file, indent=4)
 
     def get_config(self):

--- a/tools/perf/lib/figure.py
+++ b/tools/perf/lib/figure.py
@@ -147,7 +147,7 @@ class Figure:
         else:
             figures = {}
         figures[self.key] = output
-        with open(series_path, 'w') as file:
+        with open(series_path, 'w', encoding="utf-8") as file:
             json.dump(figures, file, indent=4)
         # mark as done
         self.output['done'] = True


### PR DESCRIPTION
It fixes the following errors:

```
************* Module lib.bench
rpma/tools/perf/lib/bench.py:64:13:  W1514: Using open without explicitly specifying an encoding (unspecified-encoding)
************* Module lib.figure
rpma/tools/perf/lib/figure.py:150:13: W1514: Using open without explicitly specifying an encoding (unspecified-encoding)
```

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/pmem/rpma/1228)
<!-- Reviewable:end -->
