### PR TITLE
rpma: fix indentations in enum rpma_conn_event

### DIFF
--- a/src/include/librpma.h
+++ b/src/include/librpma.h
@@ -1615,9 +1615,9 @@ int rpma_conn_get_event_fd(const struct rpma_conn *conn, int *fd);
 enum rpma_conn_event {
 	RPMA_CONN_UNDEFINED = -1,	/* Undefined connection event */
 	RPMA_CONN_ESTABLISHED,		/* Connection established */
-	RPMA_CONN_CLOSED,			/* Connection closed */
-	RPMA_CONN_LOST,				/* Connection lost */
-	RPMA_CONN_REJECTED			/* Connection rejected */
+	RPMA_CONN_CLOSED,		/* Connection closed */
+	RPMA_CONN_LOST,			/* Connection lost */
+	RPMA_CONN_REJECTED		/* Connection rejected */
 };
 
 /** 3


### PR DESCRIPTION


<!-- Reviewable:start -->
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/pmem/rpma/1602)
<!-- Reviewable:end -->
