### PR TITLE
tools: ib_read_[lat|bw] defined in figure

### DIFF
--- a/tools/perf/figures/read.json
+++ b/tools/perf/figures/read.json
@@ -18,6 +18,7 @@
         "series": [
             {
                 "tool": "ib_read",
+                "tool_mode": "lat",
                 "label": "ib_read_lat",
                 "rw": "read"
             },
@@ -83,6 +84,7 @@
         "series": [
             {
                 "tool": "ib_read",
+                "tool_mode": "bw",
                 "label": "ib_read_bw",
                 "rw": "read"
             },
@@ -115,6 +117,7 @@
         "series": [
             {
                 "tool": "ib_read",
+                "tool_mode": "bw",
                 "label": "ib_read_bw",
                 "rw": "read"
             },

--- a/tools/perf/lib/benchmark/runner/ib_read.py
+++ b/tools/perf/lib/benchmark/runner/ib_read.py
@@ -65,11 +65,12 @@ class IbReadRunner:
         if not isinstance(self.__settings, dict):
             raise ValueError(UNKNOWN_VALUE_MSG.format('mode', self.__mode))
         # path to the local ib tool
-        self.__ib_path = join(self.__config.get('IB_PATH', ''),
-                              self.__settings['ib_tool'])
+        ib_name = self.__benchmark.oneseries['tool'] + '_' + \
+            self.__benchmark.oneseries['tool_mode']
+        self.__ib_path = join(self.__config.get('IB_PATH', ''), ib_name)
         # path to the remote ib tool
         self.__r_ib_path = join(self.__config.get('REMOTE_IB_PATH', ''),
-                                self.__settings['ib_tool'])
+                                ib_name)
         # find the x-axis key
         self.__x_key = None
         for x_key in self.__X_KEYS:
@@ -249,7 +250,8 @@ class IbReadRunner:
         'rw': 'read',
         'filetype': 'malloc',
         'tool': 'ib_read',
-        'mode': None
+        'mode': None,
+        'tool_mode': None
     }
 
     __X_KEYS = ['threads', 'bs', 'iodepth']


### PR DESCRIPTION
Use _tool_mode in figures to avoid hardcoded tool name settings in the code
 and to have a common definition of settings for fio and ib_read

- [x] #1461
- [x] #1452 
- [x] #1453
- [x] #1468 
- [x] #1467 

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/pmem/rpma/1455)
<!-- Reviewable:end -->
