### PR TITLE
rpma: mark as deprecated rpma_cq_get_completion(), struct rpma_completion and enum rpma_op

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Tools:
   - Benchmarking framework basing on python scripts.
 
+### Deprecated
+- APIs:
+  - rpma_cq_get_completion - replaced with rpma_cq_get_wc
+  - struct rpma_completion - replaced with struct ibv_wc from libibverbs
+  - enum rpma_op - replaced with enum ibv_wc_opcode from libibverbs
+
 ### Removed
 - Tools:
   - Benchmarking framework basing on bash scripts.

--- a/src/include/librpma.h
+++ b/src/include/librpma.h
@@ -2717,6 +2717,7 @@ int rpma_recv(struct rpma_conn *conn,
  */
 int rpma_conn_get_completion_fd(const struct rpma_conn *conn, int *fd);
 
+/* DEPRECATED - for details please see rpma_cq_get_completion(3). */
 enum rpma_op {
 	RPMA_OP_READ,
 	RPMA_OP_WRITE,
@@ -2726,7 +2727,7 @@ enum rpma_op {
 	RPMA_OP_RECV_RDMA_WITH_IMM,
 };
 
-/* For details please see rpma_cq_get_completion(3). */
+/* DEPRECATED - for details please see rpma_cq_get_completion(3). */
 struct rpma_completion {
 	void *op_context;
 	enum rpma_op op;
@@ -2900,7 +2901,7 @@ int rpma_cq_get_fd(const struct rpma_cq *cq, int *fd);
 int rpma_cq_wait(struct rpma_cq *cq);
 
 /** 3
- * rpma_cq_get_completion - receive a completion of an operation
+ * rpma_cq_get_completion - receive a completion of an operation (deprecated)
  *
  * SYNOPSIS
  *
@@ -2975,6 +2976,28 @@ int rpma_cq_wait(struct rpma_cq *cq);
  * - RPMA_E_PROVIDER - ibv_poll_cq(3) failed with a provider error
  * - RPMA_E_UNKNOWN - ibv_poll_cq(3) failed but no provider error is available
  * - RPMA_E_NOSUPP - not supported opcode
+ *
+ * DEPRECATED
+ * This is an example snippet of code using the old API:
+ *
+ *	struct rpma_completion cmpl;
+ *
+ *	ret = rpma_cq_get_completion(cq, &cmpl);
+ *	if (ret) { error_handling_code() }
+ *
+ *	if (cmpl.op_status != IBV_WC_SUCCESS) { error_handling_code() }
+ *	if (cmpl.op != RPMA_OP_READ) { error_handling_code() }
+ *
+ * The above snippet should be replaced with
+ * the following one using the new API:
+ *
+ *	struct ibv_wc wc;
+ *
+ *	ret = rpma_cq_get_wc(cq, 1, &wc, NULL);
+ *	if (ret) { error_handling_code() }
+ *
+ *	if (wc.status != IBV_WC_SUCCESS) { error_handling_code() }
+ *	if (wc.opcode != IBV_WC_RDMA_READ) { error_handling_code() }
  *
  * SEE ALSO
  * rpma_conn_get_cq(3), rpma_conn_get_rcq(3), rpma_conn_req_recv(3),


### PR DESCRIPTION
<!-- Reviewable:start -->
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/pmem/rpma/1525)
<!-- Reviewable:end -->
