### PR TITLE
test: enable the sysconf mock only in the main of unit tests

### DIFF
--- a/tests/unit/common/mocks-unistd.c
+++ b/tests/unit/common/mocks-unistd.c
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: BSD-3-Clause
-/* Copyright 2020, Intel Corporation */
+/* Copyright 2020-2021, Intel Corporation */
 
 /*
  * mocks-unistd.c -- unistd mocks
@@ -11,12 +11,37 @@
 #include "cmocka_headers.h"
 #include "mocks-unistd.h"
 
+static int unistd_mocks_enabled;
+
+long __real_sysconf(int name);
+
+/*
+ * enable_unistd_mocks -- enable unistd mocks
+ */
+void
+enable_unistd_mocks(void)
+{
+	unistd_mocks_enabled = 1;
+}
+
+/*
+ * disable_unistd_mocks -- disable unistd mocks
+ */
+void
+disable_unistd_mocks(void)
+{
+	unistd_mocks_enabled = 0;
+}
+
 /*
  * __wrap_sysconf -- sysconf() mock
  */
 long
 __wrap_sysconf(int name)
 {
+	if (unistd_mocks_enabled == 0)
+		return __real_sysconf(name);
+
 	assert_int_equal(name, _SC_PAGESIZE);
 	int err = mock_type(int);
 	if (err) {

--- a/tests/unit/common/mocks-unistd.h
+++ b/tests/unit/common/mocks-unistd.h
@@ -1,5 +1,5 @@
 /* SPDX-License-Identifier: BSD-3-Clause */
-/* Copyright 2020, Intel Corporation */
+/* Copyright 2020-2021, Intel Corporation */
 
 /*
  * mocks-unistd.h -- the unistd mocks' header
@@ -9,5 +9,10 @@
 #define MOCKS_UNISTD_H
 
 #define PAGESIZE 4096
+
+void enable_unistd_mocks(void);
+void disable_unistd_mocks(void);
+
+long __wrap_sysconf(int name);
 
 #endif /* MOCKS_UNISTD_H */

--- a/tests/unit/flush/flush-apm_do.c
+++ b/tests/unit/flush/flush-apm_do.c
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: BSD-3-Clause
-/* Copyright 2020, Intel Corporation */
+/* Copyright 2020-2021, Intel Corporation */
 
 /*
  * flush-apm_do.c -- unit tests of the flush module
@@ -11,6 +11,7 @@
 #include "cmocka_headers.h"
 #include "flush.h"
 #include "mocks-ibverbs.h"
+#include "mocks-unistd.h"
 #include "test-common.h"
 #include "flush-common.h"
 
@@ -44,11 +45,17 @@ apm_do__success(void **fstate_ptr)
 int
 main(int argc, char *argv[])
 {
+	enable_unistd_mocks();
+
 	const struct CMUnitTest tests[] = {
 		/* rpma_flush_apm_do() unit tests */
 		cmocka_unit_test_setup_teardown(apm_do__success,
 			setup__flush_new, teardown__flush_delete),
 	};
 
-	return cmocka_run_group_tests(tests, NULL, NULL);
+	int ret = cmocka_run_group_tests(tests, NULL, NULL);
+
+	disable_unistd_mocks();
+
+	return ret;
 }

--- a/tests/unit/flush/flush-new.c
+++ b/tests/unit/flush/flush-new.c
@@ -14,6 +14,7 @@
 #include "flush.h"
 #include "flush-common.h"
 #include "mocks-stdlib.h"
+#include "mocks-unistd.h"
 #include "test-common.h"
 #include <sys/mman.h>
 
@@ -203,6 +204,8 @@ delete__apm_munmap_ERRNO(void **unused)
 int
 main(int argc, char *argv[])
 {
+	enable_unistd_mocks();
+
 	const struct CMUnitTest tests[] = {
 		/* rpma_flush_new() unit tests */
 		cmocka_unit_test(new__malloc_ERRNO),
@@ -218,5 +221,9 @@ main(int argc, char *argv[])
 		cmocka_unit_test(delete__apm_munmap_ERRNO),
 	};
 
-	return cmocka_run_group_tests(tests, NULL, NULL);
+	int ret = cmocka_run_group_tests(tests, NULL, NULL);
+
+	disable_unistd_mocks();
+
+	return ret;
 }


### PR DESCRIPTION
The clang ASAN sanitizer calls sysconf() during
the initialization step before main() and it fails
all unit tests using the mock of this syscall.

This patch introduces possibility to enable chosen
(only sysconf in this patch) unistd mocks
only during the main() function of unit tests.

Fixes: #1397

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/pmem/rpma/1410)
<!-- Reviewable:end -->
