### PR TITLE
common: disable CentOS Stream CI build

### DIFF
--- a/.github/workflows/nightly_experimental.yml
+++ b/.github/workflows/nightly_experimental.yml
@@ -35,7 +35,9 @@ jobs:
                  "N=Fedora_Rawhide_SANITS     OS=fedora  OS_VER=rawhide  CC=clang  CI_SANITS=ON   PUSH_IMAGE=0",
                  "N=Fedora_Rawhide_no_SANITS  OS=fedora  OS_VER=rawhide  CC=clang  CI_SANITS=OFF  PUSH_IMAGE=1  REBUILD_ALWAYS=YES",
                  "N=Ubuntu_Rolling            OS=ubuntu  OS_VER=rolling  CC=clang  CI_SANITS=ON   PUSH_IMAGE=1  REBUILD_ALWAYS=YES",
-                 "N=CentOS_Stream             OS=centos  OS_VER=stream   CC=gcc    CI_SANITS=OFF  PUSH_IMAGE=1  REBUILD_ALWAYS=YES",
+                 # There is no official Docker image of CentOS Stream yet: https://hub.docker.com/_/centos
+                 # and the unofficial one used so far (tgagor/centos:stream) has stopped working, so we have to disable it.
+                 # "N=CentOS_Stream             OS=centos  OS_VER=stream   CC=gcc    CI_SANITS=OFF  PUSH_IMAGE=1  REBUILD_ALWAYS=YES",
                  "N=Arch_Linux_Latest      OS=archlinux  OS_VER=latest   CC=gcc    CI_SANITS=OFF  PUSH_IMAGE=1  REBUILD_ALWAYS=YES"]
     steps:
        - name: Clone the git repo


### PR DESCRIPTION
There is still no official Docker image of CentOS Stream yet:
https://hub.docker.com/_/centos
and the unofficial one used so far (tgagor/centos:stream)
has stopped working, so we have to disable it.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/pmem/rpma/1599)
<!-- Reviewable:end -->
