### PR TITLE
tools: perf: do not assume presence of optional vars

### DIFF
--- a/tools/perf/lib/Requirement.py
+++ b/tools/perf/lib/Requirement.py
@@ -86,8 +86,8 @@ class Requirement:
     def is_met_Cascade_Lake(req, config):
         # For the CLX generation, it is possible to configure Direct Write
         # to PMem from the OS level.
-        if config['REMOTE_SUDO_NOPASSWD'] and \
-                len(config['REMOTE_RNIC_PCIE_ROOT_PORT']):
+        if config.get('REMOTE_SUDO_NOPASSWD', False) and \
+                len(config.get('REMOTE_RNIC_PCIE_ROOT_PORT', '')):
             # If there are available: passwordless sudo access and
             # the PCIe Root Port of the RNIC on the remote side
             # the configuration can be adjusted automatically.


### PR DESCRIPTION
- REMOTE_SUDO_NOPASSWD
- REMOTE_RNIC_PCIE_ROOT_PORT

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/pmem/rpma/1327)
<!-- Reviewable:end -->
