### PR TITLE
common: retry installing cmocka after updating certificates

### DIFF
--- a/utils/docker/images/install-cmocka.sh
+++ b/utils/docker/images/install-cmocka.sh
@@ -8,14 +8,26 @@
 # install-cmocka.sh - installs cmocka.org
 #
 
-set -e
+# cmocka-1.1.5-26-g672c5ce - pull latest fixes
+CMOCKA_VERSION=672c5cee79eb412025c3dd8b034e611c1f119055
 
 git clone https://git.cryptomilk.org/projects/cmocka.git
+if [ $? -ne 0 ]; then
+	# in case of a failure retry after updating certificates
+	set -e
+	openssl s_client -showcerts -servername git.cryptomilk.org -connect git.cryptomilk.org:443 </dev/null 2>/dev/null \
+		| sed -n -e '/BEGIN\ CERTIFICATE/,/END\ CERTIFICATE/ p'  > git-cryptomilk.org.pem
+	cat git-cryptomilk.org.pem | sudo tee -a /etc/ssl/certs/ca-certificates.crt
+	rm git-cryptomilk.org.pem
+	git clone https://git.cryptomilk.org/projects/cmocka.git
+fi
+
+set -e
+
 mkdir cmocka/build
 cd cmocka/build
 
-# cmocka-1.1.5-26-g672c5ce - pull latest fixes
-git checkout 672c5cee79eb412025c3dd8b034e611c1f119055
+git checkout $CMOCKA_VERSION
 
 cmake .. -DCMAKE_INSTALL_PREFIX=/usr -DCMAKE_BUILD_TYPE=RelWithDebInfo
 make -j$(nproc)


### PR DESCRIPTION
It fixes the following error:
```
Cloning into 'cmocka'...
fatal: unable to access 'https://git.cryptomilk.org/projects/cmocka.git/': server certificate verification failed. CAfile: none CRLfile: none
Exited with code exit status 128
```

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/pmem/rpma/1302)
<!-- Reviewable:end -->
