### PR TITLE
tools: add DEBUG_SKIP_REMOTE_CMDS config.json variable

### DIFF
--- a/tools/perf/CONFIG.JSON.md
+++ b/tools/perf/CONFIG.JSON.md
@@ -115,10 +115,14 @@ For debugging purposes, you can attach tracers to each or both ends of the conne
     "REMOTE_TRACER": "gdbserver localhost:2345"
 ```
 
-During in-depth analysis of the benchmarking process itself, you may find useful these two options. Where `SKIP_RUNNING_TOOLS` allows running all the machinery but prevents the actual benchmarking binaries and the script setting DDIO ([tools/ddio.sh](./tools/ddio.sh)) from being run. Whereas `DUMP_CMDS` allows dumping all commands running the benchmark binaries. You can use either or both of them.
+During in-depth analysis of the benchmarking process itself, you may find useful these three options:
+- `SKIP_RUNNING_TOOLS` allows running all the machinery but prevents the actual benchmarking binaries and the script setting DDIO ([tools/ddio.sh](./tools/ddio.sh)) from being run.
+- `DEBUG_SKIP_REMOTE_CMDS` skips running all remote commands including copying files to the remote node.
+- `DUMP_CMDS` allows dumping all commands running the benchmark binaries. You can use either or both of them.
 
 ```json
     "SKIP_RUNNING_TOOLS": true,
+    "DEBUG_SKIP_REMOTE_CMDS": true,
     "DUMP_CMDS": true
 ```
 

--- a/tools/perf/CONFIG.JSON.md
+++ b/tools/perf/CONFIG.JSON.md
@@ -115,15 +115,15 @@ For debugging purposes, you can attach tracers to each or both ends of the conne
     "REMOTE_TRACER": "gdbserver localhost:2345"
 ```
 
-During in-depth analysis of the benchmarking process itself, you may find useful these three options:
-- `SKIP_RUNNING_TOOLS` allows running all the machinery but prevents the actual benchmarking binaries and the script setting DDIO ([tools/ddio.sh](./tools/ddio.sh)) from being run.
+During in-depth analysis of the benchmarking process itself, you may find useful these three debug options:
+- `DEBUG_SKIP_RUNNING_TOOLS` allows running all the machinery but prevents the actual benchmarking binaries and the script setting DDIO ([tools/ddio.sh](./tools/ddio.sh)) from being run.
 - `DEBUG_SKIP_REMOTE_CMDS` skips running all remote commands including copying files to the remote node.
-- `DUMP_CMDS` allows dumping all commands running the benchmark binaries. You can use either or both of them.
+- `DEBUG_DUMP_CMDS` allows dumping all commands running the benchmark binaries. You can use either or both of them.
 
 ```json
-    "SKIP_RUNNING_TOOLS": true,
+    "DEBUG_SKIP_RUNNING_TOOLS": true,
     "DEBUG_SKIP_REMOTE_CMDS": true,
-    "DUMP_CMDS": true
+    "DEBUG_DUMP_CMDS": true
 ```
 
 You can also set the timeout (in seconds) of a single run of the 'fio' tool (the default value is 5 minutes):

--- a/tools/perf/lib/Requirement.py
+++ b/tools/perf/lib/Requirement.py
@@ -221,7 +221,7 @@ class Requirement:
         @classmethod
         def __set_DDIO(cls, req, config):
             """set DDIO to the required value"""
-            if config.get('SKIP_RUNNING_TOOLS', False):
+            if config.get('DEBUG_SKIP_RUNNING_TOOLS', False):
                 return
             ddio = 'ddio.sh'
             local_dir = '..'

--- a/tools/perf/lib/bench.py
+++ b/tools/perf/lib/bench.py
@@ -22,7 +22,7 @@ from .remote_cmd import RemoteCmd
 
 def get_remote_job_numa_cpulist(config):
     """get cpulist of the remote NUMA node (REMOTE_JOB_NUMA)"""
-    if config.get('SKIP_RUNNING_TOOLS', False):
+    if config.get('DEBUG_SKIP_RUNNING_TOOLS', False):
         return 0
     cpulist_path = "/sys/devices/system/node/node{}/cpulist" \
         .format(str(config['REMOTE_JOB_NUMA']))
@@ -37,7 +37,7 @@ def get_remote_job_numa_cpulist(config):
 
 def get_cores_per_socket(config):
     """get cores per socket"""
-    if config.get('SKIP_RUNNING_TOOLS', False):
+    if config.get('DEBUG_SKIP_RUNNING_TOOLS', False):
         return 1
     cores_cmd = RemoteCmd.run_sync(config, "lscpu", raise_on_error=True)
     output = cores_cmd.stdout.readlines()

--- a/tools/perf/lib/benchmark/runner/fio.py
+++ b/tools/perf/lib/benchmark/runner/fio.py
@@ -82,9 +82,9 @@ class FioRunner:
         self.__idfile = idfile
         self.__server = None
         # set dumping commands
-        self.__dump_cmds = self.__config.get('DUMP_CMDS', False)
+        self.__dump_cmds = self.__config.get('DEBUG_DUMP_CMDS', False)
         self.__skip_running_tools = \
-            self.__config.get('SKIP_RUNNING_TOOLS', False)
+            self.__config.get('DEBUG_SKIP_RUNNING_TOOLS', False)
         self.__skip_remote_cmds = \
             self.__config.get('DEBUG_SKIP_REMOTE_CMDS', False)
         verify_oneseries(self.__benchmark.oneseries, self.__ONESERIES_REQUIRED)

--- a/tools/perf/lib/benchmark/runner/fio.py
+++ b/tools/perf/lib/benchmark/runner/fio.py
@@ -40,10 +40,12 @@ class FioRunner:
         # check if the remote fio is present
         if 'SERVER_IP' not in self.__config:
             raise ValueError(MISSING_KEY_MSG.format('SERVER_IP'))
-        output = RemoteCmd.run_sync(self.__config, ['which', self.__r_fio_path])
-        if output.exit_status != 0:
-            raise ValueError("cannot find the remote fio: {}"
-                             .format(self.__r_fio_path))
+        if not self.__skip_remote_cmds:
+            output = RemoteCmd.run_sync(self.__config,
+                                        ['which', self.__r_fio_path])
+            if output.exit_status != 0:
+                raise ValueError("cannot find the remote fio: {}"
+                                 .format(self.__r_fio_path))
 
     def __set_settings_by_mode(self):
         """set all variable elements of __SETTINGS_BY_MODE"""
@@ -83,6 +85,8 @@ class FioRunner:
         self.__dump_cmds = self.__config.get('DUMP_CMDS', False)
         self.__skip_running_tools = \
             self.__config.get('SKIP_RUNNING_TOOLS', False)
+        self.__skip_remote_cmds = \
+            self.__config.get('DEBUG_SKIP_REMOTE_CMDS', False)
         verify_oneseries(self.__benchmark.oneseries, self.__ONESERIES_REQUIRED)
         # pick the result keys base on the benchmark's rw
         self.__set_results_key()
@@ -201,14 +205,14 @@ class FioRunner:
                 '--filename_format={}.\\$jobnum'.format(pmem_path))
         # copy the job file to the server
         r_job_path, job_file = self.__set_jobfile_path_and_name()
-        RemoteCmd.copy_to_remote(self.__config, job_file, r_job_path)
         args.append(r_job_path)
         args = env + args
         # dump a command to the log file
         if self.__dump_cmds:
             with open(settings['logfile_server'], 'a', encoding='utf-8') as log:
                 log.write("[server]$ {}".format(' '.join(args)))
-        if not self.__skip_running_tools:
+        if not (self.__skip_running_tools or self.__skip_remote_cmds):
+            RemoteCmd.copy_to_remote(self.__config, job_file, r_job_path)
             self.__server = RemoteCmd.run_async(self.__config, args)
             time.sleep(0.1) # wait 0.1 sec for server to start listening
 

--- a/tools/perf/lib/benchmark/runner/ib_read.py
+++ b/tools/perf/lib/benchmark/runner/ib_read.py
@@ -51,9 +51,9 @@ class IbReadRunner:
         self.__idfile = idfile
         self.__server = None
         # set dumping commands
-        self.__dump_cmds = self.__config.get('DUMP_CMDS', False)
+        self.__dump_cmds = self.__config.get('DEBUG_DUMP_CMDS', False)
         self.__skip_running_tools = \
-            self.__config.get('SKIP_RUNNING_TOOLS', False)
+            self.__config.get('DEBUG_SKIP_RUNNING_TOOLS', False)
         self.__skip_remote_cmds = \
             self.__config.get('DEBUG_SKIP_REMOTE_CMDS', False)
         verify_oneseries(self.__benchmark.oneseries, self.__ONESERIES_REQUIRED)

--- a/tools/perf/lib/benchmark/runner/ib_read.py
+++ b/tools/perf/lib/benchmark/runner/ib_read.py
@@ -38,10 +38,12 @@ class IbReadRunner:
         # check if the remote ib tool is present
         if 'SERVER_IP' not in self.__config:
             raise ValueError(MISSING_KEY_MSG.format('SERVER_IP'))
-        output = RemoteCmd.run_sync(self.__config, ['which', self.__r_ib_path])
-        if output.exit_status != 0:
-            raise ValueError("cannot find the remote ib tool: {}"
-                             .format(self.__r_ib_path))
+        if not self.__skip_remote_cmds:
+            output = RemoteCmd.run_sync(self.__config,
+                                        ['which', self.__r_ib_path])
+            if output.exit_status != 0:
+                raise ValueError("cannot find the remote ib tool: {}"
+                                 .format(self.__r_ib_path))
 
     def __init__(self, benchmark, config, idfile):
         self.__benchmark = benchmark
@@ -52,6 +54,8 @@ class IbReadRunner:
         self.__dump_cmds = self.__config.get('DUMP_CMDS', False)
         self.__skip_running_tools = \
             self.__config.get('SKIP_RUNNING_TOOLS', False)
+        self.__skip_remote_cmds = \
+            self.__config.get('DEBUG_SKIP_REMOTE_CMDS', False)
         verify_oneseries(self.__benchmark.oneseries, self.__ONESERIES_REQUIRED)
         # pick the settings predefined for the chosen mode
         self.__tool = self.__benchmark.oneseries['tool']
@@ -115,7 +119,7 @@ class IbReadRunner:
         if self.__dump_cmds:
             with open(settings['logfile_server'], 'a', encoding='utf-8') as log:
                 log.write("[server]$ {}".format(' '.join(args)))
-        if not self.__skip_running_tools:
+        if not (self.__skip_running_tools or self.__skip_remote_cmds):
             self.__server = RemoteCmd.run_async(self.__config, args)
             time.sleep(0.1) # wait 0.1 sec for server to start listening
 


### PR DESCRIPTION
Add the `SKIP_REMOTE_CMDS` config.json variable to skip running
all remote commands including copying files to the remote node.

Fixes: #1488

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/pmem/rpma/1518)
<!-- Reviewable:end -->
