### PR TITLE
test: fix and enable the rpma_conn_get_private_data MT test

### DIFF
--- a/tests/multithreaded/conn/CMakeLists.txt
+++ b/tests/multithreaded/conn/CMakeLists.txt
@@ -1,6 +1,6 @@
 #
 # SPDX-License-Identifier: BSD-3-Clause
-# Copyright 2021, Intel Corporation
+# Copyright 2021-2022, Intel Corporation
 #
 
 include(../../cmake/ctest_helpers.cmake)
@@ -23,12 +23,7 @@ add_multithreaded(NAME conn BIN rpma_conn_cfg_set_sq_size
 	SRCS rpma_conn_cfg_set_sq_size.c rpma_conn_cfg_common.c)
 add_multithreaded(NAME conn BIN rpma_conn_cfg_set_timeout
 	SRCS rpma_conn_cfg_set_timeout.c)
-#
-# XXX Disable the multithreaded-conn-rpma_conn_get_private_data_0_none test
-# temporarily, because it fails very often. Enable it again,
-# when the interprocess synchronization is implemented in MT-tests.
-#
-#add_multithreaded(NAME conn BIN rpma_conn_get_private_data
-#	SRCS rpma_conn_get_private_data.c server_rpma_conn_get_private_data.c)
+add_multithreaded(NAME conn BIN rpma_conn_get_private_data
+	SRCS rpma_conn_get_private_data.c server_rpma_conn_get_private_data.c)
 add_multithreaded(NAME conn BIN rpma_conn_req_new
 	SRCS rpma_conn_req_new.c)


### PR DESCRIPTION
The client sometimes has to wait for the server to start listening,
so the client should retry to connect to the server several
times.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/pmem/rpma/1604)
<!-- Reviewable:end -->
