### PR TITLE
tools: fix name of the f argument in figure.py

### DIFF
--- a/tools/perf/lib/figure.py
+++ b/tools/perf/lib/figure.py
@@ -30,8 +30,8 @@ class Figure:
     def _series_file(self, result_dir):
         return os.path.join(result_dir, self.file + '.json')
 
-    def __init__(self, f, result_dir=""):
-        self.output = f['output']
+    def __init__(self, figure, result_dir=""):
+        self.output = figure['output']
         self.output['done'] = self.output.get('done', False)
         # copies for convenience
         self.title = self.output['title']
@@ -42,7 +42,7 @@ class Figure:
         self.key = self.output['key']
         self.xscale = self.output.get('xscale', 'log')
         self.result_dir = result_dir
-        self.series_in = f['series']
+        self.series_in = figure['series']
         if self.output['done']:
             data = json_from_file(self._series_file(result_dir))
             self.series = data['json'][self.key]['series']


### PR DESCRIPTION
Fix the following error:
```
rpma/tools/perf/lib/figure.py:33:23: \
   C0103: Argument name "f" doesn't conform to snake_case naming style (invalid-name)
```

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/pmem/rpma/1353)
<!-- Reviewable:end -->
