### PR TITLE
tools: unit tests for runners initialization

### DIFF
--- a/tools/perf/tests/lib/benchmark/conftest.py
+++ b/tools/perf/tests/lib/benchmark/conftest.py
@@ -10,24 +10,45 @@ import pytest
 
 import lib.benchmark
 
-ONESERIES_DUMMY = {'tool': 'dummy', 'mode': 'dummy', 'filetype': 'malloc', 'id': 'di'}
-ONESERIES_BASH = {**ONESERIES_DUMMY, **{'tool': 'tool.sh'}}
-ONESERIES_BASE = {**ONESERIES_DUMMY, **{'tool': 'tool'}}
+__ONESERIES_DUMMY = \
+    {'tool': 'dummy', 'mode': 'dummy', 'filetype': 'malloc', 'id': 'di'}
+__ONESERIES_BASH = {**__ONESERIES_DUMMY, **{'tool': 'tool.sh'}}
+__ONESERIES_BASE = {**__ONESERIES_DUMMY, **{'tool': 'tool'}}
 
-@pytest.fixture(scope='function')
-def oneseries_dummy():
+__ONESERIES_FIO = \
+    {**__ONESERIES_DUMMY, **{'tool': 'fio', 'tool_mode': 'apm', 'mode': 'lat',
+    'rw': 'read', 'busy_wait_polling': False,
+    'requirements': {'direct_write_to_pmem': True}}}
+
+__ONESERIES_IB_READ = \
+    {**__ONESERIES_DUMMY, **{'tool': 'ib_read', 'tool_mode': 'lat',
+    'mode': 'lat', 'rw': 'read', 'filetype': 'malloc',
+    'requirements': {'direct_write_to_pmem': True}}}
+
+@pytest.fixture(scope='function', name='oneseries_dummy')
+def __oneseries_dummy():
     """provide a oneseries dummy"""
-    return ONESERIES_DUMMY.copy()
+    return __ONESERIES_DUMMY.copy()
 
-@pytest.fixture(scope='function')
-def oneseries_bash():
+@pytest.fixture(scope='function', name='oneseries_bash')
+def __oneseries_bash():
     """provide a oneseries bash"""
-    return ONESERIES_BASH.copy()
+    return __ONESERIES_BASH.copy()
 
-@pytest.fixture(scope='function')
-def oneseries_base():
+@pytest.fixture(scope='function', name='oneseries_base')
+def __oneseries_base():
     """provide a oneseries base"""
-    return ONESERIES_BASE.copy()
+    return __ONESERIES_BASE.copy()
+
+@pytest.fixture(scope='function', name='oneseries_fio')
+def __oneseries_fio():
+    """provide a fio oneseries"""
+    return __ONESERIES_FIO.copy()
+
+@pytest.fixture(scope='function', name='oneseries_ib_read')
+def __oneseries_ib_read():
+    """provide a fio oneseries"""
+    return __ONESERIES_IB_READ.copy()
 
 @pytest.fixture(scope='function')
 def benchmark_dummy(oneseries_dummy):

--- a/tools/perf/tests/lib/benchmark/runner/test_fio_runner_init.py
+++ b/tools/perf/tests/lib/benchmark/runner/test_fio_runner_init.py
@@ -1,0 +1,122 @@
+#!/usr/bin/env python3
+#
+# SPDX-License-Identifier: BSD-3-Clause
+# Copyright 2021-2022, Intel Corporation
+#
+
+"""test_fio_runner_init.py
+   -- lib.benchmark.runner.fio.FioRunner init tests"""
+
+import shutil
+from os.path import join
+import pytest
+
+import lib.benchmark
+import lib.benchmark.runner
+import lib.benchmark.runner.fio
+
+from lib.remote_cmd import RemoteCmd
+from lib.benchmark.runner.fio import FioRunner
+
+__CONFIG_FIO = {'server_ip': 'server_ip'}
+
+@pytest.fixture(scope='function', name='config_fio')
+def __config_fio():
+    """provide a fio oneseries_fio"""
+    return __CONFIG_FIO.copy()
+
+@pytest.mark.parametrize('fio_path', [None, '', '/tmp'])
+def test_fio_runner_init(oneseries_fio, config_fio, fio_path, monkeypatch):
+    """test proper initialization of FioRunner object
+       with all mandatory parameters
+    """
+    def run_sync_mock(_arg1, _arg2) -> RemoteCmd:
+        """mock of RemoteCmd.run_sync()"""
+        return RemoteCmd(None, None, None, exit_status=0)
+
+    def run_mock(_self) -> None:
+        """mock of IbReadRunner.run()"""
+
+    def which_mock(path: str) -> str:
+        """mock of shutil.which()"""
+        if fio_path is None or fio_path == '':
+            fio_path_full = 'fio'
+        else:
+            fio_path_full = join(config_fio['FIO_PATH'], 'fio')
+        assert path == fio_path_full
+        return path
+
+    monkeypatch.setattr(shutil, 'which', which_mock)
+    monkeypatch.setattr(RemoteCmd, 'run_sync', run_sync_mock)
+    monkeypatch.setattr(FioRunner, 'run', run_mock)
+
+    if fio_path is not None:
+        config_fio['FIO_PATH'] = fio_path
+    benchmark = lib.benchmark.Benchmark(oneseries_fio)
+    runner = FioRunner(benchmark, config_fio, 'idfile')
+    runner.run()
+
+    #pylint: disable=protected-access
+    #pylint: disable=no-member
+    assert runner._FioRunner__benchmark == benchmark
+    assert runner._FioRunner__config == config_fio
+    assert runner._FioRunner__idfile == 'idfile'
+    assert runner._FioRunner__tool == oneseries_fio['tool']
+    assert runner._FioRunner__tool_mode == oneseries_fio['tool_mode']
+    assert runner._FioRunner__mode == oneseries_fio['mode']
+    #pylint: enable=no-member
+    #pylint: enable=protected-access
+
+@pytest.mark.parametrize('key', ['tool', 'tool_mode', 'mode', 'rw', \
+                         'filetype', 'requirements'])
+def test_fio_runner_init_oneserises_incomplete(oneseries_fio, config_fio, key):
+    """failed initialization of FioRunner object - incomplete oneseries """
+    oneseries_fio.pop(key)
+    benchmark = lib.benchmark.Benchmark(oneseries_fio)
+    with pytest.raises(ValueError):
+        FioRunner(benchmark, config_fio, 'idfile')
+
+def test_fio_runner_init_no_direct_write_to_pmem(oneseries_fio, config_fio):
+    """failed initialization of FioRunner object
+       - no direct_write_to_pmem provided
+    """
+    oneseries_fio.pop('requirements')
+    oneseries_fio['requirements'] = {}
+    benchmark = lib.benchmark.Benchmark(oneseries_fio)
+    with pytest.raises(ValueError):
+        FioRunner(benchmark, config_fio, 'idfile')
+
+def test_fio_runner_init_no_config(oneseries_fio):
+    """failed initialization of FioRunner object - no config provided """
+    benchmark = lib.benchmark.Benchmark(oneseries_fio)
+    with pytest.raises(AttributeError):
+        FioRunner(benchmark, None, 'idfile')
+
+@pytest.mark.parametrize('key', ['server_ip'])
+def test_fio_runner_init_config_incomplete(oneseries_fio, config_fio, key,
+                                           monkeypatch):
+    """failed initialization of FioRunner object -
+       - incomplete config provided
+    """
+    def which_mock(path: str) -> str:
+        """mock of shutil.which()"""
+        assert path == 'fio'
+        return path
+    monkeypatch.setattr(shutil, 'which', which_mock)
+
+    config_fio.pop(key)
+    benchmark = lib.benchmark.Benchmark(oneseries_fio)
+    with pytest.raises(ValueError):
+        FioRunner(benchmark, config_fio, 'idfile')
+
+@pytest.mark.parametrize('key', ['tool_mode', 'mode', 'rw',
+                         'filetype'])
+def test_fio_runner_init_wrong_value(oneseries_fio, config_fio, key):
+    """failed initialization of IbReadRunner object -
+       - incorrect onseries values
+    """
+    oneseries_fio.pop(key)
+    oneseries_fio[key] = 'an incorrect value'
+    benchmark = lib.benchmark.Benchmark(oneseries_fio)
+    with pytest.raises(ValueError):
+        FioRunner(benchmark, config_fio, 'idfile')

--- a/tools/perf/tests/lib/benchmark/runner/test_ib_read_runner_init.py
+++ b/tools/perf/tests/lib/benchmark/runner/test_ib_read_runner_init.py
@@ -1,0 +1,106 @@
+#!/usr/bin/env python3
+#
+# SPDX-License-Identifier: BSD-3-Clause
+# Copyright 2021-2022, Intel Corporation
+#
+
+"""test_ib_read_runner_init.py
+   -- lib.benchmark.runner.ib_read.IbReadRunner init tests"""
+
+import shutil
+import pytest
+
+import lib.benchmark
+import lib.benchmark.runner
+import lib.benchmark.runner.ib_read
+
+from lib.remote_cmd import RemoteCmd
+from lib.benchmark.runner.ib_read import IbReadRunner
+
+__CONFIG_IB_READ = {'server_ip': 'server_ip'}
+
+@pytest.fixture(scope='function', name='config_ib_read')
+def __config_ib_read():
+    """provide a fio oneseries"""
+    return __CONFIG_IB_READ.copy()
+
+def which_mock(path: str) -> str:
+    """mock of shutil.which()"""
+    assert path == 'ib_read_lat'
+    return path
+
+def test_ib_read_runner_init(oneseries_ib_read, config_ib_read, monkeypatch):
+    """test proper initialization of IbReadRunner object
+       with all mandatory parameters
+    """
+    def run_sync_mock(_arg1, _arg2) -> RemoteCmd:
+        """mock of RemoteCmd.run_sync()"""
+        return RemoteCmd(None, None, None, exit_status=0)
+
+    def run_mock(_self) -> None:
+        """mock of IbReadRunner.run()"""
+
+    monkeypatch.setattr(shutil, 'which', which_mock)
+    monkeypatch.setattr(RemoteCmd, 'run_sync', run_sync_mock)
+    monkeypatch.setattr(IbReadRunner, 'run', run_mock)
+
+    benchmark = lib.benchmark.Benchmark(oneseries_ib_read)
+    runner = IbReadRunner(benchmark, config_ib_read, 'idfile')
+    runner.run()
+
+    #pylint: disable=protected-access
+    #pylint: disable=no-member
+    assert runner._IbReadRunner__benchmark == benchmark
+    assert runner._IbReadRunner__config == config_ib_read
+    assert runner._IbReadRunner__idfile == 'idfile'
+    assert runner._IbReadRunner__tool == oneseries_ib_read['tool']
+    assert runner._IbReadRunner__mode == oneseries_ib_read['mode']
+    #pylint: enable=no-member
+    #pylint: enable=protected-access
+
+# XXX 'requirements' and 'tool_mode' are not yet supported by IbReadRunner
+# to be added later
+#@pytest.mark.parametrize('key', ['tool', 'tool_mode', 'mode', 'rw',
+#                                 'filetype', 'requirements'])
+@pytest.mark.parametrize('key', ['tool', 'mode', 'rw', 'filetype'])
+def test_ib_read_runner_init_oneserises_incomplete(oneseries_ib_read,
+        config_ib_read, key):
+    """failed initialization of IbReadRunner object - incomplete oneseries"""
+    oneseries = {**oneseries_ib_read}
+    oneseries.pop(key)
+    benchmark = lib.benchmark.Benchmark(oneseries)
+    with pytest.raises(ValueError):
+        IbReadRunner(benchmark, config_ib_read, 'idfile')
+
+def test_ib_read_runner_init_no_config(oneseries_ib_read):
+    """failed initialization of IbReadRunner object - no config provided"""
+    oneseries = {**oneseries_ib_read}
+    benchmark = lib.benchmark.Benchmark(oneseries)
+    with pytest.raises(AttributeError):
+        IbReadRunner(benchmark, None, 'idfile')
+
+@pytest.mark.parametrize('key', ['server_ip'])
+def test_ib_read_runner_init_config_incomplete(oneseries_ib_read,
+        config_ib_read, key):
+    """failed initialization of IbReadRunner object -
+       - incomplete config provided
+    """
+    oneseries = {**oneseries_ib_read}
+    config = {**config_ib_read}
+    config.pop(key)
+    benchmark = lib.benchmark.Benchmark(oneseries)
+    with pytest.raises(ValueError):
+        IbReadRunner(benchmark, config, 'idfile')
+
+@pytest.mark.parametrize('key', ['mode', 'rw', 'filetype', 'tool'])
+def test_ib_read_runner_init_wrong_value(oneseries_ib_read,
+        config_ib_read, key):
+    """failed initialization of IbReadRunner object -
+       - invalid value provided
+    """
+    oneseries = {**oneseries_ib_read}
+    oneseries.pop(key)
+    oneseries[key] = 'an incorrect value'
+    benchmark = lib.benchmark.Benchmark(oneseries)
+    with pytest.raises(ValueError):
+        IbReadRunner(benchmark, config_ib_read, 'idfile')


### PR DESCRIPTION
introduce unit tests for fio and ib_read runner
several fixes related to unhandled inputs errors to run all tests smoothly
- [x] #1467 
- [x] #1461
- [x]  #1465 
- [x] #1468 
<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/pmem/rpma/1452)
<!-- Reviewable:end -->
