### PR TITLE
common: fix run-doc-update.sh for builds from a tag

### DIFF
--- a/utils/docker/run-doc-update.sh
+++ b/utils/docker/run-doc-update.sh
@@ -27,6 +27,16 @@ function set_up_repo() {
 	git config --local user.email "${BOT_NAME}@intel.com"
 
 	git remote update
+
+	# check if "upstream/${BRANCH}" is a valid branch
+	if ! git log -1 upstream/${BRANCH} 2>/dev/null; then
+		# BRANCH (set from ${CI_BRANCH}) is a tag,
+		# but tags do not introduce changes in the code,
+		# so there is no need to look for changes in the man pages.
+		echo "Notice: it is a build from a tag - skipping updating man pages"
+		exit 0
+	fi
+
 	git checkout -B ${BRANCH} upstream/${BRANCH}
 }
 


### PR DESCRIPTION
When the build is run from a tag, then the `CI_BRANCH` variable
is set to a name of this tag instead of a branch name
and it should be handled in a different way.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/pmem/rpma/1585)
<!-- Reviewable:end -->
