### PR TITLE
rpma: add RPMA_CONN_UNREACHABLE to handle RDMA_CM_EVENT_UNREACHABLE

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Added
+- APIs:
+  - RPMA_CONN_UNREACHABLE enum rpma_conn_event to handle RDMA_CM_EVENT_UNREACHABLE
+
 ### Fixed
 - APIs:
   - rpma_log_init - cannot fail to set the default log function now

--- a/src/conn.c
+++ b/src/conn.c
@@ -182,6 +182,9 @@ rpma_conn_next_event(struct rpma_conn *conn, enum rpma_conn_event *event)
 		case RDMA_CM_EVENT_REJECTED:
 			*event = RPMA_CONN_REJECTED;
 			break;
+		case RDMA_CM_EVENT_UNREACHABLE:
+			*event = RPMA_CONN_UNREACHABLE;
+			break;
 		default:
 			RPMA_LOG_WARNING("%s: %s",
 					rpma_utils_conn_event_2str(*event),

--- a/src/include/librpma.h
+++ b/src/include/librpma.h
@@ -1617,7 +1617,8 @@ enum rpma_conn_event {
 	RPMA_CONN_ESTABLISHED,		/* Connection established */
 	RPMA_CONN_CLOSED,		/* Connection closed */
 	RPMA_CONN_LOST,			/* Connection lost */
-	RPMA_CONN_REJECTED		/* Connection rejected */
+	RPMA_CONN_REJECTED,		/* Connection rejected */
+	RPMA_CONN_UNREACHABLE		/* Connection unreachable */
 };
 
 /** 3
@@ -1634,6 +1635,7 @@ enum rpma_conn_event {
  *		RPMA_CONN_CLOSED,
  *		RPMA_CONN_LOST,
  *		RPMA_CONN_REJECTED,
+ *		RPMA_CONN_UNREACHABLE
  *	};
  *
  *	int rpma_conn_next_event(struct rpma_conn *conn,
@@ -1647,6 +1649,7 @@ enum rpma_conn_event {
  * - RPMA_CONN_CLOSED - connection closed
  * - RPMA_CONN_LOST - connection lost
  * - RPMA_CONN_REJECTED - connection rejected
+ * - RPMA_CONN_UNREACHABLE - connection unreachable
  *
  * RETURN VALUE
  * The rpma_conn_next_event() function returns 0 on success or a negative
@@ -1680,7 +1683,8 @@ int rpma_conn_next_event(struct rpma_conn *conn, enum rpma_conn_event *event);
  *		RPMA_CONN_ESTABLISHED,
  *		RPMA_CONN_CLOSED,
  *		RPMA_CONN_LOST,
- *		RPMA_CONN_REJECTED
+ *		RPMA_CONN_REJECTED,
+ *		RPMA_CONN_UNREACHABLE
  *	};
  *
  * DESCRIPTION

--- a/src/rpma.c
+++ b/src/rpma.c
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: BSD-3-Clause
-/* Copyright 2020-2021, Intel Corporation */
+/* Copyright 2020-2022, Intel Corporation */
 
 /*
  * rpma.c -- entry points for librpma
@@ -129,6 +129,8 @@ rpma_utils_conn_event_2str(enum rpma_conn_event conn_event)
 		return "Connection lost";
 	case RPMA_CONN_REJECTED:
 		return "Connection rejected";
+	case RPMA_CONN_UNREACHABLE:
+		return "Connection unreachable";
 	default:
 		return "Unsupported connection event";
 	}

--- a/tests/unit/utils/utils-conn_event_2str.c
+++ b/tests/unit/utils/utils-conn_event_2str.c
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: BSD-3-Clause
-/* Copyright 2020-2021, Intel Corporation */
+/* Copyright 2020-2022, Intel Corporation */
 
 /*
  * utils-conn_event_2str.c -- a unit test for rpma_utils_conn_event_2str()
@@ -64,6 +64,17 @@ conn_event_2str__CONN_REJECTED(void **unused)
 }
 
 /*
+ * conn_event_2str__CONN_UNREACHABLE - sanity test for
+ * rpma_utils_conn_event_2str()
+ */
+static void
+conn_event_2str__CONN_UNREACHABLE(void **unused)
+{
+	assert_string_equal(rpma_utils_conn_event_2str(RPMA_CONN_UNREACHABLE),
+		"Connection unreachable");
+}
+
+/*
  * conn_event_2str__CONN_UNSUPPORTED - sanity test for
  * rpma_utils_conn_event_2str()
  */
@@ -84,6 +95,7 @@ main(int argc, char *argv[])
 		cmocka_unit_test(conn_event_2str__CONN_CLOSED),
 		cmocka_unit_test(conn_event_2str__CONN_LOST),
 		cmocka_unit_test(conn_event_2str__CONN_REJECTED),
+		cmocka_unit_test(conn_event_2str__CONN_UNREACHABLE),
 		cmocka_unit_test(conn_event_2str__CONN_UNSUPPORTED),
 	};
 


### PR DESCRIPTION
RDMA_CM_EVENT_UNREACHABLE occurs sometimes in MT-tests.

Requires:
- [x] #1605

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/pmem/rpma/1606)
<!-- Reviewable:end -->
