### PR TITLE
common: move OpenSUSE_Tumbleweed build to Nightly_Experimental

### DIFF
--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -62,8 +62,10 @@ jobs:
                  "N=Debian_Testing       OS=debian               OS_VER=testing",
                  "N=Debian_Experimental  OS=debian               OS_VER=experimental",
                  "N=Arch_Linux_Latest    OS=archlinux            OS_VER=latest",
-                 "N=OpenSUSE_Leap        OS=opensuse-leap        OS_VER=latest",
-                 "N=OpenSUSE_Tumbleweed  OS=opensuse-tumbleweed  OS_VER=latest"]
+                 # the OpenSUSE_Tumbleweed build was temporarily moved to Nightly_Experimental
+                 # because of the following bug:
+                 # https://bugzilla.opensuse.org/show_bug.cgi?id=1190670
+                 "N=OpenSUSE_Leap        OS=opensuse-leap        OS_VER=latest"]
     steps:
        - name: Clone the git repo
          uses: actions/checkout@v1
@@ -112,8 +114,10 @@ jobs:
                  "N=Debian_Testing       OS=debian               OS_VER=testing",
                  "N=Debian_Experimental  OS=debian               OS_VER=experimental",
                  "N=Arch_Linux_Latest    OS=archlinux            OS_VER=latest",
-                 "N=OpenSUSE_Leap        OS=opensuse-leap        OS_VER=latest",
-                 "N=OpenSUSE_Tumbleweed  OS=opensuse-tumbleweed  OS_VER=latest"]
+                 # the OpenSUSE_Tumbleweed build was temporarily moved to Nightly_Experimental
+                 # because of the following bug:
+                 # https://bugzilla.opensuse.org/show_bug.cgi?id=1190670
+                 "N=OpenSUSE_Leap        OS=opensuse-leap        OS_VER=latest"]
     steps:
        - name: Clone the git repo
          uses: actions/checkout@v1

--- a/.github/workflows/nightly_experimental.yml
+++ b/.github/workflows/nightly_experimental.yml
@@ -33,7 +33,10 @@ jobs:
       matrix:
         CONFIG: ["N=Fedora_Rawhide            OS=fedora  OS_VER=rawhide  CC=gcc    CI_SANITS=ON   PUSH_IMAGE=0",
                  "N=Fedora_Rawhide_SANITS     OS=fedora  OS_VER=rawhide  CC=clang  CI_SANITS=ON   PUSH_IMAGE=0",
-                 "N=Fedora_Rawhide_no_SANITS  OS=fedora  OS_VER=rawhide  CC=clang  CI_SANITS=OFF  PUSH_IMAGE=1  REBUILD_ALWAYS=YES"]
+                 "N=Fedora_Rawhide_no_SANITS  OS=fedora  OS_VER=rawhide  CC=clang  CI_SANITS=OFF  PUSH_IMAGE=1  REBUILD_ALWAYS=YES",
+                 # the OpenSUSE_Tumbleweed build was temporarily moved here, because of the following bug:
+                 # https://bugzilla.opensuse.org/show_bug.cgi?id=1190670
+                 "N=OpenSUSE_Tumbleweed OS=opensuse-tumbleweed OS_VER=latest CC=gcc CI_SANITS=ON  PUSH_IMAGE=1  REBUILD_ALWAYS=YES"]
     steps:
        - name: Clone the git repo
          uses: actions/checkout@v1

--- a/.github/workflows/nightly_rebuild.yml
+++ b/.github/workflows/nightly_rebuild.yml
@@ -43,8 +43,10 @@ jobs:
                  "N=Debian_Experimental  OS=debian               OS_VER=experimental   REBUILD_ALWAYS=YES",
                  "N=Arch_Linux_Latest    OS=archlinux            OS_VER=latest         REBUILD_ALWAYS=YES",
                  "N=CentOS_Stream        OS=centos               OS_VER=stream         REBUILD_ALWAYS=YES",
-                 "N=OpenSUSE_Leap        OS=opensuse-leap        OS_VER=latest         REBUILD_ALWAYS=YES",
-                 "N=OpenSUSE_Tumbleweed  OS=opensuse-tumbleweed  OS_VER=latest         REBUILD_ALWAYS=YES"]
+                 # the OpenSUSE_Tumbleweed build was temporarily moved to Nightly_Experimental
+                 # because of the following bug:
+                 # https://bugzilla.opensuse.org/show_bug.cgi?id=1190670
+                 "N=OpenSUSE_Leap        OS=opensuse-leap        OS_VER=latest         REBUILD_ALWAYS=YES"]
     steps:
        - name: Clone the git repo
          uses: actions/checkout@v1


### PR DESCRIPTION
Move the OpenSUSE_Tumbleweed build to Nightly_Experimental,
because of the following bug:
https://bugzilla.opensuse.org/show_bug.cgi?id=1190670

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/pmem/rpma/1301)
<!-- Reviewable:end -->
