### PR TITLE
tools: perf: precisely define DW2PMem vs non-DW2PMem

### DIFF
--- a/tools/perf/figures/read.json
+++ b/tools/perf/figures/read.json
@@ -1,7 +1,7 @@
 [
     {
         "output": {
-            "title": "Latency ({y}): ib_read_lat vs rpma_read() from DRAM",
+            "title": "Latency ({y}): ib_read_lat vs rpma_read() from DRAM (both non-DW2PMem)",
             "x": "bs",
             "y": ["lat_avg", "lat_pctl_99.9", "lat_pctl_99.99"],
             "file": "ib_read_vs_rpma_read_dram",
@@ -31,7 +31,7 @@
     },
     {
         "output": {
-            "title": "Latency ({y}): rpma_read() from DRAM vs from PMEM",
+            "title": "Latency ({y}): rpma_read() from DRAM (non-DW2PMem) vs from PMEM (DW2PMem)",
             "x": "bs",
             "y": ["lat_avg", "lat_pctl_99.9", "lat_pctl_99.99"],
             "file": "rpma_read_dram_vs_pmem",
@@ -65,7 +65,7 @@
     {
         "output": {
             "_comment": "XXX combine bw-bs and bw-th definitions",
-            "title": "Bandwidth ({x}): ib_read_bw() vs rpma_read() from DRAM",
+            "title": "Bandwidth ({x}): ib_read_bw() vs rpma_read() from DRAM (both non-DW2PMem)",
             "x": "bs",
             "y": "bw_avg",
             "file": "ib_read_vs_rpma_read_dram",
@@ -96,7 +96,7 @@
     {
         "output": {
             "_comment": "XXX combine bw-bs and bw-th definitions",
-            "title": "Bandwidth ({x}): ib_read_bw() vs rpma_read() from DRAM",
+            "title": "Bandwidth ({x}): ib_read_bw() vs rpma_read() from DRAM (both non-DW2PMem)",
             "x": "threads",
             "y": "bw_avg",
             "file": "ib_read_vs_rpma_read_dram",
@@ -127,7 +127,7 @@
     {
         "output": {
             "_comment": "XXX combine bw-bs and bw-th definitions",
-            "title": "Bandwidth ({x}): rpma_read() from DRAM vs from PMEM",
+            "title": "Bandwidth ({x}): rpma_read() from DRAM (non-DW2PMem) vs from PMEM (DW2PMem)",
             "x": "bs",
             "y": "bw_avg",
             "file": "rpma_read_dram_vs_pmem",
@@ -161,7 +161,7 @@
     {
         "output": {
             "_comment": "XXX combine bw-bs and bw-th definitions",
-            "title": "Bandwidth ({x}): rpma_read() from DRAM vs from PMEM",
+            "title": "Bandwidth ({x}): rpma_read() from DRAM (non-DW2PMem) vs from PMEM (DW2PMem)",
             "x": "threads",
             "y": "bw_avg",
             "file": "rpma_read_dram_vs_pmem",

--- a/tools/perf/figures/write.json
+++ b/tools/perf/figures/write.json
@@ -1,7 +1,7 @@
 [
     {
         "output": {
-            "title": "Latency ({y}): APM to DRAM (DDIO=ON) vs PMEM",
+            "title": "Latency ({y}): APM to DRAM (non-DW2PMem) vs APM to PMEM",
             "x": "bs",
             "y": ["lat_avg", "lat_pctl_99.9", "lat_pctl_99.99"],
             "file": "apm_dram_vs_pmem",
@@ -77,7 +77,7 @@
     {
         "output": {
             "_comment": "XXX combine bw-bs and bw-th definitions",
-            "title": "Bandwidth ({x}): APM to DRAM (DDIO=ON) vs to PMEM",
+            "title": "Bandwidth ({x}): APM to DRAM (non-DW2PMem) vs APM to PMEM",
             "x": "bs",
             "y": "bw_avg",
             "file": "apm_dram_vs_pmem",
@@ -111,7 +111,7 @@
     {
         "output": {
             "_comment": "XXX combine bw-bs and bw-th definitions",
-            "title": "Bandwidth ({x}): APM to DRAM (DDIO=ON) vs to PMEM",
+            "title": "Bandwidth ({x}): APM to DRAM (non-DW2PMem) vs APM to PMEM",
             "x": "threads",
             "y": "bw_avg",
             "file": "apm_dram_vs_pmem",

--- a/tools/perf/report.json.example
+++ b/tools/perf/report.json.example
@@ -53,7 +53,7 @@
         },
          "target" : {
             "description" :
-                "Description of applied configuration.",
+                "Description of applied configuration. With highlighting differences between Direct Write to PMem (DW2PMem) and non-Direct Write to PMem (non-DW2PMem) configurations.",
             "details": {
                 "Repository" : [
                     "https://github.com/domain/url"

--- a/tools/perf/templates/part_mix.md
+++ b/tools/perf/templates/part_mix.md
@@ -8,7 +8,7 @@
 
 <h2 id="mix" class="page-break">Mix against PMem</h2>
 
-Benchmarking mixed reads from PMem (`rpma_read()`) on the **RPMA Target** and writes (**APM**) to the same PMem on **the RPMA Target** side in the configured ratio (**MIX**) and comparing it to pure `rpma_read()` (100% reads) and **APM** (100% writes).
+Benchmarking mixed reads from PMem (`rpma_read()`) on the **RPMA Target** and writes (**APM**) to the same PMem on **the RPMA Target** side in the configured ratio (**MIX**) and comparing it to pure `rpma_read()` (100% reads) and **APM** (100% writes). **The RPMA Target** is configured to be capable of *Direct Write to PMem* (**DW2PMem**)
 
 <h3 id="mix-lat">Mix against PMem: Latency</h3>
 

--- a/tools/perf/templates/part_write.md
+++ b/tools/perf/templates/part_write.md
@@ -10,18 +10,18 @@
 
 Benchmarking two ways of writing data persistently to **the RPMA Target**: *Appliance Persistency Method* (**APM**) and *General Purpose Persistency Method* (**GPSPM**). Where:
 
-- **APM** uses `rpma_flush()` following a sequence of `rpma_write()` operations to provide the remote persistency. This method requires **the RPMA Target** to be capable of *Direct Write to PMem* (for details please see [Direct Write to PMem​​](https://pmem.io/rpma/documentation/basic-direct-write-to-pmem.html)).
-- **GPSPM** uses `rpma_send()` and `rpma_recv()` operations for sending requests to **the RPMA Target** to assure persistency of the data written using `rpma_write()`. **The RPMA Target** has to provide a thread handling these requests e.g. persisting the data using the `pmem_persist()` operation. When the persistency of the data is assured the response is sent back using also `rpma_send()` and `rpma_recv()`. Depending on how the thread polls for incoming requests you may distinguish two modes:
+- **APM** uses `rpma_flush()` following a sequence of `rpma_write()` operations to provide the remote persistency. This method requires **the RPMA Target** to be capable of *Direct Write to PMem* (**DW2PMem**; for details please see [Direct Write to PMem​​](https://pmem.io/rpma/documentation/basic-direct-write-to-pmem.html)).
+- **GPSPM** uses `rpma_send()` and `rpma_recv()` operations for sending requests to **the RPMA Target** to assure persistency of the data written using `rpma_write()`. This method does not require **the RPMA Target** to be capable of *Direct Write to PMem* (**non-DW2PMem**). **The RPMA Target** has to provide a thread handling these requests e.g. persisting the data using the `pmem_persist()` operation. When the persistency of the data is assured the response is sent back using also `rpma_send()` and `rpma_recv()`. Depending on how the thread polls for incoming requests you may distinguish two modes:
     - **GPSPM-RT** where the thread polling for incoming requests busy-wait for them (`busy_wait_polling=1`) and
     - **GPSPM** where the thread schedule to be wakened up when a request will appear (`busy_wait_polling=0`). Picking one of these polling modes over another introduces specific challenges and benefits.
 
 For more details on **APM** and **GPSPM** please see: "[Persistent Memory Replication Over Traditional RDMA Part 1: Understanding Remote Persistent Memory](https://software.intel.com/content/www/us/en/develop/articles/persistent-memory-replication-over-traditional-rdma-part-1-understanding-remote-persistent.html)" Chapter "Two Remote Replication Methods".
 
-As a baseline is used **APM** to DRAM on **the RPMA Target** with *Direct Write to PMem* capability **disabled**. Such a configuration allows benefiting from available caching on **the RPMA Target**. Note that data, in this case, is not written persistently on **the RPMA Target** but this configuration is used to show the limit of what is possible regarding data transmission in general and how big is potential overhead when transmitting data using **APM** or **GPSPM** while both of these provide the remote persistency additionally.
+As a baseline is used **APM** to DRAM on **the RPMA Target** with *Direct Write to PMem* capability **disabled** (**non-DW2PMem**). Such a configuration allows benefiting from available caching on **the RPMA Target**. Note that data, in this case, is not written to achieve persistency but to show the limit of what is possible regarding data transmission in general and how big is potential overhead when transmitting data using **APM** or **GPSPM** while both of these provide the remote persistency additionally.
 
 <h3 id="write-lat">Write to PMem: Latency</h3>
 
-Comparing the latency of **APM** to PMem on **the RPMA Target** (with *Direct Write to PMem*) vs the latency of **APM** to DRAM on **the RPMA Target** (with *Direct Write to PMem* disabled) (as a baseline) vs the latency of **GPSPM(-RT)** to PMem on **the RPMA Target** (with *Direct Write to PMem* disabled).
+Comparing the latency of **APM** to PMem on **the RPMA Target** (**DW2PMem**) vs the latency of **APM** to DRAM on **the RPMA Target** (**non-DW2PMem**) (as a baseline) vs the latency of **GPSPM(-RT)** to PMem on **the RPMA Target** (**non-DW2PMem**).
 
 {{config.lat}}
 
@@ -39,7 +39,7 @@ Comparing the latency of **APM** to PMem on **the RPMA Target** (with *Direct Wr
 
 <h3 id="write-bw" class="page-break">Write to PMem: Bandwidth</h3>
 
-Comparing the bandwidth of **APM** to PMem on **the RPMA Target** (with *Direct Write to PMem*) vs the bandwidth of **APM** to DRAM on **the RPMA Target** (with *Direct Write to PMem* disabled) (as a baseline) vs the bandwidth of **GPSPM(-RT)** to PMem on **the RPMA Target** (with *Direct Write to PMem* disabled).
+Comparing the bandwidth of **APM** to PMem on **the RPMA Target** (**DW2PMem**) vs the bandwidth of **APM** to DRAM on **the RPMA Target** (**non-DW2PMem**) (as a baseline) vs the bandwidth of **GPSPM(-RT)** to PMem on **the RPMA Target** (**non-DW2PMem**).
 
 {{config.bw}}
 


### PR DESCRIPTION
- encourage defining DW2PMem (the default) vs non-DW2PMem configuration in report.json
- highlight where the non-default (non-DW2PMem) configuration is used
    - which replaces the not-futureproof DDIO=ON

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/pmem/rpma/1279)
<!-- Reviewable:end -->
