### PR TITLE
common: move CentOS_Stream CI build to Nightly_Experimental

### DIFF
--- a/.github/workflows/nightly_experimental.yml
+++ b/.github/workflows/nightly_experimental.yml
@@ -35,6 +35,7 @@ jobs:
                  "N=Fedora_Rawhide_SANITS     OS=fedora  OS_VER=rawhide  CC=clang  CI_SANITS=ON   PUSH_IMAGE=0",
                  "N=Fedora_Rawhide_no_SANITS  OS=fedora  OS_VER=rawhide  CC=clang  CI_SANITS=OFF  PUSH_IMAGE=1  REBUILD_ALWAYS=YES",
                  "N=Ubuntu_Rolling            OS=ubuntu  OS_VER=rolling  CC=clang  CI_SANITS=ON   PUSH_IMAGE=1  REBUILD_ALWAYS=YES",
+                 "N=CentOS_Stream             OS=centos  OS_VER=stream   CC=gcc    CI_SANITS=OFF  PUSH_IMAGE=1  REBUILD_ALWAYS=YES",
                  # the OpenSUSE_Tumbleweed build was temporarily moved here, because of the following bug:
                  # https://bugzilla.opensuse.org/show_bug.cgi?id=1190670
                  "N=OpenSUSE_Tumbleweed OS=opensuse-tumbleweed OS_VER=latest CC=gcc CI_SANITS=ON  PUSH_IMAGE=1  REBUILD_ALWAYS=YES"]

--- a/.github/workflows/nightly_rebuild.yml
+++ b/.github/workflows/nightly_rebuild.yml
@@ -42,8 +42,11 @@ jobs:
                  "N=Debian_Testing       OS=debian               OS_VER=testing        REBUILD_ALWAYS=YES",
                  "N=Debian_Experimental  OS=debian               OS_VER=experimental   REBUILD_ALWAYS=YES",
                  "N=Arch_Linux_Latest    OS=archlinux            OS_VER=latest         REBUILD_ALWAYS=YES",
-                 "N=CentOS_Stream        OS=centos               OS_VER=stream         REBUILD_ALWAYS=YES",
-                 # the OpenSUSE_Tumbleweed build was temporarily moved to Nightly_Experimental
+                 # The CentOS_Stream build was moved to Nightly_Experimental,
+                 # because the 'epel-release' repo of CentOS Stream cannot be found
+                 # and this build has been failing for a long time.
+                 #
+                 # The OpenSUSE_Tumbleweed build was temporarily moved to Nightly_Experimental
                  # because of the following bug:
                  # https://bugzilla.opensuse.org/show_bug.cgi?id=1190670
                  "N=OpenSUSE_Leap        OS=opensuse-leap        OS_VER=latest         REBUILD_ALWAYS=YES"]


### PR DESCRIPTION
Move CentOS_Stream CI build to Nightly_Experimental,
because the 'epel-release' repo of CentOS Stream cannot be found
and this build has been failing for a long time.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/pmem/rpma/1483)
<!-- Reviewable:end -->
