### PR TITLE
tools: fio.py: fix setting busy_wait_polling

### DIFF
--- a/tools/perf/lib/benchmark/runner/fio.py
+++ b/tools/perf/lib/benchmark/runner/fio.py
@@ -129,7 +129,7 @@ class FioRunner:
         # XXX nice to have REMOTE_TRACER
         args = ['numactl', '-N', r_numa_n, self.__r_fio_path]
         busy_wait_polling = \
-            self.__benchmark.oneseries.get('busy_wait_polling', True)
+            int(self.__benchmark.oneseries.get('busy_wait_polling', True))
         env = ['serverip={}'.format(self.__config['server_ip']),
                'numjobs={}'.format(settings['threads']),
                'iodepth={}'.format(settings['iodepth']),


### PR DESCRIPTION
`busy_wait_polling` has to have a numeric value 0 or 1.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/pmem/rpma/1422)
<!-- Reviewable:end -->
