### PR TITLE
tools: check required keys of oneseries

### DIFF
--- a/tools/perf/lib/benchmark/runner/common.py
+++ b/tools/perf/lib/benchmark/runner/common.py
@@ -22,6 +22,9 @@ UNKNOWN_MODE_MSG = "An unexpected 'mode' value: {}"
 NO_X_AXIS_MSG = \
     "SETTINGS_BY_MODE[{}] is missing a key defined as a list (x-axis)"
 
+#: an error message when a key is missing in the figure
+MISSING_KEY_MSG = "the following key is missing in the figure: {}"
+
 #: a common block sizes list
 BS_VALUES = [256, 1024, 4096, 8192, 16384, 32768, 65536, 131072, 262144]
 

--- a/tools/perf/lib/benchmark/runner/fio.py
+++ b/tools/perf/lib/benchmark/runner/fio.py
@@ -18,9 +18,9 @@ from shutil import which
 from lib.format import FioFormat
 from ...common import json_from_file
 from ...remote_cmd import RemoteCmd
-from .common import UNKNOWN_MODE_MSG, NO_X_AXIS_MSG, BS_VALUES, \
-                    result_append, result_is_done, print_start_message, \
-                    run_pre_command, run_post_command
+from .common import UNKNOWN_MODE_MSG, NO_X_AXIS_MSG, MISSING_KEY_MSG, \
+                    BS_VALUES, run_pre_command, run_post_command, \
+                    result_append, result_is_done, print_start_message
 
 UNKNOWN_RW_MSG = "An unexpected 'rw' value: {}"
 UNKNOWN_FILETYPE_MSG = "An unexpected 'filetype' value: {}"
@@ -78,6 +78,9 @@ class FioRunner:
         # set dumping commands
         if 'DUMP_CMDS' in self.__config and self.__config['DUMP_CMDS']:
             self.__dump_cmds = True
+        for key in self.__ONESERIES_REQUIRED:
+            if key not in self.__benchmark.oneseries:
+                raise ValueError(MISSING_KEY_MSG.format(key))
         # pick the result keys base on the benchmark's rw
         readwrite = benchmark.oneseries['rw']
         if 'read' in readwrite:
@@ -299,6 +302,8 @@ class FioRunner:
             self.__server_stop(settings)
             run_post_command(self.__config, self.__benchmark.oneseries, pre_cmd)
             self.__result_append(x_value, y_value)
+
+    __ONESERIES_REQUIRED = ['tool_mode', 'mode', 'rw']
 
     __CPU_LOAD_RANGE = {
         '00_99' : [0, 25, 50, 75, 99],

--- a/tools/perf/lib/benchmark/runner/ib_read.py
+++ b/tools/perf/lib/benchmark/runner/ib_read.py
@@ -18,9 +18,9 @@ from shutil import which
 import lib.format as fmt
 from ...common import json_from_file
 from ...remote_cmd import RemoteCmd
-from .common import UNKNOWN_MODE_MSG, NO_X_AXIS_MSG, BS_VALUES, \
-                    result_append, result_is_done, print_start_message, \
-                    run_pre_command, run_post_command
+from .common import UNKNOWN_MODE_MSG, NO_X_AXIS_MSG, MISSING_KEY_MSG, \
+                    BS_VALUES, run_pre_command, run_post_command, \
+                    result_append, result_is_done, print_start_message
 
 class IbReadRunner:
     """the ib_read_{lat,bw} tools runner
@@ -33,9 +33,7 @@ class IbReadRunner:
         """validate the object and readiness of the env"""
         for key, value in self.__ONESERIES_REQUIRED.items():
             if key not in self.__benchmark.oneseries:
-                raise ValueError(
-                    "the following key is missing in the figure: {}"
-                    .format(key))
+                raise ValueError(MISSING_KEY_MSG.format(key))
             if self.__benchmark.oneseries[key] != value:
                 present_value = self.__benchmark.oneseries[key]
                 raise ValueError(".{} == {} != {}".format(key, present_value,


### PR DESCRIPTION
Add checking required keys of oneseries in fio.py
and define the `MISSING_KEY_MSG` message.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/pmem/rpma/1446)
<!-- Reviewable:end -->
