### PR TITLE
tools: pylint accepts long name

### DIFF
--- a/utils/pylint.rc
+++ b/utils/pylint.rc
@@ -28,3 +28,6 @@ ignore-long-lines=(.*('''|""")[),]?$|^[a-zA-Z,. ]+$)
 
 # Maximum number of lines in a module.
 max-module-lines=500
+
+# Regular expression for the functions names (to extend a name size from 30 (default) to 60 (needed for unit tests)) 
+function-rgx=[a-z_][a-z0-9_]{2,60}$


### PR DESCRIPTION
Long names are required for unit test functions.
The default pylint limit is set to 30.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/pmem/rpma/1465)
<!-- Reviewable:end -->
