### PR TITLE
test: fix test_dict2kvtable.py

### DIFF
--- a/tests/tools/perf/kvtable/test_dict2kvtable.py
+++ b/tests/tools/perf/kvtable/test_dict2kvtable.py
@@ -14,10 +14,11 @@ STOP = '</tbody></table>'
 
 EMPTY = START + HEADER + STOP
 SIMPLE_RANGE = 10
+KVT = {str(k): str(k + 1) for k in range(SIMPLE_RANGE)}
 SIMPLE = START + HEADER \
     + "".join([
-        '<tr><td>{}</td><td><pre>{}</pre></td></tr>'.format(k, k + 1)
-            for k in range(SIMPLE_RANGE)]) \
+        '<tr><td>{}</td><td><pre>{}</pre></td></tr>'.format(k, KVT[k])
+            for k in KVT.keys()]) \
     + STOP
 
 EMPTY_KVTABLE = {"type": "kvtable"}
@@ -29,7 +30,6 @@ def test_empty_empty():
 
 def test_simple():
     """produce a simple table n -> (n + 1)"""
-    kvt = {str(k): str(k + 1) for k in range(SIMPLE_RANGE)}
-    kvt["type"] = "kvtable"
-    output = lib.report.utils.dict2kvtable(kvt, {})
+    KVT["type"] = "kvtable"
+    output = lib.report.utils.dict2kvtable(KVT, {})
     assert(output == SIMPLE)


### PR DESCRIPTION
On Debian 9 the keys in the dictionary:
```
kvt = {str(k): str(k + 1) for k in range(10)}
```
are not sorted in the ascending order (0, 1, ..., 10):
https://github.com/ldorau/rpma/runs/4667689633

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/pmem/rpma/1466)
<!-- Reviewable:end -->
