### PR TITLE
tools: do not use cpuio engine when cpuload==0 (fix)

### DIFF
--- a/tools/perf/lib/benchmark/runner/fio.py
+++ b/tools/perf/lib/benchmark/runner/fio.py
@@ -131,7 +131,7 @@ class FioRunner:
                'direct_write_to_pmem={}'.format(self.__direct_write_to_pmem),
                'busy_wait_polling={}'.format(busy_wait_polling),
                'cores_per_socket={}'.format(self.__config['CORES_PER_SOCKET'])]
-        if 'cpuload' in settings:
+        if 'cpuload' in settings and settings['cpuload'] > 0:
             env.append('cpuload={}'.format(settings['cpuload']))
         else:
             # no CPU load


### PR DESCRIPTION
Do not use the cpuio engine when cpuload==0,
because it requires cpuload > 0.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/pmem/rpma/1425)
<!-- Reviewable:end -->
