### PR TITLE
tools: fix: do not use len(SEQUENCE) to determine if a sequence is empty

### DIFF
--- a/tools/perf/lib/figure.py
+++ b/tools/perf/lib/figure.py
@@ -172,7 +172,7 @@ class Figure:
             if isinstance(rows, dict):
                 rw_dir = series['rw_dir']
                 rows = rows[rw_dir]
-            if len(rows) == 0:
+            if not rows:
                 continue
             # it is assumed each row has the same names of columns
             keys = rows[0].keys()


### PR DESCRIPTION
Fix the pylint error:
```
Do not use `len(SEQUENCE)` to determine if a sequence is empty (len-as-condition)
```

Ref: #1303