### PR TITLE
tools: fix reading AUX_PARAMS and REMOTE_AUX_PARAMS

### DIFF
--- a/tools/perf/lib/benchmark/runner/ib_read.py
+++ b/tools/perf/lib/benchmark/runner/ib_read.py
@@ -109,8 +109,10 @@ class IbReadRunner:
               .format(settings['bs'], settings['threads'],
                       settings['iodepth'], settings['iterations']))
         r_numa_n = str(self.__config['REMOTE_JOB_NUMA'])
-        r_aux_params = [*self.__config['REMOTE_AUX_PARAMS'].split(' '),
-                        *settings['args']]
+        r_aux_params = [*settings['args']]
+        cfg_r_aux_params = self.__config['REMOTE_AUX_PARAMS'].split(' ')
+        if cfg_r_aux_params != ['']:
+            r_aux_params = r_aux_params + cfg_r_aux_params
 
         args = ['numactl', '-N', r_numa_n, self.__r_ib_path, *r_aux_params]
         # XXX add option to dump the command (DUMP_CMDS)
@@ -140,8 +142,10 @@ class IbReadRunner:
         """run the client (locally) and wait till the end of execution"""
         numa_n = str(self.__config['JOB_NUMA'])
         it_opt = '--iters=' + str(settings['iterations'])
-        aux_params = [*self.__config['AUX_PARAMS'].split(' '),
-                      *settings['args']]
+        aux_params = [*settings['args']]
+        cfg_aux_params = self.__config['AUX_PARAMS'].split(' ')
+        if cfg_aux_params != ['']:
+            aux_params = aux_params + cfg_aux_params
         server_ip = self.__config['server_ip']
         args = ['numactl', '-N', numa_n, self.__ib_path, *aux_params,
                 it_opt, server_ip]


### PR DESCRIPTION
If AUX_PARAMS or REMOTE_AUX_PARAMS are empty (""),
the current code fails with the following error:
```
 Invalid Command line. Please check command rerun
 Parser function exited with Error

subprocess.CalledProcessError: \
Command '['numactl', '-N', '0', 'ib_read_lat', '', '--size=256', '--perform_warm_up', '--iters=1000', '192.168.1.100']' \
returned non-zero exit status 1.
```
This patch fixes that issue.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/pmem/rpma/1408)
<!-- Reviewable:end -->
