### PR TITLE
examples: fix memory leak in the 09 example

### DIFF
--- a/examples/09-flush-to-persistent-GPSPM/server.c
+++ b/examples/09-flush-to-persistent-GPSPM/server.c
@@ -215,7 +215,7 @@ main(int argc, char *argv[])
 
 	/* receive an incoming connection request */
 	if ((ret = rpma_ep_next_conn_req(ep, cfg, &req)))
-		goto err_mr_dereg;
+		goto err_req_delete;
 
 	/* prepare buffer for a flush request */
 	if ((ret = rpma_conn_req_recv(req, msg_mr, RECV_OFFSET, MSG_SIZE_MAX,


### PR DESCRIPTION
cfg can leak here - fix it.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/pmem/rpma/1325)
<!-- Reviewable:end -->
