### PR TITLE
tools: fix reading AUX_PARAMS and REMOTE_AUX_PARAMS

### DIFF
--- a/tools/perf/lib/benchmark/runner/ib_read.py
+++ b/tools/perf/lib/benchmark/runner/ib_read.py
@@ -108,7 +108,8 @@ class IbReadRunner:
               .format(settings['bs'], settings['threads'],
                       settings['iodepth'], settings['iterations']))
         r_numa_n = str(self.__config['REMOTE_JOB_NUMA'])
-        r_aux_params = [*self.__config['REMOTE_AUX_PARAMS'], *settings['args']]
+        r_aux_params = [*self.__config['REMOTE_AUX_PARAMS'].split(' '),
+                        *settings['args']]
 
         args = ['numactl', '-N', r_numa_n, self.__r_ib_path, *r_aux_params]
         # XXX add option to dump the command (DUMP_CMDS)
@@ -126,7 +127,8 @@ class IbReadRunner:
         """run the client (locally) and wait till the end of execution"""
         numa_n = str(self.__config['JOB_NUMA'])
         it_opt = '--iters=' + str(settings['iterations'])
-        aux_params = [*self.__config['AUX_PARAMS'], *settings['args']]
+        aux_params = [*self.__config['AUX_PARAMS'].split(' '),
+                      *settings['args']]
         server_ip = self.__config['server_ip']
         args = ['numactl', '-N', numa_n, self.__ib_path, *aux_params,
                 it_opt, server_ip]


### PR DESCRIPTION
`AUX_PARAMS` and `REMOTE_AUX_PARAMS` are strings
and can contain many arguments, so they have to be splitted
by the space ' ' to lists.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/pmem/rpma/1405)
<!-- Reviewable:end -->
