### PR TITLE
tools: disable bad-continuation pylint warning

### DIFF
--- a/utils/pylint.rc
+++ b/utils/pylint.rc
@@ -12,7 +12,8 @@
 # too-many-locals - (X>15) XXX requires consideration
 # len-as-condition - bug in Pylint, fixed as of Pylint 2.4 (https://github.com/PyCQA/pylint/pull/2815)
 # duplicate-code - XXX requires consideration
-disable=fixme,too-few-public-methods,too-many-arguments,too-many-instance-attributes,no-self-use,consider-using-f-string,unused-private-member,too-many-locals,len-as-condition,duplicate-code
+# bad-continuation - removed from pylint (https://github.com/PyCQA/pylint/pull/3571), but still enabled by default in old releases
+disable=fixme,too-few-public-methods,too-many-arguments,too-many-instance-attributes,no-self-use,consider-using-f-string,unused-private-member,too-many-locals,len-as-condition,duplicate-code,bad-continuation
 
 [FORMAT]
 


### PR DESCRIPTION
bad-continuation has been removed from pylint
https://github.com/PyCQA/pylint/pull/3571

It is still enabled in old releases producing a lot of
false warnings.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/pmem/rpma/1468)
<!-- Reviewable:end -->
