### PR TITLE
tools: perf: close matplotlib.pyplot.figure's

### DIFF
--- a/tools/perf/lib/figure.py
+++ b/tools/perf/lib/figure.py
@@ -236,6 +236,7 @@ class Figure:
 
         os.chdir(self.result_dir)
         plt.savefig(self.png_path())
+        plt.close(fig)
 
     def html_data_table(self):
         """


### PR DESCRIPTION
Fix:

```
RuntimeWarning: More than 20 figures have been opened. Figures created through the pyplot interface (`matplotlib.pyplot.figure`) are retained until explicitly closed and may consume too much memory. (To control this warning, see the rcParam `figure.max_open_warning`).
```

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/pmem/rpma/1240)
<!-- Reviewable:end -->
