### PR TITLE
tools: do nothing if src and dst specify the same file

### DIFF
--- a/tools/perf/report_create.py
+++ b/tools/perf/report_create.py
@@ -8,7 +8,7 @@
 
 import argparse
 
-from shutil import copy
+from shutil import copy, SameFileError
 from jinja2 import Environment, FileSystemLoader
 
 from lib.common import json_from_file
@@ -36,8 +36,12 @@ def main():
     bench = Bench.carry_on(args.bench)
     bench.check_completed()
     report = Report(LOADER, ENV, bench, args.report)
-    # copying report.json file to the result dir for future reference
-    copy(args.report['input_file'], bench.result_dir)
+    try:
+        # copying report.json file to the result dir for future reference
+        copy(args.report['input_file'], bench.result_dir)
+    except SameFileError:
+        # do nothing if src and dst specify the same file
+        pass
     report.create(args.output)
     print("Done.")
 


### PR DESCRIPTION
Do nothing if src and dst specify the same file
when copying report.json file to the result dir
for future reference.

It fixes the following error:
```
Traceback (most recent call last):
  File "/mnt/files/repos/rpma/tools/perf/./report_create.py", line 45, in <module>
    main()
  File "/mnt/files/repos/rpma/tools/perf/./report_create.py", line 40, in main
    copy(args.report['input_file'], bench.result_dir)
  File "/usr/lib/python3.9/shutil.py", line 418, in copy
    copyfile(src, dst, follow_symlinks=follow_symlinks)
  File "/usr/lib/python3.9/shutil.py", line 244, in copyfile
    raise SameFileError("{!r} and {!r} are the same file".format(src, dst))
shutil.SameFileError: './report_python/report.json' and '/mnt/files/repos/rpma/tools/perf/report_python/report.json' are the same file
```

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/pmem/rpma/1251)
<!-- Reviewable:end -->
