### PR TITLE
common: add missing upgrade of pip to Fedora 34 docker image

### DIFF
--- a/utils/docker/images/Dockerfile.fedora-34
+++ b/utils/docker/images/Dockerfile.fedora-34
@@ -68,6 +68,8 @@ RUN dnf install -y \
 	$DOC_UPDATE_DEPS \
 && dnf clean all
 
+RUN pip3 install --upgrade pip
+
 # Install cmocka
 COPY install-cmocka.sh install-cmocka.sh
 RUN ./install-cmocka.sh


### PR DESCRIPTION
See commit ce36455

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/pmem/rpma/1261)
<!-- Reviewable:end -->
