### PR TITLE
common: add description to all GHA workflow files

### DIFF
--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -1,5 +1,10 @@
+#
+# Builds run over the night testing all OSes supported by librpma.
+# (each of them is built with two compilers, gcc and clang, separately).
+#
+# It is run at 00:00 UTC every day or on demand.
+#
 
-# This build is run at 00:00 UTC every day
 name: Nightly
 
 on:
@@ -46,8 +51,7 @@ jobs:
                  "N=CentOS7      OS=centos  OS_VER=7",
                  "N=Debian11     OS=debian  OS_VER=11",
                  "N=Debian10     OS=debian  OS_VER=10",
-                 # Debian9 was moved to per-PR builds
-                 # because it has older Python v3.5.3
+                 "N=Debian9      OS=debian  OS_VER=9",
                  "N=DebianS      OS=debian  OS_VER=stable",
                  # successors of CentOS:
                  "N=RockyLinux8.4  OS=rockylinux OS_VER=8.4",

--- a/.github/workflows/nightly_experimental.yml
+++ b/.github/workflows/nightly_experimental.yml
@@ -1,5 +1,9 @@
+#
+# Builds using very experimental OS distributions that can fail very often.
+#
+# It is run at 00:00 UTC every day or on demand.
+#
 
-# This build is run at 00:00 UTC every day
 name: Nightly_Experimental
 
 on:

--- a/.github/workflows/nightly_rebuild.yml
+++ b/.github/workflows/nightly_rebuild.yml
@@ -1,5 +1,11 @@
+#
+# Builds containing rolling/testing/experimental OS distributions
+# which are updated very frequently and because of that
+# their docker images should be rebuilt every time.
+#
+# It is run at 00:00 UTC every day or on demand.
+#
 
-# This build is run at 00:00 UTC every day
 name: Nightly_Rebuild
 
 on:

--- a/.github/workflows/on_pull_request.yml
+++ b/.github/workflows/on_pull_request.yml
@@ -1,5 +1,8 @@
+#
+# Builds run on every pull request and every push to the repo.
+#
 
-name: RPMA
+name: On_Pull_Request
 on: [push, pull_request]
 
 env:


### PR DESCRIPTION
1. Add a description to all GHA workflow files.
2. Re-add Debian9 to Nightly builds
   (reverted from the commit 45484c8),
   so that it contains all OSes supported by librpma now.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/pmem/rpma/1283)
<!-- Reviewable:end -->
