### PR TITLE
common: add encoding argument to all open() calls

### DIFF
--- a/tools/perf/csv2standardized.py
+++ b/tools/perf/csv2standardized.py
@@ -131,7 +131,7 @@ def main():
             output = {key: df.to_dict(orient='records')
                 for key, df in zip(args.keys, dfs)}
             # write the constructed dict() to the output_file
-            with open(args.output_file, 'w') as file:
+            with open(args.output_file, 'w', encoding='utf-8') as file:
                 json.dump(output, file)
     else:
         raise Exception(f"Unsupported output file extension: {ext}")

--- a/tools/perf/fio_json2csv.py
+++ b/tools/perf/fio_json2csv.py
@@ -27,8 +27,8 @@ def main():
         default='output.csv', help='an output file')
     args = parser.parse_args()
 
-    with open(args.json_file) as json_file, \
-            open(args.output_file, 'w') as csv_file:
+    with open(args.json_file, 'r', encoding='utf-8') as json_file, \
+            open(args.output_file, 'w', encoding='utf-8') as csv_file:
         # read JSON file
         data = json.load(json_file)
         job = data['jobs'][0]

--- a/tools/perf/lib/Report.py
+++ b/tools/perf/lib/Report.py
@@ -142,5 +142,5 @@ class Report:
         html = layout_tmpl.render(variables)
         # write the output file
         output_file = os.path.join(self.result_dir, output + '.html')
-        with open(output_file, 'w') as f:
+        with open(output_file, 'w', encoding='utf-8') as f:
             f.write(html)

--- a/tools/perf/lib/bench.py
+++ b/tools/perf/lib/bench.py
@@ -62,7 +62,7 @@ class Bench:
         }
 
         output_path = os.path.join(self.result_dir, 'bench.json')
-        with open(output_path, 'w', encoding="utf-8") as file:
+        with open(output_path, 'w', encoding='utf-8') as file:
             json.dump(output, file, indent=4)
 
     def get_config(self):

--- a/tools/perf/lib/common.py
+++ b/tools/perf/lib/common.py
@@ -27,7 +27,7 @@ def json_from_file(string):
     if not os.path.isfile(string):
         raise FileNotFoundError(string)
     # read the file
-    with open(string, "r") as read_file:
+    with open(string, 'r', encoding='utf-8') as read_file:
         data = json.load(read_file)
     # return the content of the file
     return {'input_file': string, 'json': data}

--- a/tools/perf/lib/figure.py
+++ b/tools/perf/lib/figure.py
@@ -204,7 +204,7 @@ class Figure:
         else:
             figures = {}
         figures[self.key] = output
-        with open(series_path, 'w', encoding="utf-8") as file:
+        with open(series_path, 'w', encoding='utf-8') as file:
             json.dump(figures, file, indent=4)
         # mark as done
         self.output['done'] = True


### PR DESCRIPTION
Add the 'encoding' argument to all open() calls to avoid the error:
```
W1514: Using open without explicitly specifying an encoding (unspecified-encoding)
```
<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/pmem/rpma/1323)
<!-- Reviewable:end -->
