### PR TITLE
rpma: re-mark enum rpma_op as deprecated

### DIFF
--- a/src/include/librpma.h
+++ b/src/include/librpma.h
@@ -2651,6 +2651,7 @@ int rpma_recv(struct rpma_conn *conn,
 
 /* completion handling */
 
+/* DEPRECATED - for details please see rpma_cq_get_completion(3). */
 enum rpma_op {
 	RPMA_OP_READ,
 	RPMA_OP_WRITE,


### PR DESCRIPTION
Re-mark enum rpma_op as deprecated.
It was marked as deprecated in #1525 and by accident removed in #1529.

Ref: #1525
Ref: #1529

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/pmem/rpma/1538)
<!-- Reviewable:end -->
