### PR TITLE
examples: add -std=gnu99 option to CMAKE_C_FLAGS in 08 example

### DIFF
--- a/examples/08-messages-ping-pong/CMakeLists.txt
+++ b/examples/08-messages-ping-pong/CMakeLists.txt
@@ -14,6 +14,8 @@ include(${CMAKE_SOURCE_DIR}/../../cmake/functions.cmake)
 # set LIBRT_LIBRARIES if linking with librt is required
 check_if_librt_is_required()
 
+set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -std=gnu99")
+
 find_package(PkgConfig QUIET)
 
 if(PKG_CONFIG_FOUND)


### PR DESCRIPTION
Add the '-std=gnu99' option to CMAKE_C_FLAGS in 08 example
in order to prevent the following error on CentOS 7:
```
/rpma/examples/08-messages-ping-pong/messages-ping-pong-common.c:66:3:\
 error: 'for' loop initial declarations are only allowed in C99 mode
   for (int i = 0; i < num_got; i++) {
   ^
```

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/pmem/rpma/1551)
<!-- Reviewable:end -->
