### PR TITLE
common: fix allowing members of group wheel to execute any command

### DIFF
--- a/utils/docker/images/Dockerfile.opensuse-leap-latest
+++ b/utils/docker/images/Dockerfile.opensuse-leap-latest
@@ -89,7 +89,7 @@ RUN echo $USERPASS > $PFILE
 RUN echo $USERPASS >> $PFILE
 RUN passwd $USER < $PFILE
 RUN rm -f $PFILE
-RUN sed -i 's/# %wheel ALL=(ALL) NOPASSWD: ALL/%wheel ALL=(ALL) NOPASSWD: ALL/g' /etc/sudoers
+RUN sed -i 's/# %wheel/%wheel/g' /etc/sudoers
 RUN groupadd wheel
 RUN gpasswd wheel -a $USER
 USER $USER

--- a/utils/docker/images/Dockerfile.opensuse-tumbleweed-latest
+++ b/utils/docker/images/Dockerfile.opensuse-tumbleweed-latest
@@ -90,7 +90,7 @@ RUN echo $USERPASS > $PFILE
 RUN echo $USERPASS >> $PFILE
 RUN passwd $USER < $PFILE
 RUN rm -f $PFILE
-RUN sed -i 's/# %wheel ALL=(ALL) NOPASSWD: ALL/%wheel ALL=(ALL) NOPASSWD: ALL/g' /etc/sudoers
+RUN sed -i 's/# %wheel/%wheel/g' /etc/sudoers
 RUN groupadd wheel
 RUN gpasswd wheel -a $USER
 USER $USER


### PR DESCRIPTION
Fix allowing members of group wheel to execute any command
without a password on OpenSUSE Leap and Tumbleweed.
The format of the `/etc/sudoers` has been changed recently
and the current pattern does not match any longer.

Ref: 12965c4

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/pmem/rpma/1562)
<!-- Reviewable:end -->
