### PR TITLE
rpma: ibv_context naming unification

### DIFF
--- a/examples/01-connection/client.c
+++ b/examples/01-connection/client.c
@@ -38,7 +38,7 @@ main(int argc, char *argv[])
 	char *port = argv[2];
 
 	/* resources */
-	struct ibv_context *dev = NULL;
+	struct ibv_context *ibv_ctx = NULL;
 	struct rpma_peer *peer = NULL;
 	struct rpma_conn_req *req = NULL;
 	struct rpma_conn *conn = NULL;
@@ -47,12 +47,12 @@ main(int argc, char *argv[])
 
 	/* obtain an IBV context for a remote IP address */
 	ret = rpma_utils_get_ibv_context(addr, RPMA_UTIL_IBV_CONTEXT_REMOTE,
-			&dev);
+			&ibv_ctx);
 	if (ret)
 		return ret;
 
 	/* create a new peer object */
-	ret = rpma_peer_new(dev, &peer);
+	ret = rpma_peer_new(ibv_ctx, &peer);
 	if (ret)
 		return ret;
 

--- a/examples/01-connection/server.c
+++ b/examples/01-connection/server.c
@@ -33,7 +33,7 @@ main(int argc, char *argv[])
 	char *port = argv[2];
 
 	/* resources */
-	struct ibv_context *dev = NULL;
+	struct ibv_context *ibv_ctx = NULL;
 	struct rpma_peer *peer = NULL;
 	struct rpma_ep *ep = NULL;
 	struct rpma_conn_req *req = NULL;
@@ -43,12 +43,12 @@ main(int argc, char *argv[])
 
 	/* obtain an IBV context for a local IP address */
 	ret = rpma_utils_get_ibv_context(addr, RPMA_UTIL_IBV_CONTEXT_LOCAL,
-			&dev);
+			&ibv_ctx);
 	if (ret)
 		return ret;
 
 	/* create a new peer object */
-	ret = rpma_peer_new(dev, &peer);
+	ret = rpma_peer_new(ibv_ctx, &peer);
 	if (ret)
 		return ret;
 

--- a/examples/common/common-conn.c
+++ b/examples/common/common-conn.c
@@ -46,14 +46,14 @@ int
 common_peer_via_address(const char *addr, enum rpma_util_ibv_context_type type,
 		struct rpma_peer **peer_ptr)
 {
-	struct ibv_context *dev = NULL;
+	struct ibv_context *ibv_ctx = NULL;
 
-	int ret = rpma_utils_get_ibv_context(addr, type, &dev);
+	int ret = rpma_utils_get_ibv_context(addr, type, &ibv_ctx);
 	if (ret)
 		return ret;
 
 	/* create a new peer object */
-	return rpma_peer_new(dev, peer_ptr);
+	return rpma_peer_new(ibv_ctx, peer_ptr);
 }
 
 /*

--- a/src/cq.c
+++ b/src/cq.c
@@ -43,22 +43,22 @@ rpma_cq_get_ibv_cq(const struct rpma_cq *cq)
  * encapsulate them in a rpma_cq object
  *
  * ASSUMPTIONS
- * - dev != NULL && cq_ptr != NULL
+ * - ibv_ctx != NULL && cq_ptr != NULL
  */
 int
-rpma_cq_new(struct ibv_context *dev, int cqe, struct rpma_cq **cq_ptr)
+rpma_cq_new(struct ibv_context *ibv_ctx, int cqe, struct rpma_cq **cq_ptr)
 {
 	int ret = 0;
 
 	/* create a completion channel */
-	struct ibv_comp_channel *channel = ibv_create_comp_channel(dev);
+	struct ibv_comp_channel *channel = ibv_create_comp_channel(ibv_ctx);
 	if (channel == NULL) {
 		RPMA_LOG_ERROR_WITH_ERRNO(errno, "ibv_create_comp_channel()");
 		return RPMA_E_PROVIDER;
 	}
 
 	/* create a CQ */
-	struct ibv_cq *cq = ibv_create_cq(dev, cqe,
+	struct ibv_cq *cq = ibv_create_cq(ibv_ctx, cqe,
 				NULL /* cq_context */,
 				channel /* channel */,
 				0 /* comp_vector */);

--- a/src/cq.h
+++ b/src/cq.h
@@ -27,7 +27,7 @@ struct ibv_cq *rpma_cq_get_ibv_cq(const struct rpma_cq *cq);
  * ibv_req_notify_cq(3) failed with a provider error
  * - RPMA_E_NOMEM - out of memory
  */
-int rpma_cq_new(struct ibv_context *dev, int cqe, struct rpma_cq **cq_ptr);
+int rpma_cq_new(struct ibv_context *ibv_ctx, int cqe, struct rpma_cq **cq_ptr);
 
 /*
  * ERRORS

--- a/src/include/librpma.h
+++ b/src/include/librpma.h
@@ -455,7 +455,7 @@ enum rpma_util_ibv_context_type {
  *
  *	int rpma_utils_get_ibv_context(const char *addr,
  *		enum rpma_util_ibv_context_type type,
- *		struct ibv_context **dev_ptr);
+ *		struct ibv_context **ibv_ctx_ptr);
  *
  * DESCRIPTION
  * rpma_utils_get_ibv_context() obtains an RDMA device context
@@ -470,13 +470,13 @@ enum rpma_util_ibv_context_type {
  *
  * RETURN VALUE
  * The rpma_utils_get_ibv_context() function returns 0 on success or a negative
- * error code on failure. rpma_utils_get_ibv_context() does not set *dev_ptr
- * value on failure.
+ * error code on failure.
+ * rpma_utils_get_ibv_context() does not set *ibv_ctx_ptr value on failure.
  *
  * ERRORS
  * rpma_utils_get_ibv_context() can fail with the following errors:
  *
- * - RPMA_E_INVAL - addr or dev_ptr is NULL or type is unknown
+ * - RPMA_E_INVAL - addr or ibv_ctx_ptr is NULL or type is unknown
  * - RPMA_E_NOMEM - out of memory
  * - RPMA_E_PROVIDER - rdma_getaddrinfo(), rdma_create_id(), rdma_bind_addr()
  * or rdma_resolve_addr() failed, the exact cause of the error
@@ -488,7 +488,7 @@ enum rpma_util_ibv_context_type {
  */
 int rpma_utils_get_ibv_context(const char *addr,
 		enum rpma_util_ibv_context_type type,
-		struct ibv_context **dev_ptr);
+		struct ibv_context **ibv_ctx_ptr);
 
 /** 3
  * rpma_utils_ibv_context_is_odp_capable - is On-Demand Paging supported
@@ -498,7 +498,7 @@ int rpma_utils_get_ibv_context(const char *addr,
  *	#include <librpma.h>
  *
  *	struct ibv_context;
- *	int rpma_utils_ibv_context_is_odp_capable(struct ibv_context *dev,
+ *	int rpma_utils_ibv_context_is_odp_capable(struct ibv_context *ibv_ctx,
  *		int *is_odp_capable);
  *
  * DESCRIPTION
@@ -513,14 +513,14 @@ int rpma_utils_get_ibv_context(const char *addr,
  * ERRORS
  * rpma_utils_ibv_context_is_odp_capable() can fail with the following errors:
  *
- * - RPMA_E_INVAL - dev or is_odp_capable is NULL
+ * - RPMA_E_INVAL - ibv_ctx or is_odp_capable is NULL
  * - RPMA_E_PROVIDER - ibv_query_device_ex() failed, the exact cause
  * of the error can be read from the log
  *
  * SEE ALSO
  * rpma_utils_get_ibv_context(3), librpma(7) and https://pmem.io/rpma/
  */
-int rpma_utils_ibv_context_is_odp_capable(struct ibv_context *dev,
+int rpma_utils_ibv_context_is_odp_capable(struct ibv_context *ibv_ctx,
 		int *is_odp_capable);
 
 /* peer configuration */

--- a/src/rpma.c
+++ b/src/rpma.c
@@ -19,9 +19,9 @@
 int
 rpma_utils_get_ibv_context(const char *addr,
 		enum rpma_util_ibv_context_type type,
-		struct ibv_context **dev_ptr)
+		struct ibv_context **ibv_ctx_ptr)
 {
-	if (addr == NULL || dev_ptr == NULL)
+	if (addr == NULL || ibv_ctx_ptr == NULL)
 		return RPMA_E_INVAL;
 
 	enum rpma_info_side side;
@@ -61,7 +61,7 @@ rpma_utils_get_ibv_context(const char *addr,
 	}
 
 	/* obtain the device */
-	*dev_ptr = temp_id->verbs;
+	*ibv_ctx_ptr = temp_id->verbs;
 
 err_destroy_id:
 	(void) rdma_destroy_id(temp_id);
@@ -76,10 +76,10 @@ err_info_delete:
  * capabilities and check if it supports On-Demand Paging
  */
 int
-rpma_utils_ibv_context_is_odp_capable(struct ibv_context *dev,
+rpma_utils_ibv_context_is_odp_capable(struct ibv_context *ibv_ctx,
 		int *is_odp_capable)
 {
-	if (dev == NULL || is_odp_capable == NULL)
+	if (ibv_ctx == NULL || is_odp_capable == NULL)
 		return RPMA_E_INVAL;
 
 	*is_odp_capable = 0;
@@ -87,7 +87,7 @@ rpma_utils_ibv_context_is_odp_capable(struct ibv_context *dev,
 #ifdef ON_DEMAND_PAGING_SUPPORTED
 	/* query an RDMA device's attributes */
 	struct ibv_device_attr_ex attr = {{{0}}};
-	errno = ibv_query_device_ex(dev, NULL /* input */, &attr);
+	errno = ibv_query_device_ex(ibv_ctx, NULL /* input */, &attr);
 	if (errno) {
 		RPMA_LOG_ERROR_WITH_ERRNO(errno,
 			"ibv_query_device_ex(attr={0})");

--- a/tests/integration/common/mocks.c
+++ b/tests/integration/common/mocks.c
@@ -43,10 +43,10 @@ struct ibv_odp_caps Ibv_odp_capable_caps = {
  * ibv_query_device -- ibv_query_device() mock
  */
 int
-ibv_query_device(struct ibv_context *context,
+ibv_query_device(struct ibv_context *ibv_ctx,
 		struct ibv_device_attr *device_attr)
 {
-	assert_ptr_equal(context, MOCK_VERBS);
+	assert_ptr_equal(ibv_ctx, MOCK_VERBS);
 	assert_non_null(device_attr);
 
 	int ret = mock_type(int);
@@ -63,12 +63,12 @@ ibv_query_device(struct ibv_context *context,
  * ibv_query_device_ex_mock -- ibv_query_device_ex() mock
  */
 int
-ibv_query_device_ex_mock(struct ibv_context *context,
+ibv_query_device_ex_mock(struct ibv_context *ibv_ctx,
 		const struct ibv_query_device_ex_input *input,
 		struct ibv_device_attr_ex *attr,
 		size_t attr_size)
 {
-	assert_ptr_equal(context, MOCK_VERBS);
+	assert_ptr_equal(ibv_ctx, MOCK_VERBS);
 	assert_null(input);
 	assert_non_null(attr);
 	/* attr_size is provided by ibverbs - no validation needed */
@@ -267,13 +267,13 @@ ibv_dealloc_pd(struct ibv_pd *pd)
  * ibv_create_cq -- ibv_create_cq() mock
  */
 struct ibv_cq *
-ibv_create_cq(struct ibv_context *context, int cqe, void *cq_context,
+ibv_create_cq(struct ibv_context *ibv_ctx, int cqe, void *cq_context,
 		struct ibv_comp_channel *channel, int comp_vector)
 {
 	int cqe_default;
 	(void) rpma_conn_cfg_get_cqe(rpma_conn_cfg_default(), &cqe_default);
 
-	assert_ptr_equal(context, MOCK_VERBS);
+	assert_ptr_equal(ibv_ctx, MOCK_VERBS);
 	assert_int_equal(cqe, cqe_default);
 	assert_ptr_equal(channel, MOCK_COMP_CHANNEL);
 	assert_int_equal(comp_vector, 0);
@@ -304,9 +304,9 @@ ibv_destroy_cq(struct ibv_cq *cq)
  * ibv_create_comp_channel -- ibv_create_comp_channel() mock
  */
 struct ibv_comp_channel *
-ibv_create_comp_channel(struct ibv_context *context)
+ibv_create_comp_channel(struct ibv_context *ibv_ctx)
 {
-	assert_ptr_equal(context, MOCK_VERBS);
+	assert_ptr_equal(ibv_ctx, MOCK_VERBS);
 
 	struct ibv_comp_channel *channel = mock_type(struct ibv_comp_channel *);
 	if (!channel) {

--- a/tests/integration/common/mocks.h
+++ b/tests/integration/common/mocks.h
@@ -71,7 +71,7 @@ struct mmap_args {
 };
 
 #ifdef ON_DEMAND_PAGING_SUPPORTED
-int ibv_query_device_ex_mock(struct ibv_context *context,
+int ibv_query_device_ex_mock(struct ibv_context *ibv_ctx,
 		const struct ibv_query_device_ex_input *input,
 		struct ibv_device_attr_ex *attr,
 		size_t attr_size);

--- a/tests/multithreaded/conn/rpma_conn_get_private_data.c
+++ b/tests/multithreaded/conn/rpma_conn_get_private_data.c
@@ -30,19 +30,19 @@ static void
 prestate_init(void *prestate, struct mtt_result *tr)
 {
 	struct prestate *pr = (struct prestate *)prestate;
-	struct ibv_context *dev;
+	struct ibv_context *ibv_ctx;
 	struct rpma_conn_req *req = NULL;
 	enum rpma_conn_event conn_event = RPMA_CONN_UNDEFINED;
 
 	int ret;
 
 	if ((ret = rpma_utils_get_ibv_context(pr->addr,
-			RPMA_UTIL_IBV_CONTEXT_REMOTE, &dev))) {
+			RPMA_UTIL_IBV_CONTEXT_REMOTE, &ibv_ctx))) {
 		MTT_RPMA_ERR(tr, "rpma_utils_get_ibv_context", ret);
 		return;
 	}
 
-	if ((ret = rpma_peer_new(dev, &pr->peer))) {
+	if ((ret = rpma_peer_new(ibv_ctx, &pr->peer))) {
 		MTT_RPMA_ERR(tr, "rpma_peer_new", ret);
 		return;
 	}

--- a/tests/multithreaded/conn/rpma_conn_req_new.c
+++ b/tests/multithreaded/conn/rpma_conn_req_new.c
@@ -29,16 +29,16 @@ static void
 prestate_init(void *prestate, struct mtt_result *tr)
 {
 	struct prestate *pr = (struct prestate *)prestate;
-	struct ibv_context *dev;
+	struct ibv_context *ibv_ctx;
 	int ret;
 
 	if ((ret = rpma_utils_get_ibv_context(pr->addr,
-			RPMA_UTIL_IBV_CONTEXT_REMOTE, &dev))) {
+			RPMA_UTIL_IBV_CONTEXT_REMOTE, &ibv_ctx))) {
 		MTT_RPMA_ERR(tr, "rpma_utils_get_ibv_context", ret);
 		return;
 	}
 
-	if ((ret = rpma_peer_new(dev, &pr->peer)))
+	if ((ret = rpma_peer_new(ibv_ctx, &pr->peer)))
 		MTT_RPMA_ERR(tr, "rpma_peer_new", ret);
 }
 

--- a/tests/multithreaded/conn/server_rpma_conn_get_private_data.c
+++ b/tests/multithreaded/conn/server_rpma_conn_get_private_data.c
@@ -89,7 +89,7 @@ common_wait_for_conn_close_and_disconnect(struct rpma_conn **conn_ptr)
 int
 server_main(char *addr, unsigned port)
 {
-	struct ibv_context *dev = NULL;
+	struct ibv_context *ibv_ctx = NULL;
 	struct rpma_peer *peer = NULL;
 	struct rpma_ep *ep = NULL;
 	struct rpma_conn *conn = NULL;
@@ -101,13 +101,13 @@ server_main(char *addr, unsigned port)
 
 	/* lookup an ibv_context via the address */
 	if ((ret = rpma_utils_get_ibv_context(addr,
-			RPMA_UTIL_IBV_CONTEXT_LOCAL, &dev))) {
+			RPMA_UTIL_IBV_CONTEXT_LOCAL, &ibv_ctx))) {
 		SERVER_RPMA_ERR("rpma_utils_get_ibv_context", ret);
 		return ret;
 	}
 
 	/* create a new peer object */
-	if ((ret = rpma_peer_new(dev, &peer))) {
+	if ((ret = rpma_peer_new(ibv_ctx, &peer))) {
 		SERVER_RPMA_ERR("rpma_peer_new", ret);
 		return ret;
 	}

--- a/tests/multithreaded/ep/rpma_ep_get_fd.c
+++ b/tests/multithreaded/ep/rpma_ep_get_fd.c
@@ -13,7 +13,7 @@
 struct prestate {
 	char *addr;
 	unsigned port;
-	struct ibv_context *dev;
+	struct ibv_context *ibv_ctx;
 	struct rpma_peer *peer;
 	struct rpma_ep *ep;
 	int ep_fd_exp;
@@ -31,12 +31,12 @@ prestate_init(void *prestate, struct mtt_result *tr)
 	int ret;
 
 	if ((ret = rpma_utils_get_ibv_context(pr->addr,
-			RPMA_UTIL_IBV_CONTEXT_LOCAL, &pr->dev))) {
+			RPMA_UTIL_IBV_CONTEXT_LOCAL, &pr->ibv_ctx))) {
 		MTT_RPMA_ERR(tr, "rpma_utils_get_ibv_context", ret);
 		return;
 	}
 
-	if ((ret = rpma_peer_new(pr->dev, &pr->peer))) {
+	if ((ret = rpma_peer_new(pr->ibv_ctx, &pr->peer))) {
 		MTT_RPMA_ERR(tr, "rpma_peer_new", ret);
 		return;
 	}

--- a/tests/multithreaded/ep/rpma_ep_listen.c
+++ b/tests/multithreaded/ep/rpma_ep_listen.c
@@ -13,7 +13,7 @@
 struct prestate {
 	char *addr;
 	unsigned port;
-	struct ibv_context *dev;
+	struct ibv_context *ibv_ctx;
 	struct rpma_peer *peer;
 };
 
@@ -32,12 +32,12 @@ prestate_init(void *prestate, struct mtt_result *tr)
 	int ret;
 
 	if ((ret = rpma_utils_get_ibv_context(pr->addr,
-			RPMA_UTIL_IBV_CONTEXT_LOCAL, &pr->dev))) {
+			RPMA_UTIL_IBV_CONTEXT_LOCAL, &pr->ibv_ctx))) {
 		MTT_RPMA_ERR(tr, "rpma_utils_get_ibv_context", ret);
 		return;
 	}
 
-	if ((ret = rpma_peer_new(pr->dev, &pr->peer)))
+	if ((ret = rpma_peer_new(pr->ibv_ctx, &pr->peer)))
 		MTT_RPMA_ERR(tr, "rpma_peer_new", ret);
 }
 

--- a/tests/multithreaded/mr/rpma_mr_get_descriptor.c
+++ b/tests/multithreaded/mr/rpma_mr_get_descriptor.c
@@ -28,16 +28,16 @@ static void
 prestate_init(void *prestate, struct mtt_result *tr)
 {
 	struct prestate *pr = (struct prestate *)prestate;
-	struct ibv_context *dev;
+	struct ibv_context *ibv_ctx;
 	int ret;
 
 	if ((ret = rpma_utils_get_ibv_context(pr->addr,
-			RPMA_UTIL_IBV_CONTEXT_LOCAL, &dev))) {
+			RPMA_UTIL_IBV_CONTEXT_LOCAL, &ibv_ctx))) {
 		MTT_RPMA_ERR(tr, "rpma_utils_get_ibv_context", ret);
 		return;
 	}
 
-	if ((ret = rpma_peer_new(dev, &pr->peer))) {
+	if ((ret = rpma_peer_new(ibv_ctx, &pr->peer))) {
 		MTT_RPMA_ERR(tr, "rpma_peer_new", ret);
 		return;
 	}

--- a/tests/multithreaded/mr/rpma_mr_get_ptr.c
+++ b/tests/multithreaded/mr/rpma_mr_get_ptr.c
@@ -26,17 +26,17 @@ static void
 prestate_init(void *prestate, struct mtt_result *tr)
 {
 	struct prestate *pr = (struct prestate *)prestate;
-	struct ibv_context *dev;
+	struct ibv_context *ibv_ctx;
 	void *mr_ptr_exp;
 	int ret;
 
 	if ((ret = rpma_utils_get_ibv_context(pr->addr,
-			RPMA_UTIL_IBV_CONTEXT_LOCAL, &dev))) {
+			RPMA_UTIL_IBV_CONTEXT_LOCAL, &ibv_ctx))) {
 		MTT_RPMA_ERR(tr, "rpma_utils_get_ibv_context", ret);
 		return;
 	}
 
-	if ((ret = rpma_peer_new(dev, &pr->peer))) {
+	if ((ret = rpma_peer_new(ibv_ctx, &pr->peer))) {
 		MTT_RPMA_ERR(tr, "rpma_peer_new", ret);
 		return;
 	}

--- a/tests/multithreaded/mr/rpma_mr_get_size.c
+++ b/tests/multithreaded/mr/rpma_mr_get_size.c
@@ -27,16 +27,16 @@ static void
 prestate_init(void *prestate, struct mtt_result *tr)
 {
 	struct prestate *pr = (struct prestate *)prestate;
-	struct ibv_context *dev;
+	struct ibv_context *ibv_ctx;
 	int ret;
 
 	if ((ret = rpma_utils_get_ibv_context(pr->addr,
-			RPMA_UTIL_IBV_CONTEXT_LOCAL, &dev))) {
+			RPMA_UTIL_IBV_CONTEXT_LOCAL, &ibv_ctx))) {
 		MTT_RPMA_ERR(tr, "rpma_utils_get_ibv_context", ret);
 		return;
 	}
 
-	if ((ret = rpma_peer_new(dev, &pr->peer))) {
+	if ((ret = rpma_peer_new(ibv_ctx, &pr->peer))) {
 		MTT_RPMA_ERR(tr, "rpma_peer_new", ret);
 		return;
 	}

--- a/tests/multithreaded/mr/rpma_mr_reg.c
+++ b/tests/multithreaded/mr/rpma_mr_reg.c
@@ -13,7 +13,7 @@
 struct prestate {
 	char *addr;
 	unsigned port;
-	struct ibv_context *dev;
+	struct ibv_context *ibv_ctx;
 	struct rpma_peer *peer;
 };
 
@@ -33,12 +33,12 @@ prestate_init(void *prestate, struct mtt_result *tr)
 	int ret;
 
 	if ((ret = rpma_utils_get_ibv_context(pr->addr,
-			RPMA_UTIL_IBV_CONTEXT_LOCAL, &pr->dev))) {
+			RPMA_UTIL_IBV_CONTEXT_LOCAL, &pr->ibv_ctx))) {
 		MTT_RPMA_ERR(tr, "rpma_utils_get_ibv_context", ret);
 		return;
 	}
 
-	if ((ret = rpma_peer_new(pr->dev, &pr->peer)))
+	if ((ret = rpma_peer_new(pr->ibv_ctx, &pr->peer)))
 		MTT_RPMA_ERR(tr, "rpma_peer_new", ret);
 }
 

--- a/tests/multithreaded/peer/rpma_peer_new.c
+++ b/tests/multithreaded/peer/rpma_peer_new.c
@@ -12,7 +12,7 @@
 
 struct prestate {
 	char *addr;
-	struct ibv_context *dev;
+	struct ibv_context *ibv_ctx;
 };
 
 struct state {
@@ -27,7 +27,7 @@ prestate_init(void *prestate, struct mtt_result *tr)
 {
 	struct prestate *pr = (struct prestate *)prestate;
 	int ret = rpma_utils_get_ibv_context(pr->addr,
-			RPMA_UTIL_IBV_CONTEXT_REMOTE, &pr->dev);
+			RPMA_UTIL_IBV_CONTEXT_REMOTE, &pr->ibv_ctx);
 	if (ret)
 		MTT_RPMA_ERR(tr, "rpma_utils_get_ibv_context", ret);
 }
@@ -59,7 +59,7 @@ thread(unsigned id, void *prestate, void *state,
 	struct state *st = (struct state *)state;
 
 	/* create a new peer object */
-	int ret = rpma_peer_new(pr->dev, &st->peer);
+	int ret = rpma_peer_new(pr->ibv_ctx, &st->peer);
 	if (ret) {
 		MTT_RPMA_ERR(result, "rpma_peer_new", ret);
 		return;

--- a/tests/multithreaded/utils/rpma_utils_get_ibv_context.c
+++ b/tests/multithreaded/utils/rpma_utils_get_ibv_context.c
@@ -22,12 +22,12 @@ thread(unsigned id, void *prestate, void *state,
 		struct mtt_result *result)
 {
 	struct prestate *ps = (struct prestate *)prestate;
-	struct ibv_context *dev = NULL;
+	struct ibv_context *ibv_ctx = NULL;
 	int ret;
 
 	/* obtain an IBV context for a local IP address */
 	ret = rpma_utils_get_ibv_context(ps->addr, RPMA_UTIL_IBV_CONTEXT_LOCAL,
-			&dev);
+			&ibv_ctx);
 	if (ret)
 		MTT_RPMA_ERR(result, "rpma_utils_get_ibv_context", ret);
 }

--- a/tests/multithreaded/utils/rpma_utils_ibv_context_is_odp_capable.c
+++ b/tests/multithreaded/utils/rpma_utils_ibv_context_is_odp_capable.c
@@ -17,7 +17,7 @@
 
 struct prestate {
 	char *addr;
-	struct ibv_context *dev;
+	struct ibv_context *ibv_ctx;
 	int is_odp_supported_exp;
 };
 
@@ -33,14 +33,14 @@ prestate_init(void *prestate, struct mtt_result *tr)
 
 	/* obtain an IBV context for a remote IP address */
 	ret = rpma_utils_get_ibv_context(pr->addr,
-			RPMA_UTIL_IBV_CONTEXT_REMOTE, &pr->dev);
+			RPMA_UTIL_IBV_CONTEXT_REMOTE, &pr->ibv_ctx);
 	if (ret) {
 		MTT_RPMA_ERR(tr, "rpma_utils_get_ibv_context", ret);
 		return;
 	}
 
 	/* check if the device supports On-Demand Paging */
-	ret = rpma_utils_ibv_context_is_odp_capable(pr->dev,
+	ret = rpma_utils_ibv_context_is_odp_capable(pr->ibv_ctx,
 				&pr->is_odp_supported_exp);
 	if (ret)
 		MTT_RPMA_ERR(tr, "rpma_utils_ibv_context_is_odp_capable", ret);
@@ -57,7 +57,7 @@ thread(unsigned id, void *prestate, void *state, struct mtt_result *tr)
 	int is_odp_supported;
 
 	/* check if the device supports On-Demand Paging */
-	int ret = rpma_utils_ibv_context_is_odp_capable(pr->dev,
+	int ret = rpma_utils_ibv_context_is_odp_capable(pr->ibv_ctx,
 				&is_odp_supported);
 	if (ret) {
 		MTT_RPMA_ERR(tr, "rpma_utils_ibv_context_is_odp_capable", ret);

--- a/tests/unit/common/mocks-ibverbs.c
+++ b/tests/unit/common/mocks-ibverbs.c
@@ -28,10 +28,10 @@ struct ibv_mr Ibv_mr;
  * ibv_query_device -- ibv_query_device() mock
  */
 int
-ibv_query_device(struct ibv_context *context,
+ibv_query_device(struct ibv_context *ibv_ctx,
 		struct ibv_device_attr *device_attr)
 {
-	assert_ptr_equal(context, MOCK_VERBS);
+	assert_ptr_equal(ibv_ctx, MOCK_VERBS);
 	assert_non_null(device_attr);
 
 	int ret = mock_type(int);
@@ -48,12 +48,12 @@ ibv_query_device(struct ibv_context *context,
  * ibv_query_device_ex_mock -- ibv_query_device_ex() mock
  */
 int
-ibv_query_device_ex_mock(struct ibv_context *context,
+ibv_query_device_ex_mock(struct ibv_context *ibv_ctx,
 		const struct ibv_query_device_ex_input *input,
 		struct ibv_device_attr_ex *attr,
 		size_t attr_size)
 {
-	assert_ptr_equal(context, MOCK_VERBS);
+	assert_ptr_equal(ibv_ctx, MOCK_VERBS);
 	assert_null(input);
 	assert_non_null(attr);
 	/* attr_size is provided by ibverbs - no validation needed */
@@ -72,10 +72,10 @@ ibv_query_device_ex_mock(struct ibv_context *context,
  * ibv_create_cq -- ibv_create_cq() mock
  */
 struct ibv_cq *
-ibv_create_cq(struct ibv_context *context, int cqe, void *cq_context,
+ibv_create_cq(struct ibv_context *ibv_ctx, int cqe, void *cq_context,
 		struct ibv_comp_channel *channel, int comp_vector)
 {
-	assert_ptr_equal(context, MOCK_VERBS);
+	assert_ptr_equal(ibv_ctx, MOCK_VERBS);
 	check_expected(cqe);
 	assert_ptr_equal(channel, MOCK_COMP_CHANNEL);
 	assert_int_equal(comp_vector, 0);
@@ -106,9 +106,9 @@ ibv_destroy_cq(struct ibv_cq *cq)
  * ibv_create_comp_channel -- ibv_create_comp_channel() mock
  */
 struct ibv_comp_channel *
-ibv_create_comp_channel(struct ibv_context *context)
+ibv_create_comp_channel(struct ibv_context *ibv_ctx)
 {
-	assert_ptr_equal(context, MOCK_VERBS);
+	assert_ptr_equal(ibv_ctx, MOCK_VERBS);
 
 	struct ibv_comp_channel *channel = mock_type(struct ibv_comp_channel *);
 	if (!channel) {

--- a/tests/unit/common/mocks-ibverbs.h
+++ b/tests/unit/common/mocks-ibverbs.h
@@ -59,7 +59,7 @@ struct ibv_post_recv_mock_args {
 };
 
 #ifdef ON_DEMAND_PAGING_SUPPORTED
-int ibv_query_device_ex_mock(struct ibv_context *context,
+int ibv_query_device_ex_mock(struct ibv_context *ibv_ctx,
 		const struct ibv_query_device_ex_input *input,
 		struct ibv_device_attr_ex *attr,
 		size_t attr_size);

--- a/tests/unit/common/mocks-rpma-cq.c
+++ b/tests/unit/common/mocks-rpma-cq.c
@@ -44,9 +44,9 @@ rpma_cq_wait(struct rpma_cq *cq)
  * rpma_cq_new -- rpma_cq_new() mock
  */
 int
-rpma_cq_new(struct ibv_context *dev, int cqe, struct rpma_cq **cq_ptr)
+rpma_cq_new(struct ibv_context *ibv_ctx, int cqe, struct rpma_cq **cq_ptr)
 {
-	assert_non_null(dev);
+	assert_non_null(ibv_ctx);
 	check_expected(cqe);
 	assert_non_null(cq_ptr);
 

--- a/tests/unit/common/mocks-rpma-utils.c
+++ b/tests/unit/common/mocks-rpma-utils.c
@@ -17,10 +17,10 @@
  * rpma_utils_ibv_context_is_odp_capable() mock
  */
 int
-rpma_utils_ibv_context_is_odp_capable(struct ibv_context *dev,
+rpma_utils_ibv_context_is_odp_capable(struct ibv_context *ibv_ctx,
 		int *is_odp_capable)
 {
-	assert_ptr_equal(dev, MOCK_VERBS);
+	assert_ptr_equal(ibv_ctx, MOCK_VERBS);
 	assert_non_null(is_odp_capable);
 
 	*is_odp_capable = mock_type(int);

--- a/tests/unit/utils/utils-get_ibv_context.c
+++ b/tests/unit/utils/utils-get_ibv_context.c
@@ -36,20 +36,20 @@ static void
 get_ibvc__addr_NULL(void **unused)
 {
 	/* run test */
-	struct ibv_context *dev = NULL;
+	struct ibv_context *ibv_ctx = NULL;
 	int ret = rpma_utils_get_ibv_context(NULL, RPMA_UTIL_IBV_CONTEXT_REMOTE,
-			&dev);
+			&ibv_ctx);
 
 	/* verify the results */
 	assert_int_equal(ret, RPMA_E_INVAL);
-	assert_null(dev);
+	assert_null(ibv_ctx);
 }
 
 /*
- * get_ibvc__dev_NULL - test NULL dev parameter
+ * get_ibvc__ibv_ctx_NULL - test NULL ibv_ctx parameter
  */
 static void
-get_ibvc__dev_NULL(void **unused)
+get_ibvc__ibv_ctx_NULL(void **unused)
 {
 	/* run test */
 	int ret = rpma_utils_get_ibv_context(MOCK_IP_ADDRESS,
@@ -66,20 +66,20 @@ static void
 get_ibvc__type_unknown(void **unused)
 {
 	/* run test */
-	struct ibv_context *dev = NULL;
+	struct ibv_context *ibv_ctx = NULL;
 	int ret = rpma_utils_get_ibv_context(MOCK_IP_ADDRESS,
-			TYPE_UNKNOWN, &dev);
+			TYPE_UNKNOWN, &ibv_ctx);
 
 	/* verify the results */
 	assert_int_equal(ret, RPMA_E_INVAL);
 }
 
 /*
- * get_ibvc__addr_NULL_dev_NULL_type_unknown - test NULL addr and dev parameter
- * and type == TYPE_UNKNOWN
+ * get_ibvc__addr_NULL_ibv_ctx_NULL_type_unknown - test NULL addr and
+ * ibv_ctx parameter and type == TYPE_UNKNOWN
  */
 static void
-get_ibvc__addr_NULL_dev_NULL_type_unknown(void **unused)
+get_ibvc__addr_NULL_ibv_ctx_NULL_type_unknown(void **unused)
 {
 	/* run test */
 	int ret = rpma_utils_get_ibv_context(NULL, TYPE_UNKNOWN, NULL);
@@ -106,13 +106,13 @@ get_ibvc__info_new_failed_E_PROVIDER(void **unused)
 	will_return_maybe(rdma_destroy_id, 0);
 
 	/* run test */
-	struct ibv_context *dev = NULL;
+	struct ibv_context *ibv_ctx = NULL;
 	int ret = rpma_utils_get_ibv_context(MOCK_IP_ADDRESS,
-			RPMA_UTIL_IBV_CONTEXT_REMOTE, &dev);
+			RPMA_UTIL_IBV_CONTEXT_REMOTE, &ibv_ctx);
 
 	/* verify the results */
 	assert_int_equal(ret, RPMA_E_PROVIDER);
-	assert_null(dev);
+	assert_null(ibv_ctx);
 }
 
 /*
@@ -131,13 +131,13 @@ get_ibvc__info_new_failed_E_NOMEM(void **unused)
 	will_return_maybe(rdma_destroy_id, 0);
 
 	/* run test */
-	struct ibv_context *dev = NULL;
+	struct ibv_context *ibv_ctx = NULL;
 	int ret = rpma_utils_get_ibv_context(MOCK_IP_ADDRESS,
-			RPMA_UTIL_IBV_CONTEXT_REMOTE, &dev);
+			RPMA_UTIL_IBV_CONTEXT_REMOTE, &ibv_ctx);
 
 	/* verify the results */
 	assert_int_equal(ret, RPMA_E_NOMEM);
-	assert_null(dev);
+	assert_null(ibv_ctx);
 }
 
 /*
@@ -159,13 +159,13 @@ get_ibvc__create_id_failed(void **unused)
 	will_return(rdma_create_id, MOCK_ERRNO);
 
 	/* run test */
-	struct ibv_context *dev = NULL;
+	struct ibv_context *ibv_ctx = NULL;
 	int ret = rpma_utils_get_ibv_context(MOCK_IP_ADDRESS,
-			RPMA_UTIL_IBV_CONTEXT_LOCAL, &dev);
+			RPMA_UTIL_IBV_CONTEXT_LOCAL, &ibv_ctx);
 
 	/* verify the results */
 	assert_int_equal(ret, RPMA_E_PROVIDER);
-	assert_null(dev);
+	assert_null(ibv_ctx);
 }
 
 /*
@@ -191,13 +191,13 @@ get_ibvc__bind_addr_failed_E_PROVIDER(void **unused)
 	will_return(rdma_destroy_id, 0);
 
 	/* run test */
-	struct ibv_context *dev = NULL;
+	struct ibv_context *ibv_ctx = NULL;
 	int ret = rpma_utils_get_ibv_context(MOCK_IP_ADDRESS,
-			RPMA_UTIL_IBV_CONTEXT_LOCAL, &dev);
+			RPMA_UTIL_IBV_CONTEXT_LOCAL, &ibv_ctx);
 
 	/* verify the results */
 	assert_int_equal(ret, RPMA_E_PROVIDER);
-	assert_null(dev);
+	assert_null(ibv_ctx);
 }
 
 /*
@@ -223,13 +223,13 @@ get_ibvc__resolve_addr_failed_E_PROVIDER(void **unused)
 	will_return(rdma_destroy_id, 0);
 
 	/* run test */
-	struct ibv_context *dev = NULL;
+	struct ibv_context *ibv_ctx = NULL;
 	int ret = rpma_utils_get_ibv_context(MOCK_IP_ADDRESS,
-			RPMA_UTIL_IBV_CONTEXT_REMOTE, &dev);
+			RPMA_UTIL_IBV_CONTEXT_REMOTE, &ibv_ctx);
 
 	/* verify the results */
 	assert_int_equal(ret, RPMA_E_PROVIDER);
-	assert_null(dev);
+	assert_null(ibv_ctx);
 }
 
 /*
@@ -254,13 +254,13 @@ get_ibvc__success_destroy_id_failed_passive(void **unused)
 	will_return(rdma_destroy_id, MOCK_ERRNO);
 
 	/* run test */
-	struct ibv_context *dev = NULL;
+	struct ibv_context *ibv_ctx = NULL;
 	int ret = rpma_utils_get_ibv_context(MOCK_IP_ADDRESS,
-			RPMA_UTIL_IBV_CONTEXT_LOCAL, &dev);
+			RPMA_UTIL_IBV_CONTEXT_LOCAL, &ibv_ctx);
 
 	/* verify the results */
 	assert_int_equal(ret, 0);
-	assert_ptr_equal(dev, MOCK_VERBS);
+	assert_ptr_equal(ibv_ctx, MOCK_VERBS);
 }
 
 /*
@@ -285,13 +285,13 @@ get_ibvc__success_destroy_id_failed_active(void **unused)
 	will_return(rdma_destroy_id, MOCK_ERRNO);
 
 	/* run test */
-	struct ibv_context *dev = NULL;
+	struct ibv_context *ibv_ctx = NULL;
 	int ret = rpma_utils_get_ibv_context(MOCK_IP_ADDRESS,
-			RPMA_UTIL_IBV_CONTEXT_REMOTE, &dev);
+			RPMA_UTIL_IBV_CONTEXT_REMOTE, &ibv_ctx);
 
 	/* verify the results */
 	assert_int_equal(ret, 0);
-	assert_ptr_equal(dev, MOCK_VERBS);
+	assert_ptr_equal(ibv_ctx, MOCK_VERBS);
 }
 
 /*
@@ -314,13 +314,13 @@ get_ibvc__success_passive(void **unused)
 	will_return(rdma_destroy_id, 0);
 
 	/* run test */
-	struct ibv_context *dev = NULL;
+	struct ibv_context *ibv_ctx = NULL;
 	int ret = rpma_utils_get_ibv_context(MOCK_IP_ADDRESS,
-			RPMA_UTIL_IBV_CONTEXT_LOCAL, &dev);
+			RPMA_UTIL_IBV_CONTEXT_LOCAL, &ibv_ctx);
 
 	/* verify the results */
 	assert_int_equal(ret, 0);
-	assert_ptr_equal(dev, MOCK_VERBS);
+	assert_ptr_equal(ibv_ctx, MOCK_VERBS);
 }
 
 /*
@@ -343,13 +343,13 @@ get_ibvc__success_active(void **unused)
 	will_return(rdma_destroy_id, 0);
 
 	/* run test */
-	struct ibv_context *dev = NULL;
+	struct ibv_context *ibv_ctx = NULL;
 	int ret = rpma_utils_get_ibv_context(MOCK_IP_ADDRESS,
-			RPMA_UTIL_IBV_CONTEXT_REMOTE, &dev);
+			RPMA_UTIL_IBV_CONTEXT_REMOTE, &ibv_ctx);
 
 	/* verify the results */
 	assert_int_equal(ret, 0);
-	assert_ptr_equal(dev, MOCK_VERBS);
+	assert_ptr_equal(ibv_ctx, MOCK_VERBS);
 }
 
 int
@@ -360,9 +360,9 @@ main(int argc, char *argv[])
 		cmocka_unit_test(sanity__type_unknown),
 
 		cmocka_unit_test(get_ibvc__addr_NULL),
-		cmocka_unit_test(get_ibvc__dev_NULL),
+		cmocka_unit_test(get_ibvc__ibv_ctx_NULL),
 		cmocka_unit_test(get_ibvc__type_unknown),
-		cmocka_unit_test(get_ibvc__addr_NULL_dev_NULL_type_unknown),
+		cmocka_unit_test(get_ibvc__addr_NULL_ibv_ctx_NULL_type_unknown),
 		cmocka_unit_test(get_ibvc__info_new_failed_E_PROVIDER),
 		cmocka_unit_test(get_ibvc__info_new_failed_E_NOMEM),
 		cmocka_unit_test(get_ibvc__create_id_failed),

--- a/tests/unit/utils/utils-ibv_context_is_odp_capable.c
+++ b/tests/unit/utils/utils-ibv_context_is_odp_capable.c
@@ -12,10 +12,10 @@
 #include "test-common.h"
 
 /*
- * ibvc_odp__dev_NULL -- dev NULL is invalid
+ * ibvc_odp__ibv_ctx_NULL -- ibv_ctx NULL is invalid
  */
 static void
-ibvc_odp__dev_NULL(void **unused)
+ibvc_odp__ibv_ctx_NULL(void **unused)
 {
 	/* run test */
 	int is_odp_capable;
@@ -39,10 +39,10 @@ ibvc_odp__cap_NULL(void **unused)
 }
 
 /*
- * ibvc_odp__dev_cap_NULL -- dev and is_odp_capable NULL are invalid
+ * ibvc_odp__ibv_ctx_cap_NULL -- ibv_ctx and is_odp_capable NULL are invalid
  */
 static void
-ibvc_odp__dev_cap_NULL(void **unused)
+ibvc_odp__ibv_ctx_cap_NULL(void **unused)
 {
 	/* run test */
 	int ret = rpma_utils_ibv_context_is_odp_capable(NULL, NULL);
@@ -163,9 +163,9 @@ main(int argc, char *argv[])
 
 	const struct CMUnitTest tests[] = {
 		/* rpma_utils_ibv_context_is_odp_capable() unit tests */
-		cmocka_unit_test(ibvc_odp__dev_NULL),
+		cmocka_unit_test(ibvc_odp__ibv_ctx_NULL),
 		cmocka_unit_test(ibvc_odp__cap_NULL),
-		cmocka_unit_test(ibvc_odp__dev_cap_NULL),
+		cmocka_unit_test(ibvc_odp__ibv_ctx_cap_NULL),
 		cmocka_unit_test(ibvc_odp__query_fail),
 		cmocka_unit_test(ibvc_odp__general_caps_no),
 		cmocka_unit_test(ibvc_odp__rc_caps_not_all),


### PR DESCRIPTION
ibv_context is referring by either ibv_ctx or ibv_ctx_ptr.
dev name is not used anywhere.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/pmem/rpma/1590)
<!-- Reviewable:end -->
