### PR TITLE
common: add libpmem2 to docker images

### DIFF
--- a/utils/docker/images/Dockerfile.debian-11
+++ b/utils/docker/images/Dockerfile.debian-11
@@ -32,7 +32,8 @@ ENV BASE_DEPS "\
 	whois"
 
 ENV EXAMPLES_DEPS "\
-	libpmem-dev"
+	libpmem-dev \
+	libpmem2-dev"
 
 ENV TOOLS_DEPS "\
 	python3-jinja2"

--- a/utils/docker/images/Dockerfile.debian-experimental
+++ b/utils/docker/images/Dockerfile.debian-experimental
@@ -28,6 +28,9 @@ ENV BASE_DEPS "\
 	sudo \
 	whois"
 
+ENV EXAMPLES_DEPS "\
+	libpmem2-dev"
+
 ENV TOOLS_DEPS "\
 	python3-jinja2"
 
@@ -56,6 +59,7 @@ ENV RPMA_DEPS "\
 # Install all required packages
 RUN apt-get install -y --no-install-recommends \
 	$BASE_DEPS \
+	$EXAMPLES_DEPS \
 	$TOOLS_DEPS \
 	$TESTS_DEPS \
 	$RPMA_DEPS \

--- a/utils/docker/images/Dockerfile.debian-stable
+++ b/utils/docker/images/Dockerfile.debian-stable
@@ -32,7 +32,8 @@ ENV BASE_DEPS "\
 	whois"
 
 ENV EXAMPLES_DEPS "\
-	libpmem-dev"
+	libpmem-dev \
+	libpmem2-dev"
 
 ENV TOOLS_DEPS "\
 	python3-jinja2"

--- a/utils/docker/images/Dockerfile.debian-testing
+++ b/utils/docker/images/Dockerfile.debian-testing
@@ -28,6 +28,9 @@ ENV BASE_DEPS "\
 	sudo \
 	whois"
 
+ENV EXAMPLES_DEPS "\
+	libpmem2-dev"
+
 ENV TOOLS_DEPS "\
 	python3-jinja2"
 
@@ -56,6 +59,7 @@ ENV RPMA_DEPS "\
 # Install all required packages
 RUN apt-get install -y --no-install-recommends \
 	$BASE_DEPS \
+	$EXAMPLES_DEPS \
 	$TOOLS_DEPS \
 	$TESTS_DEPS \
 	$RPMA_DEPS \

--- a/utils/docker/images/Dockerfile.fedora-34
+++ b/utils/docker/images/Dockerfile.fedora-34
@@ -28,6 +28,7 @@ ENV BASE_DEPS "\
 
 ENV EXAMPLES_DEPS "\
 	libpmem-devel \
+	libpmem2-devel \
 	protobuf-c-devel"
 
 ENV TOOLS_DEPS "\

--- a/utils/docker/images/Dockerfile.fedora-rawhide
+++ b/utils/docker/images/Dockerfile.fedora-rawhide
@@ -28,6 +28,7 @@ ENV BASE_DEPS "\
 
 ENV EXAMPLES_DEPS "\
 	libpmem-devel \
+	libpmem2-devel \
 	protobuf-c-devel"
 
 ENV TOOLS_DEPS "\

--- a/utils/docker/images/Dockerfile.opensuse-tumbleweed-latest
+++ b/utils/docker/images/Dockerfile.opensuse-tumbleweed-latest
@@ -28,6 +28,9 @@ ENV BASE_DEPS "\
 	sudo \
 	which"
 
+ENV EXAMPLES_DEPS "\
+	libpmem2-devel"
+
 ENV TOOLS_DEPS "\
 	python3-Jinja2"
 
@@ -56,6 +59,7 @@ ENV RPMA_DEPS "\
 # Install all required packages
 RUN zypper install -y \
 	$BASE_DEPS \
+	$EXAMPLES_DEPS \
 	$TOOLS_DEPS \
 	$TESTS_DEPS \
 	$RPMA_DEPS

--- a/utils/docker/images/Dockerfile.ubuntu-21.04
+++ b/utils/docker/images/Dockerfile.ubuntu-21.04
@@ -33,6 +33,7 @@ ENV BASE_DEPS "\
 
 ENV EXAMPLES_DEPS "\
 	libpmem-dev \
+	libpmem2-dev \
 	libprotobuf-c-dev"
 
 ENV TOOLS_DEPS "\

--- a/utils/docker/images/Dockerfile.ubuntu-rolling
+++ b/utils/docker/images/Dockerfile.ubuntu-rolling
@@ -30,6 +30,7 @@ ENV BASE_DEPS "\
 
 ENV EXAMPLES_DEPS "\
 	libpmem-dev \
+	libpmem2-dev \
 	libprotobuf-c-dev"
 
 ENV TOOLS_DEPS "\


### PR DESCRIPTION
use of libpmem2 instead of libpmem for mapping PMem allows decreasing number of resources needed to run examples

Ref: #991

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/pmem/rpma/1306)
<!-- Reviewable:end -->
