### PR TITLE
tools: fix message in __server_start()

### DIFF
--- a/tools/perf/lib/benchmark/runner/fio.py
+++ b/tools/perf/lib/benchmark/runner/fio.py
@@ -117,9 +117,18 @@ class FioRunner:
         """Start the server on the remote side (using RemoteCmd)
            and keep an object allowing to control the server.
         """
-        print('[mode: {},  size: {}, threads: {}, tx_depth: {}, sync: {} ] '\
-              .format(self.__tool_mode, settings['bs'], settings['threads'],
-                      settings['iodepth'], settings['sync']))
+        operation = self.__benchmark.oneseries['rw']
+        if 'rw_dir' in self.__benchmark.oneseries:
+            operation = operation + '-' + self.__benchmark.oneseries['rw_dir']
+        if 'cpuload' in settings:
+            cpuload = settings['cpuload']
+        else:
+            cpuload = 0
+        print('[mode: {}, op: {}, size: {}, threads: {}, tx_depth: {}, '\
+              'sync: {}, cpuload: {}]'\
+              .format(self.__tool_mode, operation, settings['bs'],
+                      settings['threads'], settings['iodepth'],
+                      settings['sync'], cpuload))
         r_numa_n = str(self.__config['REMOTE_JOB_NUMA'])
         # XXX nice to have REMOTE_TRACER
         args = ['numactl', '-N', r_numa_n, self.__r_fio_path]


### PR DESCRIPTION
'op' and 'cpuload' were missing in the message.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/pmem/rpma/1428)
<!-- Reviewable:end -->
