### PR TITLE
tools: ignore results folder

### DIFF
--- a/tools/perf/.gitignore
+++ b/tools/perf/.gitignore
@@ -7,3 +7,4 @@ report_*
 !report_bench.py
 !report_bench.sh
 !report_figures.py
+results


### PR DESCRIPTION
Benchmark documentation sugest to use results folder as place for
benchmarking temporary and output files.
Let's ignore it for any git operation.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/pmem/rpma/1432)
<!-- Reviewable:end -->
