### PR TITLE
tools: stop the server when the client failed

### DIFF
--- a/tools/perf/lib/benchmark/runner/fio.py
+++ b/tools/perf/lib/benchmark/runner/fio.py
@@ -229,6 +229,7 @@ class FioRunner:
         except subprocess.CalledProcessError as err:
             print('\nstdout:\n{}\nstderr:\n{}\n'
                   .format(err.stdout, err.stderr))
+            self.__server_stop(settings)
             raise # re-raise the current exception
 
         result = FioFormat.parse(ret.stdout)

--- a/tools/perf/lib/benchmark/runner/ib_read.py
+++ b/tools/perf/lib/benchmark/runner/ib_read.py
@@ -166,6 +166,7 @@ class IbReadRunner:
                 if not self.__probably_no_server(err) or counter == 10:
                     print('\nstdout:\n{}\nstderr:\n{}\n'
                           .format(err.stdout, err.stderr))
+                    self.__server_stop(settings)
                     raise # re-raise the current exception
                 print('Retrying #{} ...'.format(counter))
                 time.sleep(0.1) # wait 0.1 sec for server to start listening


### PR DESCRIPTION
We have to stop the server when the client failed in order to:
1) have server logs (otherwise there are no server logs)
2) clean the server's environment

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/pmem/rpma/1423)
<!-- Reviewable:end -->
