### PR TITLE
tools: add default value of THE_NEW_DDIO_IMPL (fix)

### DIFF
--- a/tools/perf/lib/Requirement.py
+++ b/tools/perf/lib/Requirement.py
@@ -144,7 +144,7 @@ class Requirement:
                 # XXX for the non-Bash runners, it is the only viable implementation
                 # so a dedicated variable won't be needed when the Bash runner will
                 # be decommissioned.
-                if config['THE_NEW_DDIO_IMPL']:
+                if config.get('THE_NEW_DDIO_IMPL', True):
                     cls.__set_DDIO(req, config)
                 return True
             else:


### PR DESCRIPTION
Add default value of THE_NEW_DDIO_IMPL
to prevent the following error:
```
File "rpma/tools/perf/lib/Requirement.py", line 147, in is_met
    if config['THE_NEW_DDIO_IMPL']:
KeyError: 'THE_NEW_DDIO_IMPL'
```

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/pmem/rpma/1337)
<!-- Reviewable:end -->
