### PR TITLE
tools: fix capturing stdout and stderr in subprocess.run()

### DIFF
--- a/tools/perf/lib/benchmark/runner/ib_read.py
+++ b/tools/perf/lib/benchmark/runner/ib_read.py
@@ -134,8 +134,10 @@ class IbReadRunner:
         # XXX add option to dump the command (DUMP_CMDS)
         # XXX optionally measure the run time and assert exe_time >= 60s
         try:
-            ret = subprocess.run(args, capture_output = True,
-                                 text = True, check = True)
+            ret = subprocess.run(args, check = True,
+                                 stdout = subprocess.PIPE,
+                                 stderr = subprocess.PIPE,
+                                 encoding='utf-8')
         except subprocess.CalledProcessError as err:
             print('\nstdout:\n{}\nstderr:\n{}\n'
                   .format(err.stdout, err.stderr))


### PR DESCRIPTION
`capture_output` and `text` were introduced in pyton-3.7.
There is an error in case of python-3.6:
```
  File "/usr/lib64/python3.6/subprocess.py", line 423, in run
    with Popen(*popenargs, **kwargs) as process:
  TypeError: __init__() got an unexpected keyword argument 'capture_output'
```
and:
```
  File "/usr/lib64/python3.6/subprocess.py", line 423, in run
    with Popen(*popenargs, **kwargs) as process:
  TypeError: __init__() got an unexpected keyword argument 'text'
```

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/pmem/rpma/1404)
<!-- Reviewable:end -->
