### PR TITLE
tools: iterate the dictionary directly instead of calling .keys() (fix)

### DIFF
--- a/tools/perf/lib/report/base.py
+++ b/tools/perf/lib/report/base.py
@@ -130,7 +130,7 @@ class Report:
         figures = {}
         for figure in bench.figures:
             # add to 2-level figure dictionary
-            if figure.file not in figures.keys():
+            if figure.file not in figures:
                 figures[figure.file] = {}
             figures[figure.file][figure.key] = figure
         return figures


### PR DESCRIPTION
Fix following error:
```
tools/perf/lib/report/base.py:133:34: \
   C0201: Consider iterating the dictionary directly instead of calling .keys() (consider-iterating-dictionary)
```

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/pmem/rpma/1396)
<!-- Reviewable:end -->
