### PR TITLE
common: move all Fedora Rawhide CI builds to Nightly_Experimental

### DIFF
--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -53,8 +53,8 @@ jobs:
                  "N=RockyLinux8.4  OS=rockylinux OS_VER=8.4",
                  "N=VzLinux8       OS=vzlinux    OS_VER=latest",
                  # Rolling/testing/experimental distributions:
+                 # (the Fedora_Rawhide build was moved to Nightly_Experimental)
                  "N=Ubuntu_Rolling       OS=ubuntu               OS_VER=rolling",
-                 "N=Fedora_Rawhide       OS=fedora               OS_VER=rawhide",
                  "N=Debian_Testing       OS=debian               OS_VER=testing",
                  "N=Debian_Experimental  OS=debian               OS_VER=experimental",
                  "N=Arch_Linux_Latest    OS=archlinux            OS_VER=latest",
@@ -99,13 +99,12 @@ jobs:
                  "N=Debian10     OS=debian  OS_VER=10",
                  "N=Debian9      OS=debian  OS_VER=9",
                  "N=DebianS      OS=debian  OS_VER=stable",
-                 # Rolling/testing/experimental distributions:
-                 "N=Ubuntu_Rolling       OS=ubuntu               OS_VER=rolling",
                  # successors of CentOS:
                  "N=RockyLinux8.4  OS=rockylinux OS_VER=8.4",
                  "N=VzLinux8       OS=vzlinux    OS_VER=latest",
-                 # the build Fedora_Rawhide with sanitizers was moved to Nightly_Experimental
-                 "N=Fedora_Rawhide_no_SANITS  OS=fedora          OS_VER=rawhide  CI_SANITS=OFF",
+                 # Rolling/testing/experimental distributions:
+                 # (the Fedora_Rawhide builds were moved to Nightly_Experimental)
+                 "N=Ubuntu_Rolling       OS=ubuntu               OS_VER=rolling",
                  "N=Debian_Testing       OS=debian               OS_VER=testing",
                  "N=Debian_Experimental  OS=debian               OS_VER=experimental",
                  "N=Arch_Linux_Latest    OS=archlinux            OS_VER=latest",

--- a/.github/workflows/nightly_experimental.yml
+++ b/.github/workflows/nightly_experimental.yml
@@ -26,7 +26,9 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        CONFIG: ["N=Fedora_Rawhide_SANITS  OS=fedora  OS_VER=rawhide  CC=clang  CI_SANITS=ON  PUSH_IMAGE=0"]
+        CONFIG: ["N=Fedora_Rawhide            OS=fedora  OS_VER=rawhide  CC=gcc    CI_SANITS=ON   PUSH_IMAGE=1",
+                 "N=Fedora_Rawhide_SANITS     OS=fedora  OS_VER=rawhide  CC=clang  CI_SANITS=ON   PUSH_IMAGE=0",
+                 "N=Fedora_Rawhide_no_SANITS  OS=fedora  OS_VER=rawhide  CC=clang  CI_SANITS=OFF  PUSH_IMAGE=0"]
     steps:
        - name: Clone the git repo
          uses: actions/checkout@v1


### PR DESCRIPTION
Move all Fedora Rawhide CI builds to Nightly_Experimental,
since they have been failing for a long time,
because of the following error:
```
Curl error (6): Couldn't resolve host name for \
  https://mirrors.fedoraproject.org/metalink?repo=rawhide&arch=x86_64 [getaddrinfo() thread failed to start]
```
See:
https://www.mail-archive.com/devel@lists.fedoraproject.org/msg169919.html
https://github.com/actions/virtual-environments/issues/3812

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/pmem/rpma/1275)
<!-- Reviewable:end -->
