### PR TITLE
tools: verify if key is in the figure (fix)

### DIFF
--- a/tools/perf/lib/benchmark/runner/ib_read.py
+++ b/tools/perf/lib/benchmark/runner/ib_read.py
@@ -21,6 +21,10 @@ class IbReadRunner:
     def __validate(self):
         """validate the object and readiness of the env"""
         for key, value in self.ONESERIES_REQUIRED.items():
+            if key not in self.__benchmark.oneseries:
+                raise ValueError(
+                    "the following key is missing in the figure: {}"
+                    .format(key))
             if self.__benchmark.oneseries[key] != value:
                 present_value = self.__benchmark.oneseries[key]
                 raise ValueError(".{} == {} != {}".format(key, present_value,


### PR DESCRIPTION
It fixes the following error:
```
"rpma/tools/perf/lib/benchmark/runner/ib_read.py", line 25, in __validate
    if self.__benchmark.oneseries[key] != value:
KeyError: 'rw'
```

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/pmem/rpma/1342)
<!-- Reviewable:end -->
