### PR TITLE
common: add CentOS Stream CI build to Nightly_Rebuild

### DIFF
--- a/.github/workflows/nightly_rebuild.yml
+++ b/.github/workflows/nightly_rebuild.yml
@@ -35,6 +35,7 @@ jobs:
                  "N=Debian_Testing       OS=debian               OS_VER=testing        REBUILD_ALWAYS=YES",
                  "N=Debian_Experimental  OS=debian               OS_VER=experimental   REBUILD_ALWAYS=YES",
                  "N=Arch_Linux_Latest    OS=archlinux            OS_VER=latest         REBUILD_ALWAYS=YES",
+                 "N=CentOS_Stream        OS=centos               OS_VER=stream         REBUILD_ALWAYS=YES",
                  "N=OpenSUSE_Leap        OS=opensuse-leap        OS_VER=latest         REBUILD_ALWAYS=YES",
                  "N=OpenSUSE_Tumbleweed  OS=opensuse-tumbleweed  OS_VER=latest         REBUILD_ALWAYS=YES"]
     steps:

--- a/utils/docker/images/Dockerfile.centos-stream
+++ b/utils/docker/images/Dockerfile.centos-stream
@@ -1,0 +1,91 @@
+#
+# SPDX-License-Identifier: BSD-3-Clause
+# Copyright 2020-2021, Intel Corporation
+#
+
+#
+# Dockerfile - a 'recipe' for Docker to build an image of fedora-based
+#              environment prepared for running tests of librpma.
+#
+
+# Pull base image
+# There is NO official docker image of CentOS Stream, so we use tgagor/centos-stream.
+FROM tgagor/centos:stream
+MAINTAINER tomasz.gromadzki@intel.com
+
+RUN dnf update -y
+RUN dnf install -y epel-release
+RUN dnf install -y 'dnf-command(config-manager)'
+RUN dnf config-manager --set-enabled powertools
+
+# base deps
+ENV BASE_DEPS "\
+	clang \
+	gcc \
+	git \
+	make \
+	passwd \
+	pkg-config \
+	rpm-build \
+	sudo \
+	which"
+
+ENV TOOLS_DEPS "\
+	python3-jinja2"
+
+ENV TESTS_DEPS "\
+	python3-pylint \
+	python3-pip \
+	python3-pytest"
+
+ENV PYTHON_DEPS "\
+	markdown2 \
+	matplotlib \
+	pandas"
+
+# RPMA deps
+ENV RPMA_DEPS "\
+	cmake \
+	diffutils \
+	file \
+	gawk \
+	groff \
+	graphviz \
+	libunwind-devel \
+	pandoc \
+	rdma-core-devel"
+
+# Install all required packages
+RUN dnf install -y \
+	$BASE_DEPS \
+	$TOOLS_DEPS \
+	$TESTS_DEPS \
+	$RPMA_DEPS \
+&& dnf clean all
+
+RUN pip3 install --upgrade pip
+
+# Install cmocka
+COPY install-cmocka.sh install-cmocka.sh
+RUN ./install-cmocka.sh
+
+# Install txt2man
+COPY install-txt2man.sh install-txt2man.sh
+RUN ./install-txt2man.sh
+
+# Add user
+ENV USER user
+ENV USERPASS p1a2s3s4
+RUN useradd -m $USER
+RUN echo $USERPASS | passwd $USER --stdin
+RUN gpasswd wheel -a $USER
+USER $USER
+
+# Set required environment variables
+ENV OS centos
+ENV OS_VER stream
+ENV PACKAGE_MANAGER rpm
+ENV NOTTY 1
+
+# install python modules for the default user
+RUN pip3 install --user $PYTHON_DEPS


### PR DESCRIPTION
There is NO official docker image of CentOS Stream,
so we use tgagor/centos-stream.

See:
https://hub.docker.com/r/tgagor/centos-stream/tags
https://timor.site/2021/02/centos-8-stream-docker-image/

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/pmem/rpma/1278)
<!-- Reviewable:end -->
