### PR TITLE
tools: fix result_is_done()

### DIFF
--- a/tools/perf/lib/benchmark/runner/common.py
+++ b/tools/perf/lib/benchmark/runner/common.py
@@ -34,7 +34,7 @@ def result_is_done(data: list, x_key: str, x_value: int) -> bool:
         if x_key not in result:
             raise ValueError('key \'{}\' is missing the previous results'
                              .format(x_key))
-        if result[x_key] == x_value:
+        if str(result[x_key]) == str(x_value):
             return True
     return False
 


### PR DESCRIPTION
`result[x_key]` and `x_value` can have the same value,
but they can be of different types, so casting them to `str`
will solve the problem.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/pmem/rpma/1414)
<!-- Reviewable:end -->
