### PR TITLE
common: disable consider-using-f-string in pylint

### DIFF
--- a/utils/pylint.rc
+++ b/utils/pylint.rc
@@ -7,7 +7,8 @@
 # too-many-arguments - (X>5) XXX requires consideration
 # too-many-instance-attributes - (X>7) XXX requires consideration
 # no-self-use - XXX requires consideration
-disable=fixme,too-few-public-methods,too-many-arguments,too-many-instance-attributes,no-self-use
+# consider-using-f-string - f-string is not supported on Debian 9 with python v3.5.3 and pylint3 v1.6.5
+disable=fixme,too-few-public-methods,too-many-arguments,too-many-instance-attributes,no-self-use,consider-using-f-string
 
 
 [FORMAT]


### PR DESCRIPTION
Disable the pylint 'consider-using-f-string' warning, see:
https://github.com/pmem/rpma/runs/3627503704

We cannot use f-strings, because they are not supported
on Debian 9 with python v3.5.3 and pylint3 v1.6.5.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/pmem/rpma/1287)
<!-- Reviewable:end -->
