### PR TITLE
common: move temporarily Arch Linux build to Nightly Experimental

### DIFF
--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -53,7 +53,7 @@ jobs:
                  "N=Ubuntu_Rolling       OS=ubuntu               OS_VER=rolling",
                  "N=Debian_Testing       OS=debian               OS_VER=testing",
                  "N=Debian_Experimental  OS=debian               OS_VER=experimental",
-                 "N=Arch_Linux_Latest    OS=archlinux            OS_VER=latest",
+                 # Arch Linux build was temporarily moved to Nightly Experimental
                  "N=OpenSUSE_Leap        OS=opensuse-leap        OS_VER=latest",
                  "N=OpenSUSE_Tumbleweed  OS=opensuse-tumbleweed  OS_VER=latest"]
     steps:
@@ -94,7 +94,7 @@ jobs:
                  # (the Fedora_Rawhide and Ubuntu_Rolling builds were moved to Nightly_Experimental)
                  "N=Debian_Testing       OS=debian               OS_VER=testing",
                  "N=Debian_Experimental  OS=debian               OS_VER=experimental",
-                 "N=Arch_Linux_Latest    OS=archlinux            OS_VER=latest",
+                 # Arch Linux build was temporarily moved to Nightly Experimental
                  "N=OpenSUSE_Leap        OS=opensuse-leap        OS_VER=latest",
                  "N=OpenSUSE_Tumbleweed  OS=opensuse-tumbleweed  OS_VER=latest"]
     steps:

--- a/.github/workflows/nightly_experimental.yml
+++ b/.github/workflows/nightly_experimental.yml
@@ -35,7 +35,8 @@ jobs:
                  "N=Fedora_Rawhide_SANITS     OS=fedora  OS_VER=rawhide  CC=clang  CI_SANITS=ON   PUSH_IMAGE=0",
                  "N=Fedora_Rawhide_no_SANITS  OS=fedora  OS_VER=rawhide  CC=clang  CI_SANITS=OFF  PUSH_IMAGE=1  REBUILD_ALWAYS=YES",
                  "N=Ubuntu_Rolling            OS=ubuntu  OS_VER=rolling  CC=clang  CI_SANITS=ON   PUSH_IMAGE=1  REBUILD_ALWAYS=YES",
-                 "N=CentOS_Stream             OS=centos  OS_VER=stream   CC=gcc    CI_SANITS=OFF  PUSH_IMAGE=1  REBUILD_ALWAYS=YES"]
+                 "N=CentOS_Stream             OS=centos  OS_VER=stream   CC=gcc    CI_SANITS=OFF  PUSH_IMAGE=1  REBUILD_ALWAYS=YES",
+                 "N=Arch_Linux_Latest      OS=archlinux  OS_VER=latest   CC=gcc    CI_SANITS=OFF  PUSH_IMAGE=1  REBUILD_ALWAYS=YES"]
     steps:
        - name: Clone the git repo
          uses: actions/checkout@v1


### PR DESCRIPTION
Move temporarily Arch Linux build to Nightly Experimental,
because of the following bug during installation of PMDK:
```
==> Starting build()...
test -f .skip-doc || make -C doc all
make[1]: Entering directory '/pmdk/src/pmdk-1.11.1/doc'
../utils/md2man.sh libpmem/libpmem.7.md default.man libpmem/libpmem.7
pandoc: /usr/lib/libc.so.6: version `GLIBC_2.34' not found \
       (required by pandoc)
make[1]: *** [Makefile:257: libpmem/libpmem.7] Error 1
make[1]: Leaving directory '/pmdk/src/pmdk-1.11.1/doc'
make: *** [Makefile:62: doc] Error 2
Command exited with non-zero status 2
```

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/pmem/rpma/1580)
<!-- Reviewable:end -->
