### PR TITLE
common: fix Arch Linux CI build

### DIFF
--- a/utils/docker/images/Dockerfile.archlinux-latest
+++ b/utils/docker/images/Dockerfile.archlinux-latest
@@ -97,7 +97,7 @@ RUN echo $USERPASS > $PFILE
 RUN echo $USERPASS >> $PFILE
 RUN passwd $USER < $PFILE
 RUN rm -f $PFILE
-RUN sed -i 's/# %wheel ALL=(ALL) NOPASSWD: ALL/%wheel ALL=(ALL) NOPASSWD: ALL/g' /etc/sudoers
+RUN sed -i 's/# %wheel/%wheel/g' /etc/sudoers
 RUN gpasswd wheel -a $USER
 
 # Enable preserving given variables in the privileged environment -

--- a/utils/docker/images/Dockerfile.archlinux-latest
+++ b/utils/docker/images/Dockerfile.archlinux-latest
@@ -52,6 +52,10 @@ ENV PYTHON_DEPS "\
 	paramiko \
 	scp"
 
+# PMDK deps
+ENV PMDK_DEPS "\
+	ndctl"
+
 # RPMA deps
 ENV RPMA_DEPS "\
 	cmake \
@@ -70,6 +74,7 @@ RUN pacman -S --noconfirm \
 	$TOOLS_DEPS \
 	$TESTS_DEPS \
 	$RDMA_DEPS \
+	$PMDK_DEPS \
 	$RPMA_DEPS \
 && rm -rf /var/cache/pacman/pkg/*
 


### PR DESCRIPTION
This PR contains two fixes:

1) common: add ndctl required by pmdk to Arch Linux Dockerfile

Add the ndctl package (required by pmdk) to Arch Linux Dockerfile.

See: https://github.com/ldorau/rpma/runs/5107934970
```
==> Missing dependencies:
  -> ndctl>=63
==> Checking buildtime dependencies...
==> ERROR: Could not resolve all dependencies.
```

and:

2) common: fix allowing members of group wheel to execute any command

Fix allowing members of group wheel to execute any command
without a password on Arch Linux. The format of the `/etc/sudoers`
has been changed recently and the current pattern does not match
any longer.

See: https://github.com/ldorau/rpma/runs/5108094502
```
sudo: a terminal is required to read the password; \
          either use the -S option to read from standard input \
          or configure an askpass helper
sudo: a password is required
==> WARNING: Failed to install built package(s).
```

The CI build with this fix:
https://github.com/ldorau/rpma/runs/5108331925

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/pmem/rpma/1556)
<!-- Reviewable:end -->
