### PR TITLE
common: add matplotlib, pytest and co. to Docker files

### DIFF
--- a/utils/docker/images/Dockerfile.archlinux-latest
+++ b/utils/docker/images/Dockerfile.archlinux-latest
@@ -29,12 +29,20 @@ ENV TOOLS_DEPS "\
 	python-jinja"
 
 ENV TESTS_DEPS "\
-	python-pylint"
+	python-mccabe \
+	python-pylint \
+	python-pip \
+	python-pytest"
 
 # rdma-core deps
 ENV RDMA_DEPS "\
 	fakeroot \
 	file"
+
+ENV PYTHON_DEPS "\
+	markdown2 \
+	matplotlib \
+	pandas"
 
 # RPMA deps
 ENV RPMA_DEPS "\
@@ -93,3 +101,6 @@ ENV OS archlinux
 ENV OS_VER latest
 ENV PACKAGE_MANAGER none
 ENV NOTTY 1
+
+# install python modules for the default user
+RUN pip3 install --user $PYTHON_DEPS

--- a/utils/docker/images/Dockerfile.archlinux-latest
+++ b/utils/docker/images/Dockerfile.archlinux-latest
@@ -64,6 +64,8 @@ RUN pacman -S --noconfirm \
 	$RPMA_DEPS \
 && rm -rf /var/cache/pacman/pkg/*
 
+RUN pip3 install --upgrade pip
+
 # Install cmocka
 COPY install-cmocka.sh install-cmocka.sh
 RUN ./install-cmocka.sh

--- a/utils/docker/images/Dockerfile.centos-7
+++ b/utils/docker/images/Dockerfile.centos-7
@@ -31,7 +31,13 @@ ENV TOOLS_DEPS "\
 	python36-jinja2"
 
 ENV TESTS_DEPS "\
-	python36-pylint"
+	python36-pylint \
+	python36-pytest"
+
+ENV PYTHON_DEPS "\
+	markdown2 \
+	matplotlib \
+	pandas"
 
 # RPMA deps
 ENV RPMA_DEPS "\
@@ -78,3 +84,6 @@ ENV OS centos
 ENV OS_VER 7
 ENV PACKAGE_MANAGER rpm
 ENV NOTTY 1
+
+# install python modules for the default user
+RUN pip3 install --user $PYTHON_DEPS

--- a/utils/docker/images/Dockerfile.centos-7
+++ b/utils/docker/images/Dockerfile.centos-7
@@ -59,6 +59,8 @@ RUN yum install -y \
 	$RPMA_DEPS \
 && yum clean all
 
+RUN pip3 install --upgrade pip
+
 # run cmake3 as cmake
 RUN ln -s /usr/bin/cmake3 /usr/bin/cmake
 RUN ln -s /usr/bin/ctest3 /usr/bin/ctest

--- a/utils/docker/images/Dockerfile.centos-8
+++ b/utils/docker/images/Dockerfile.centos-8
@@ -62,6 +62,8 @@ RUN dnf install -y \
 	$RPMA_DEPS \
 && dnf clean all
 
+RUN pip3 install --upgrade pip
+
 # Install cmocka
 COPY install-cmocka.sh install-cmocka.sh
 RUN ./install-cmocka.sh

--- a/utils/docker/images/Dockerfile.centos-8
+++ b/utils/docker/images/Dockerfile.centos-8
@@ -33,7 +33,14 @@ ENV TOOLS_DEPS "\
 	python3-jinja2"
 
 ENV TESTS_DEPS "\
-	python3-pylint"
+	python3-pylint \
+	python3-pip \
+	python3-pytest"
+
+ENV PYTHON_DEPS "\
+	markdown2 \
+	matplotlib \
+	pandas"
 
 # RPMA deps
 ENV RPMA_DEPS "\
@@ -76,3 +83,6 @@ ENV OS centos
 ENV OS_VER 8
 ENV PACKAGE_MANAGER rpm
 ENV NOTTY 1
+
+# install python modules for the default user
+RUN pip3 install --user $PYTHON_DEPS

--- a/utils/docker/images/Dockerfile.debian-10
+++ b/utils/docker/images/Dockerfile.debian-10
@@ -38,7 +38,14 @@ ENV TOOLS_DEPS "\
 	python3-jinja2"
 
 ENV TESTS_DEPS "\
-	pylint3"
+	pylint3 \
+	python3-pip \
+	python3-pytest"
+
+ENV PYTHON_DEPS "\
+	markdown2 \
+	matplotlib \
+	pandas"
 
 # RPMA deps
 ENV RPMA_DEPS "\
@@ -80,3 +87,6 @@ ENV OS debian
 ENV OS_VER 10
 ENV PACKAGE_MANAGER deb
 ENV NOTTY 1
+
+# install python modules for the default user
+RUN pip3 install --user $PYTHON_DEPS

--- a/utils/docker/images/Dockerfile.debian-10
+++ b/utils/docker/images/Dockerfile.debian-10
@@ -68,6 +68,8 @@ RUN apt-get install -y --no-install-recommends \
 	$RPMA_DEPS \
 && rm -rf /var/lib/apt/lists/*
 
+RUN pip3 install --upgrade pip
+
 # Install cmocka
 COPY install-cmocka.sh install-cmocka.sh
 RUN ./install-cmocka.sh

--- a/utils/docker/images/Dockerfile.debian-9
+++ b/utils/docker/images/Dockerfile.debian-9
@@ -67,6 +67,8 @@ RUN apt-get install -y --no-install-recommends \
 	$RPMA_DEPS \
 && rm -rf /var/lib/apt/lists/*
 
+RUN pip3 install --upgrade pip
+
 # create a link for pytest
 RUN ln -s /usr/bin/pytest-3 /usr/bin/pytest
 

--- a/utils/docker/images/Dockerfile.debian-experimental
+++ b/utils/docker/images/Dockerfile.debian-experimental
@@ -61,6 +61,8 @@ RUN apt-get install -y --no-install-recommends \
 	$RPMA_DEPS \
 && rm -rf /var/lib/apt/lists/*
 
+RUN pip3 install --upgrade pip
+
 # Install cmocka
 COPY install-cmocka.sh install-cmocka.sh
 RUN ./install-cmocka.sh

--- a/utils/docker/images/Dockerfile.debian-experimental
+++ b/utils/docker/images/Dockerfile.debian-experimental
@@ -32,7 +32,14 @@ ENV TOOLS_DEPS "\
 	python3-jinja2"
 
 ENV TESTS_DEPS "\
-	pylint3"
+	pylint3 \
+	python3-pip \
+	python3-pytest"
+
+ENV PYTHON_DEPS "\
+	markdown2 \
+	matplotlib \
+	pandas"
 
 # RPMA deps
 ENV RPMA_DEPS "\
@@ -73,3 +80,6 @@ ENV OS debian
 ENV OS_VER experimental
 ENV PACKAGE_MANAGER deb
 ENV NOTTY 1
+
+# install python modules for the default user
+RUN pip3 install --user $PYTHON_DEPS

--- a/utils/docker/images/Dockerfile.debian-stable
+++ b/utils/docker/images/Dockerfile.debian-stable
@@ -68,6 +68,8 @@ RUN apt-get install -y --no-install-recommends \
 	$RPMA_DEPS \
 && rm -rf /var/lib/apt/lists/*
 
+RUN pip3 install --upgrade pip
+
 # Install cmocka
 COPY install-cmocka.sh install-cmocka.sh
 RUN ./install-cmocka.sh

--- a/utils/docker/images/Dockerfile.debian-stable
+++ b/utils/docker/images/Dockerfile.debian-stable
@@ -38,7 +38,14 @@ ENV TOOLS_DEPS "\
 	python3-jinja2"
 
 ENV TESTS_DEPS "\
-	pylint3"
+	pylint3 \
+	python3-pip \
+	python3-pytest"
+
+ENV PYTHON_DEPS "\
+	markdown2 \
+	matplotlib \
+	pandas"
 
 # RPMA deps
 ENV RPMA_DEPS "\
@@ -80,3 +87,6 @@ ENV OS debian
 ENV OS_VER stable
 ENV PACKAGE_MANAGER deb
 ENV NOTTY 1
+
+# install python modules for the default user
+RUN pip3 install --user $PYTHON_DEPS

--- a/utils/docker/images/Dockerfile.debian-testing
+++ b/utils/docker/images/Dockerfile.debian-testing
@@ -61,6 +61,8 @@ RUN apt-get install -y --no-install-recommends \
 	$RPMA_DEPS \
 && rm -rf /var/lib/apt/lists/*
 
+RUN pip3 install --upgrade pip
+
 # Install cmocka
 COPY install-cmocka.sh install-cmocka.sh
 RUN ./install-cmocka.sh

--- a/utils/docker/images/Dockerfile.debian-testing
+++ b/utils/docker/images/Dockerfile.debian-testing
@@ -32,7 +32,14 @@ ENV TOOLS_DEPS "\
 	python3-jinja2"
 
 ENV TESTS_DEPS "\
-	pylint3"
+	pylint3 \
+	python3-pip \
+	python3-pytest"
+
+ENV PYTHON_DEPS "\
+	markdown2 \
+	matplotlib \
+	pandas"
 
 # RPMA deps
 ENV RPMA_DEPS "\
@@ -73,3 +80,6 @@ ENV OS debian
 ENV OS_VER testing
 ENV PACKAGE_MANAGER deb
 ENV NOTTY 1
+
+# install python modules for the default user
+RUN pip3 install --user $PYTHON_DEPS

--- a/utils/docker/images/Dockerfile.fedora-26
+++ b/utils/docker/images/Dockerfile.fedora-26
@@ -70,6 +70,8 @@ RUN dnf install -y \
 	$DOC_UPDATE_DEPS \
 && dnf clean all
 
+RUN pip3 install --upgrade pip
+
 # Install cmocka
 COPY install-cmocka.sh install-cmocka.sh
 RUN ./install-cmocka.sh

--- a/utils/docker/images/Dockerfile.fedora-26
+++ b/utils/docker/images/Dockerfile.fedora-26
@@ -35,7 +35,14 @@ ENV TOOLS_DEPS "\
 	python3-jinja2"
 
 ENV TESTS_DEPS "\
-	pylint"
+	pylint \
+	python3-pip \
+	python3-pytest"
+
+ENV PYTHON_DEPS "\
+	markdown2 \
+	matplotlib \
+	pandas"
 
 # RPMA deps
 ENV RPMA_DEPS "\
@@ -85,3 +92,5 @@ ENV OS_VER 26
 ENV PACKAGE_MANAGER rpm
 ENV NOTTY 1
 
+# install python modules for the default user
+RUN pip3 install --user $PYTHON_DEPS

--- a/utils/docker/images/Dockerfile.fedora-27
+++ b/utils/docker/images/Dockerfile.fedora-27
@@ -69,6 +69,8 @@ RUN dnf install -y \
 	$DOC_UPDATE_DEPS \
 && dnf clean all
 
+RUN pip3 install --upgrade pip
+
 # Install cmocka
 COPY install-cmocka.sh install-cmocka.sh
 RUN ./install-cmocka.sh

--- a/utils/docker/images/Dockerfile.fedora-27
+++ b/utils/docker/images/Dockerfile.fedora-27
@@ -35,7 +35,14 @@ ENV TOOLS_DEPS "\
 	python3-jinja2"
 
 ENV TESTS_DEPS "\
-	pylint"
+	pylint \
+	python3-pip \
+	python3-pytest"
+
+ENV PYTHON_DEPS "\
+	markdown2 \
+	matplotlib \
+	pandas"
 
 # RPMA deps
 ENV RPMA_DEPS "\
@@ -84,3 +91,5 @@ ENV OS_VER 27
 ENV PACKAGE_MANAGER rpm
 ENV NOTTY 1
 
+# install python modules for the default user
+RUN pip3 install --user $PYTHON_DEPS

--- a/utils/docker/images/Dockerfile.fedora-28
+++ b/utils/docker/images/Dockerfile.fedora-28
@@ -69,6 +69,8 @@ RUN dnf install -y \
 	$DOC_UPDATE_DEPS \
 && dnf clean all
 
+RUN pip3 install --upgrade pip
+
 # Install cmocka
 COPY install-cmocka.sh install-cmocka.sh
 RUN ./install-cmocka.sh

--- a/utils/docker/images/Dockerfile.fedora-28
+++ b/utils/docker/images/Dockerfile.fedora-28
@@ -35,7 +35,14 @@ ENV TOOLS_DEPS "\
 	python3-jinja2"
 
 ENV TESTS_DEPS "\
-	pylint"
+	pylint \
+	python3-pip \
+	python3-pytest"
+
+ENV PYTHON_DEPS "\
+	markdown2 \
+	matplotlib \
+	pandas"
 
 # RPMA deps
 ENV RPMA_DEPS "\
@@ -84,3 +91,5 @@ ENV OS_VER 28
 ENV PACKAGE_MANAGER rpm
 ENV NOTTY 1
 
+# install python modules for the default user
+RUN pip3 install --user $PYTHON_DEPS

--- a/utils/docker/images/Dockerfile.fedora-29
+++ b/utils/docker/images/Dockerfile.fedora-29
@@ -69,6 +69,8 @@ RUN dnf install -y \
 	$DOC_UPDATE_DEPS \
 && dnf clean all
 
+RUN pip3 install --upgrade pip
+
 # Install cmocka
 COPY install-cmocka.sh install-cmocka.sh
 RUN ./install-cmocka.sh

--- a/utils/docker/images/Dockerfile.fedora-29
+++ b/utils/docker/images/Dockerfile.fedora-29
@@ -35,7 +35,14 @@ ENV TOOLS_DEPS "\
 	python3-jinja2"
 
 ENV TESTS_DEPS "\
-	pylint"
+	pylint \
+	python3-pip \
+	python3-pytest"
+
+ENV PYTHON_DEPS "\
+	markdown2 \
+	matplotlib \
+	pandas"
 
 # RPMA deps
 ENV RPMA_DEPS "\
@@ -84,3 +91,5 @@ ENV OS_VER 29
 ENV PACKAGE_MANAGER rpm
 ENV NOTTY 1
 
+# install python modules for the default user
+RUN pip3 install --user $PYTHON_DEPS

--- a/utils/docker/images/Dockerfile.fedora-30
+++ b/utils/docker/images/Dockerfile.fedora-30
@@ -34,7 +34,14 @@ ENV TOOLS_DEPS "\
 	python3-jinja2"
 
 ENV TESTS_DEPS "\
-	pylint"
+	pylint \
+	python3-pip \
+	python3-pytest"
+
+ENV PYTHON_DEPS "\
+	markdown2 \
+	matplotlib \
+	pandas"
 
 # RPMA deps
 ENV RPMA_DEPS "\
@@ -83,3 +90,5 @@ ENV OS_VER 30
 ENV PACKAGE_MANAGER rpm
 ENV NOTTY 1
 
+# install python modules for the default user
+RUN pip3 install --user $PYTHON_DEPS

--- a/utils/docker/images/Dockerfile.fedora-30
+++ b/utils/docker/images/Dockerfile.fedora-30
@@ -68,6 +68,8 @@ RUN dnf install -y \
 	$DOC_UPDATE_DEPS \
 && dnf clean all
 
+RUN pip3 install --upgrade pip
+
 # Install cmocka
 COPY install-cmocka.sh install-cmocka.sh
 RUN ./install-cmocka.sh

--- a/utils/docker/images/Dockerfile.fedora-31
+++ b/utils/docker/images/Dockerfile.fedora-31
@@ -34,7 +34,14 @@ ENV TOOLS_DEPS "\
 	python3-jinja2"
 
 ENV TESTS_DEPS "\
-	pylint"
+	pylint \
+	python3-pip \
+	python3-pytest"
+
+ENV PYTHON_DEPS "\
+	markdown2 \
+	matplotlib \
+	pandas"
 
 # RPMA deps
 ENV RPMA_DEPS "\
@@ -83,3 +90,5 @@ ENV OS_VER 31
 ENV PACKAGE_MANAGER rpm
 ENV NOTTY 1
 
+# install python modules for the default user
+RUN pip3 install --user $PYTHON_DEPS

--- a/utils/docker/images/Dockerfile.fedora-31
+++ b/utils/docker/images/Dockerfile.fedora-31
@@ -68,6 +68,8 @@ RUN dnf install -y \
 	$DOC_UPDATE_DEPS \
 && dnf clean all
 
+RUN pip3 install --upgrade pip
+
 # Install cmocka
 COPY install-cmocka.sh install-cmocka.sh
 RUN ./install-cmocka.sh

--- a/utils/docker/images/Dockerfile.fedora-32
+++ b/utils/docker/images/Dockerfile.fedora-32
@@ -68,6 +68,8 @@ RUN dnf install -y \
 	$DOC_UPDATE_DEPS \
 && dnf clean all
 
+RUN pip3 install --upgrade pip
+
 # Install cmocka
 COPY install-cmocka.sh install-cmocka.sh
 RUN ./install-cmocka.sh

--- a/utils/docker/images/Dockerfile.fedora-33
+++ b/utils/docker/images/Dockerfile.fedora-33
@@ -68,6 +68,8 @@ RUN dnf install -y \
 	$DOC_UPDATE_DEPS \
 && dnf clean all
 
+RUN pip3 install --upgrade pip
+
 # Install cmocka
 COPY install-cmocka.sh install-cmocka.sh
 RUN ./install-cmocka.sh

--- a/utils/docker/images/Dockerfile.fedora-33
+++ b/utils/docker/images/Dockerfile.fedora-33
@@ -34,7 +34,14 @@ ENV TOOLS_DEPS "\
 	python3-jinja2"
 
 ENV TESTS_DEPS "\
-	pylint"
+	pylint \
+	python3-pip \
+	python3-pytest"
+
+ENV PYTHON_DEPS "\
+	markdown2 \
+	matplotlib \
+	pandas"
 
 # RPMA deps
 ENV RPMA_DEPS "\
@@ -83,3 +90,5 @@ ENV OS_VER 33
 ENV PACKAGE_MANAGER rpm
 ENV NOTTY 1
 
+# install python modules for the default user
+RUN pip3 install --user $PYTHON_DEPS

--- a/utils/docker/images/Dockerfile.fedora-rawhide
+++ b/utils/docker/images/Dockerfile.fedora-rawhide
@@ -63,6 +63,8 @@ RUN dnf install -y \
 	$RPMA_DEPS \
 && dnf clean all
 
+RUN pip3 install --upgrade pip
+
 # Install cmocka
 COPY install-cmocka.sh install-cmocka.sh
 RUN ./install-cmocka.sh

--- a/utils/docker/images/Dockerfile.fedora-rawhide
+++ b/utils/docker/images/Dockerfile.fedora-rawhide
@@ -34,7 +34,14 @@ ENV TOOLS_DEPS "\
 	python3-jinja2"
 
 ENV TESTS_DEPS "\
-	pylint"
+	pylint \
+	python3-pip \
+	python3-pytest"
+
+ENV PYTHON_DEPS "\
+	markdown2 \
+	matplotlib \
+	pandas"
 
 # RPMA deps
 ENV RPMA_DEPS "\
@@ -78,3 +85,5 @@ ENV OS_VER rawhide
 ENV PACKAGE_MANAGER rpm
 ENV NOTTY 1
 
+# install python modules for the default user
+RUN pip3 install --user $PYTHON_DEPS

--- a/utils/docker/images/Dockerfile.opensuse-leap-latest
+++ b/utils/docker/images/Dockerfile.opensuse-leap-latest
@@ -34,7 +34,13 @@ ENV TOOLS_DEPS "\
 ENV TESTS_DEPS "\
 	python3-pip \
 	python3-pylint \
+	python3-pytest \
 	python3-setuptools"
+
+ENV PYTHON_DEPS "\
+	markdown2 \
+	matplotlib \
+	pandas"
 
 # RPMA deps
 ENV RPMA_DEPS "\
@@ -89,3 +95,5 @@ ENV OS_VER latest
 ENV PACKAGE_MANAGER rpm
 ENV NOTTY 1
 
+# install python modules for the default user
+RUN pip3 install --user $PYTHON_DEPS

--- a/utils/docker/images/Dockerfile.opensuse-leap-latest
+++ b/utils/docker/images/Dockerfile.opensuse-leap-latest
@@ -61,6 +61,8 @@ RUN zypper install -y \
 	$TESTS_DEPS \
 	$RPMA_DEPS
 
+RUN pip3 install --upgrade pip
+
 # Required by python3-pylint
 RUN pip install setuptools
 

--- a/utils/docker/images/Dockerfile.opensuse-tumbleweed-latest
+++ b/utils/docker/images/Dockerfile.opensuse-tumbleweed-latest
@@ -60,6 +60,8 @@ RUN zypper install -y \
 	$TESTS_DEPS \
 	$RPMA_DEPS
 
+RUN pip3 install --upgrade pip
+
 # Install cmocka
 COPY install-cmocka.sh install-cmocka.sh
 RUN ./install-cmocka.sh

--- a/utils/docker/images/Dockerfile.opensuse-tumbleweed-latest
+++ b/utils/docker/images/Dockerfile.opensuse-tumbleweed-latest
@@ -32,7 +32,14 @@ ENV TOOLS_DEPS "\
 	python3-Jinja2"
 
 ENV TESTS_DEPS "\
-	python3-pylint"
+	python3-pylint \
+	python3-pip \
+	python3-pytest"
+
+ENV PYTHON_DEPS "\
+	markdown2 \
+	matplotlib \
+	pandas"
 
 # RPMA deps
 ENV RPMA_DEPS "\
@@ -84,3 +91,5 @@ ENV OS_VER latest
 ENV PACKAGE_MANAGER rpm
 ENV NOTTY 1
 
+# install python modules for the default user
+RUN pip3 install --user $PYTHON_DEPS

--- a/utils/docker/images/Dockerfile.rockylinux-8.4
+++ b/utils/docker/images/Dockerfile.rockylinux-8.4
@@ -33,7 +33,14 @@ ENV TOOLS_DEPS "\
 	python3-jinja2"
 
 ENV TESTS_DEPS "\
-	python3-pylint"
+	python3-pylint \
+	python3-pip \
+	python3-pytest"
+
+ENV PYTHON_DEPS "\
+	markdown2 \
+	matplotlib \
+	pandas"
 
 # RPMA deps
 ENV RPMA_DEPS "\
@@ -76,3 +83,6 @@ ENV OS rockylinux/rockylinux
 ENV OS_VER 8.4
 ENV PACKAGE_MANAGER rpm
 ENV NOTTY 1
+
+# install python modules for the default user
+RUN pip3 install --user $PYTHON_DEPS

--- a/utils/docker/images/Dockerfile.rockylinux-8.4
+++ b/utils/docker/images/Dockerfile.rockylinux-8.4
@@ -62,6 +62,8 @@ RUN dnf install -y \
 	$RPMA_DEPS \
 && dnf clean all
 
+RUN pip3 install --upgrade pip
+
 # Install cmocka
 COPY install-cmocka.sh install-cmocka.sh
 RUN ./install-cmocka.sh

--- a/utils/docker/images/Dockerfile.ubuntu-18.04
+++ b/utils/docker/images/Dockerfile.ubuntu-18.04
@@ -40,7 +40,14 @@ ENV TOOLS_DEPS "\
 	python3-jinja2"
 
 ENV TESTS_DEPS "\
-	pylint3"
+	pylint3 \
+	python3-pip \
+	python3-pytest"
+
+ENV PYTHON_DEPS "\
+	markdown2 \
+	matplotlib \
+	pandas"
 
 # RPMA deps
 ENV RPMA_DEPS "\
@@ -82,3 +89,6 @@ ENV OS ubuntu
 ENV OS_VER 18.04
 ENV PACKAGE_MANAGER deb
 ENV NOTTY 1
+
+# install python modules for the default user
+RUN pip3 install --user $PYTHON_DEPS

--- a/utils/docker/images/Dockerfile.ubuntu-18.04
+++ b/utils/docker/images/Dockerfile.ubuntu-18.04
@@ -70,6 +70,8 @@ RUN apt-get install -y --no-install-recommends \
 	$RPMA_DEPS \
 && rm -rf /var/lib/apt/lists/*
 
+RUN pip3 install --upgrade pip
+
 # Install cmocka
 COPY install-cmocka.sh install-cmocka.sh
 RUN ./install-cmocka.sh

--- a/utils/docker/images/Dockerfile.ubuntu-20.04
+++ b/utils/docker/images/Dockerfile.ubuntu-20.04
@@ -69,6 +69,8 @@ RUN apt-get install -y --no-install-recommends \
 	$RPMA_DEPS \
 && rm -rf /var/lib/apt/lists/*
 
+RUN pip3 install --upgrade pip
+
 # create a link for pytest
 RUN ln -s /usr/bin/pytest-3 /usr/bin/pytest
 

--- a/utils/docker/images/Dockerfile.ubuntu-rolling
+++ b/utils/docker/images/Dockerfile.ubuntu-rolling
@@ -36,7 +36,14 @@ ENV TOOLS_DEPS "\
 	python3-jinja2"
 
 ENV TESTS_DEPS "\
-	pylint3"
+	pylint3 \
+	python3-pip \
+	python3-pytest"
+
+ENV PYTHON_DEPS "\
+	markdown2 \
+	matplotlib \
+	pandas"
 
 # RPMA deps
 ENV RPMA_DEPS "\
@@ -78,3 +85,6 @@ ENV OS ubuntu
 ENV OS_VER rolling
 ENV PACKAGE_MANAGER deb
 ENV NOTTY 1
+
+# install python modules for the default user
+RUN pip3 install --user $PYTHON_DEPS

--- a/utils/docker/images/Dockerfile.ubuntu-rolling
+++ b/utils/docker/images/Dockerfile.ubuntu-rolling
@@ -66,6 +66,8 @@ RUN apt-get install -y --no-install-recommends \
 	$RPMA_DEPS \
 && rm -rf /var/lib/apt/lists/*
 
+RUN pip3 install --upgrade pip
+
 # Install cmocka
 COPY install-cmocka.sh install-cmocka.sh
 RUN ./install-cmocka.sh

--- a/utils/docker/images/Dockerfile.vzlinux-latest
+++ b/utils/docker/images/Dockerfile.vzlinux-latest
@@ -33,7 +33,14 @@ ENV TOOLS_DEPS "\
 	python3-jinja2"
 
 ENV TESTS_DEPS "\
-	python3-pylint"
+	python3-pylint \
+	python3-pip \
+	python3-pytest"
+
+ENV PYTHON_DEPS "\
+	markdown2 \
+	matplotlib \
+	pandas"
 
 # RPMA deps
 ENV RPMA_DEPS "\
@@ -76,3 +83,6 @@ ENV OS virtuozzo/vzlinux8
 ENV OS_VER latest
 ENV PACKAGE_MANAGER rpm
 ENV NOTTY 1
+
+# install python modules for the default user
+RUN pip3.6 install --user $PYTHON_DEPS

--- a/utils/docker/images/Dockerfile.vzlinux-latest
+++ b/utils/docker/images/Dockerfile.vzlinux-latest
@@ -62,6 +62,8 @@ RUN dnf install -y \
 	$RPMA_DEPS \
 && dnf clean all
 
+RUN pip3.6 install --upgrade pip
+
 # Install cmocka
 COPY install-cmocka.sh install-cmocka.sh
 RUN ./install-cmocka.sh


### PR DESCRIPTION
Add matplotlib, pytest and other required python packages
to Docker files of OSes tested in nightly CI builds.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/pmem/rpma/1256)
<!-- Reviewable:end -->
