### PR TITLE
rpma: implement shared RQ configuration

### DIFF
--- a/doc/manuals_3.txt
+++ b/doc/manuals_3.txt
@@ -61,6 +61,12 @@ rpma_read.3
 rpma_recv.3
 rpma_send.3
 rpma_send_with_imm.3
+rpma_srq_cfg_delete.3
+rpma_srq_cfg_get_rcq_size.3
+rpma_srq_cfg_get_rq_size.3
+rpma_srq_cfg_new.3
+rpma_srq_cfg_set_rcq_size.3
+rpma_srq_cfg_set_rq_size.3
 rpma_utils_conn_event_2str.3
 rpma_utils_get_ibv_context.3
 rpma_utils_ibv_context_is_odp_capable.3

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -1,7 +1,7 @@
 #
 # SPDX-License-Identifier: BSD-3-Clause
 # Copyright 2020, Intel Corporation
-# Copyright 2021, Fujitsu
+# Copyright 2021-2022, Fujitsu
 #
 
 add_cstyle(src
@@ -28,7 +28,8 @@ set(SOURCES
 	peer_cfg.c
 	private_data.c
 	rpma_err.c
-	rpma.c)
+	rpma.c
+	srq_cfg.c)
 
 add_library(rpma SHARED ${SOURCES})
 

--- a/src/include/librpma.h
+++ b/src/include/librpma.h
@@ -2276,6 +2276,196 @@ int rpma_ep_next_conn_req(struct rpma_ep *ep,
 int rpma_conn_req_get_private_data(const struct rpma_conn_req *req,
 		struct rpma_conn_private_data *pdata);
 
+/* shared RQ configuration */
+
+struct rpma_srq_cfg;
+
+/** 3
+ * rpma_srq_cfg_new - create a new shared RQ configuration object
+ *
+ * SYNOPSIS
+ *
+ *	#include <librpma.h>
+ *
+ *	struct rpma_srq_cfg;
+ *	int rpma_srq_cfg_new(struct rpma_srq_cfg **cfg_ptr);
+ *
+ * DESCRIPTION
+ * rpma_srq_cfg_new() creates a new shared RQ configuration object
+ * and fills it with the default values:
+ *
+ *	.rcq_size = 100
+ *	.rq_size = 100
+ *
+ * RETURN VALUE
+ * The rpma_srq_cfg_new() function returns 0 on success or a negative
+ * error code on failure. rpma_srq_cfg_new() does not set *cfg_ptr value
+ * on failure.
+ *
+ * ERRORS
+ * rpma_srq_cfg_new() can fail with the following error:
+ *
+ * - RPMA_E_INVAL - cfg_ptr is NULL
+ * - RPMA_E_NOMEM - out of memory
+ *
+ * SEE ALSO
+ * rpma_srq_cfg_delete(3), rpma_srq_cfg_get_rcq_size(3),
+ * rpma_srq_cfg_get_rq_size(3), rpma_srq_cfg_set_rcq_size(3),
+ * rpma_srq_cfg_set_rq_size(3), librpma(7) and https://pmem.io/rpma/
+ */
+int rpma_srq_cfg_new(struct rpma_srq_cfg **cfg_ptr);
+
+/** 3
+ * rpma_srq_cfg_delete - delete the shared RQ configuration object
+ *
+ * SYNOPSIS
+ *
+ *	#include <librpma.h>
+ *
+ *	struct rpma_srq_cfg;
+ *	int rpma_srq_cfg_delete(struct rpma_srq_cfg **cfg_ptr);
+ *
+ * DESCRIPTION
+ * rpma_srq_cfg_delete() deletes the shared RQ configuration object.
+ *
+ * RETURN VALUE
+ * The rpma_srq_cfg_delete() function returns 0 on success or a negative
+ * error code on failure. rpma_srq_cfg_delete() sets *cfg_ptr value to NULL
+ * on success and on failure.
+ *
+ * ERRORS
+ * rpma_srq_cfg_delete() can fail with the following error:
+ *
+ * - RPMA_E_INVAL - cfg_ptr is NULL
+ *
+ * SEE ALSO
+ * rpma_srq_cfg_new(3), librpma(7) and https://pmem.io/rpma/
+ */
+int rpma_srq_cfg_delete(struct rpma_srq_cfg **cfg_ptr);
+
+/** 3
+ * rpma_srq_cfg_set_rq_size - set RQ size for the shared RQ
+ *
+ * SYNOPSIS
+ *
+ *	#include <librpma.h>
+ *
+ *	struct rpma_srq_cfg;
+ *	int rpma_srq_cfg_set_rq_size(struct rpma_srq_cfg *cfg,
+ *			uint32_t rq_size);
+ *
+ * DESCRIPTION
+ * rpma_srq_cfg_set_rq_size() sets the RQ size for the shared RQ.
+ * If this function is not called, the rq_size has the default
+ * value (100) set by rpma_srq_cfg_new(3).
+ *
+ * RETURN VALUE
+ * The rpma_srq_cfg_set_rq_size() function returns 0 on success or a negative
+ * error code on failure.
+ *
+ * ERRORS
+ * rpma_srq_cfg_set_rq_size() can fail with the following error:
+ *
+ * - RPMA_E_INVAL - cfg is NULL
+ *
+ * SEE ALSO
+ * rpma_srq_cfg_new(3), rpma_srq_cfg_get_rq_size(3), librpma(7) and
+ * https://pmem.io/rpma/
+ */
+int rpma_srq_cfg_set_rq_size(struct rpma_srq_cfg *cfg, uint32_t rq_size);
+
+/** 3
+ * rpma_srq_cfg_get_rq_size - get RQ size for the shared RQ
+ *
+ * SYNOPSIS
+ *
+ *	#include <librpma.h>
+ *
+ *	struct rpma_srq_cfg;
+ *	int rpma_srq_cfg_get_rq_size(const struct rpma_srq_cfg *cfg,
+ *			uint32_t *rq_size);
+ *
+ * DESCRIPTION
+ * rpma_srq_cfg_get_rq_size() gets the RQ size for the shared RQ.
+ *
+ * RETURN VALUE
+ * The rpma_srq_cfg_get_rq_size() function returns 0 on success or a negative
+ * error code on failure. rpma_srq_cfg_get_rq_size() does not set
+ * *rq_size value on failure.
+ *
+ * ERRORS
+ * rpma_srq_cfg_get_rq_size() can fail with the following error:
+ *
+ * - RPMA_E_INVAL - cfg or rq_size is NULL
+ *
+ * SEE ALSO
+ * rpma_srq_cfg_new(3), rpma_srq_cfg_set_rq_size(3), librpma(7) and
+ * https://pmem.io/rpma/
+ */
+int rpma_srq_cfg_get_rq_size(const struct rpma_srq_cfg *cfg, uint32_t *rq_size);
+
+/** 3
+ * rpma_srq_cfg_set_rcq_size - set receive CQ size for the shared RQ
+ *
+ * SYNOPSIS
+ *
+ *	#include <librpma.h>
+ *
+ *	struct rpma_srq_cfg;
+ *	int rpma_srq_cfg_set_rcq_size(struct rpma_srq_cfg *cfg,
+ *			uint32_t rcq_size);
+ *
+ * DESCRIPTION
+ * rpma_srq_cfg_set_rcq_size() sets the receive CQ size for the shared RQ.
+ * If this function is not called, the rcq_size has the default value (100)
+ * set by rpma_srq_cfg_new(3).
+ *
+ * RETURN VALUE
+ * The rpma_srq_cfg_set_rcq_size() function returns 0 on success or
+ * a negative error code on failure.
+ *
+ * ERRORS
+ * rpma_srq_cfg_set_rcq_size() can fail with the following error:
+ *
+ * - RPMA_E_INVAL - cfg is NULL
+ *
+ * SEE ALSO
+ * rpma_srq_cfg_get_rcq_size(3), rpma_srq_cfg_new(3), librpma(7) and
+ * https://pmem.io/rpma/
+ */
+int rpma_srq_cfg_set_rcq_size(struct rpma_srq_cfg *cfg, uint32_t rcq_size);
+
+/** 3
+ * rpma_srq_cfg_get_rcq_size - get receive CQ size for the shared RQ
+ *
+ * SYNOPSIS
+ *
+ *	#include <librpma.h>
+ *
+ *	struct rpma_srq_cfg;
+ *	int rpma_srq_cfg_get_rcq_size(const struct rpma_srq_cfg *cfg,
+ *			uint32_t *rcq_size);
+ *
+ * DESCRIPTION
+ * rpma_srq_cfg_get_rcq_size() gets the receive CQ size for the shared RQ.
+ *
+ * RETURN VALUE
+ * The rpma_srq_cfg_get_rcq_size() function returns 0 on success or
+ * a negative error code on failure. rpma_srq_cfg_get_rcq_size() does not
+ * set *rcq_size value on failure.
+ *
+ * ERRORS
+ * rpma_srq_cfg_get_rcq_size() can fail with the following error:
+ *
+ * - RPMA_E_INVAL - cfg or rcq_size is NULL
+ *
+ * SEE ALSO
+ * rpma_srq_cfg_new(3), rpma_srq_cfg_set_rcq_size(3), librpma(7) and
+ * https://pmem.io/rpma/
+ */
+int rpma_srq_cfg_get_rcq_size(const struct rpma_srq_cfg *cfg,
+		uint32_t *rcq_size);
+
 /* remote memory access functions */
 
 /* generate operation completion on error */

--- a/src/librpma.map
+++ b/src/librpma.map
@@ -71,6 +71,12 @@ LIBRPMA_0.12 {
 		rpma_recv;
 		rpma_send;
 		rpma_send_with_imm;
+		rpma_srq_cfg_delete;
+		rpma_srq_cfg_get_rcq_size;
+		rpma_srq_cfg_get_rq_size;
+		rpma_srq_cfg_new;
+		rpma_srq_cfg_set_rcq_size;
+		rpma_srq_cfg_set_rq_size;
 		rpma_utils_conn_event_2str;
 		rpma_utils_get_ibv_context;
 		rpma_utils_ibv_context_is_odp_capable;

--- a/src/srq_cfg.c
+++ b/src/srq_cfg.c
@@ -1,0 +1,121 @@
+// SPDX-License-Identifier: BSD-3-Clause
+/* Copyright 2022, Fujitsu */
+
+/*
+ * srq_cfg.c -- librpma shared-RQ-configuration-related implementations
+ */
+
+#include <limits.h>
+#include <stdlib.h>
+
+#include "librpma.h"
+
+#ifdef TEST_MOCK_ALLOC
+#include "cmocka_alloc.h"
+#endif
+
+#define RPMA_DEFAULT_SRQ_SIZE	100
+
+struct rpma_srq_cfg {
+	uint32_t rq_size;
+	uint32_t rcq_size;
+};
+
+static struct rpma_srq_cfg Srq_cfg_default  = {
+	.rq_size = RPMA_DEFAULT_SRQ_SIZE,
+	.rcq_size = RPMA_DEFAULT_SRQ_SIZE
+};
+
+/* public librpma API */
+
+/*
+ * rpma_srq_cfg_new -- create a new shared RQ configuration
+ */
+int
+rpma_srq_cfg_new(struct rpma_srq_cfg **cfg_ptr)
+{
+	if (cfg_ptr == NULL)
+		return RPMA_E_INVAL;
+
+	*cfg_ptr = malloc(sizeof(struct rpma_srq_cfg));
+	if (*cfg_ptr == NULL)
+		return RPMA_E_NOMEM;
+
+	memcpy(*cfg_ptr, &Srq_cfg_default, sizeof(struct rpma_srq_cfg));
+
+	return 0;
+}
+
+/*
+ * rpma_srq_cfg_delete -- delete the shared RQ configuration
+ */
+int
+rpma_srq_cfg_delete(struct rpma_srq_cfg **cfg_ptr)
+{
+	if (cfg_ptr == NULL)
+		return RPMA_E_INVAL;
+
+	if (*cfg_ptr == NULL)
+		return 0;
+
+	free(*cfg_ptr);
+	*cfg_ptr = NULL;
+
+	return 0;
+}
+
+/*
+ * rpma_srq_cfg_set_rq_size -- set shared RQ size
+ */
+int
+rpma_srq_cfg_set_rq_size(struct rpma_srq_cfg *cfg, uint32_t rq_size)
+{
+	if (cfg == NULL)
+		return RPMA_E_INVAL;
+
+	cfg->rq_size = rq_size;
+
+	return 0;
+}
+
+/*
+ * rpma_srq_cfg_get_rq_size -- get shared RQ size
+ */
+int
+rpma_srq_cfg_get_rq_size(const struct rpma_srq_cfg *cfg, uint32_t *rq_size)
+{
+	if (cfg == NULL || rq_size == NULL)
+		return RPMA_E_INVAL;
+
+	*rq_size = cfg->rq_size;
+
+	return 0;
+}
+
+/*
+ * rpma_srq_cfg_set_rcq_size -- set shared receive CQ size
+ */
+int
+rpma_srq_cfg_set_rcq_size(struct rpma_srq_cfg *cfg, uint32_t rcq_size)
+{
+	if (cfg == NULL)
+		return RPMA_E_INVAL;
+
+	cfg->rcq_size = rcq_size;
+
+	return 0;
+}
+
+/*
+ * rpma_srq_cfg_get_rcq_size -- get shared receive CQ size
+ */
+int
+rpma_srq_cfg_get_rcq_size(const struct rpma_srq_cfg *cfg, uint32_t *rcq_size)
+{
+	if (cfg == NULL || rcq_size == NULL)
+		return RPMA_E_INVAL;
+
+	*rcq_size = cfg->rcq_size;
+
+	return 0;
+}

--- a/tests/unit/CMakeLists.txt
+++ b/tests/unit/CMakeLists.txt
@@ -1,7 +1,7 @@
 #
 # SPDX-License-Identifier: BSD-3-Clause
 # Copyright 2020, Intel Corporation
-# Copyright 2021, Fujitsu
+# Copyright 2021-2022, Fujitsu
 #
 
 add_subdirectory(conn)
@@ -18,6 +18,7 @@ add_subdirectory(mr)
 add_subdirectory(peer)
 add_subdirectory(peer_cfg)
 add_subdirectory(private_data)
+add_subdirectory(srq_cfg)
 add_subdirectory(template)
 add_subdirectory(utils)
 

--- a/tests/unit/srq_cfg/CMakeLists.txt
+++ b/tests/unit/srq_cfg/CMakeLists.txt
@@ -1,0 +1,28 @@
+#
+# SPDX-License-Identifier: BSD-3-Clause
+# Copyright 2022, Fujitsu
+#
+
+include(../../cmake/ctest_helpers.cmake)
+
+function(add_test_srq_cfg name)
+       set(name srq_cfg-${name})
+       build_test_src(UNIT NAME ${name} SRCS
+              ${name}.c
+              srq_cfg-common.c
+              ${TEST_UNIT_COMMON_DIR}/mocks-stdlib.c
+              ${LIBRPMA_SOURCE_DIR}/srq_cfg.c)
+
+       target_compile_definitions(${name} PRIVATE TEST_MOCK_ALLOC)
+
+       set_target_properties(${name}
+              PROPERTIES
+              LINK_FLAGS "-Wl,--wrap=_test_malloc")
+
+       add_test_generic(NAME ${name} TRACERS none)
+endfunction()
+
+add_test_srq_cfg(delete)
+add_test_srq_cfg(rcq_size)
+add_test_srq_cfg(rq_size)
+add_test_srq_cfg(new)

--- a/tests/unit/srq_cfg/srq_cfg-common.c
+++ b/tests/unit/srq_cfg/srq_cfg-common.c
@@ -1,0 +1,51 @@
+// SPDX-License-Identifier: BSD-3-Clause
+/* Copyright 2022, Fujitsu */
+
+/*
+ * srq_cfg-common.c -- the srq_cfg unit tests common functions
+ */
+
+#include "srq_cfg-common.h"
+
+/*
+ * setup__srq_cfg -- prepare a new rpma_srq_cfg
+ */
+int
+setup__srq_cfg(void **cstate_ptr)
+{
+	static struct srq_cfg_test_state cstate = {0};
+
+	/* configure mocks */
+	will_return(__wrap__test_malloc, MOCK_OK);
+
+	/* prepare an object */
+	int ret = rpma_srq_cfg_new(&cstate.cfg);
+
+	/* verify the results */
+	assert_int_equal(ret, MOCK_OK);
+	assert_non_null(cstate.cfg);
+
+	*cstate_ptr = &cstate;
+
+	return 0;
+}
+
+/*
+ * teardown__srq_cfg -- delete the rpma_srq_cfg
+ */
+int
+teardown__srq_cfg(void **cstate_ptr)
+{
+	struct srq_cfg_test_state *cstate = *cstate_ptr;
+
+	/* prepare an object */
+	int ret = rpma_srq_cfg_delete(&cstate->cfg);
+
+	/* verify the results */
+	assert_int_equal(ret, MOCK_OK);
+	assert_null(cstate->cfg);
+
+	*cstate_ptr = NULL;
+
+	return 0;
+}

--- a/tests/unit/srq_cfg/srq_cfg-common.h
+++ b/tests/unit/srq_cfg/srq_cfg-common.h
@@ -1,0 +1,25 @@
+/* SPDX-License-Identifier: BSD-3-Clause */
+/* Copyright 2022, Fujitsu */
+
+/*
+ * srq_cfg-common.h -- the srq_cfg unit tests common definitions
+ */
+
+#ifndef SRQ_CFG_COMMON
+#define SRQ_CFG_COMMON
+
+#include "cmocka_headers.h"
+#include "librpma.h"
+#include "test-common.h"
+
+/*
+ * All the resources used between setup__srq_cfg and teardown__srq_cfg
+ */
+struct srq_cfg_test_state {
+	struct rpma_srq_cfg *cfg;
+};
+
+int setup__srq_cfg(void **cstate_ptr);
+int teardown__srq_cfg(void **cstate_ptr);
+
+#endif /* SRQ_CFG_COMMON */

--- a/tests/unit/srq_cfg/srq_cfg-delete.c
+++ b/tests/unit/srq_cfg/srq_cfg-delete.c
@@ -1,0 +1,51 @@
+// SPDX-License-Identifier: BSD-3-Clause
+/* Copyright 2022, Fujitsu */
+
+/*
+ * srq_cfg-delete.c -- the rpma_srq_cfg_delete() unit tests
+ *
+ * APIs covered:
+ * - rpma_srq_cfg_delete()
+ */
+
+#include "srq_cfg-common.h"
+
+/*
+ * delete__cfg_ptr_NULL -- NULL cfg_ptr is invalid
+ */
+static void
+delete__cfg_ptr_NULL(void **unused)
+{
+	/* run test */
+	int ret = rpma_srq_cfg_delete(NULL);
+
+	/* verify the results */
+	assert_int_equal(ret, RPMA_E_INVAL);
+}
+
+/*
+ * delete__cfg_NULL -- NULL cfg is valid - quick exit
+ */
+static void
+delete__cfg_NULL(void **unused)
+{
+	/* run test */
+	struct rpma_srq_cfg *cfg = NULL;
+	int ret = rpma_srq_cfg_delete(&cfg);
+
+	/* verify the results */
+	assert_int_equal(ret, MOCK_OK);
+	assert_null(cfg);
+}
+
+static const struct CMUnitTest test_delete[] = {
+	/* rpma_srq_cfg_delete() unit tests */
+	cmocka_unit_test(delete__cfg_ptr_NULL),
+	cmocka_unit_test(delete__cfg_NULL),
+};
+
+int
+main(int argc, char *argv[])
+{
+	return cmocka_run_group_tests(test_delete, NULL, NULL);
+}

--- a/tests/unit/srq_cfg/srq_cfg-new.c
+++ b/tests/unit/srq_cfg/srq_cfg-new.c
@@ -1,0 +1,80 @@
+// SPDX-License-Identifier: BSD-3-Clause
+/* Copyright 2022, Fujitsu */
+
+/*
+ * srq_cfg-new.c -- the rpma_srq_cfg_new() unit tests
+ *
+ * API covered:
+ * - rpma_srq_cfg_new()
+ */
+
+#include "srq_cfg-common.h"
+
+/*
+ * new__cfg_ptr_NULL -- NULL cfg_ptr is invalid
+ */
+static void
+new__cfg_ptr_NULL(void **unused)
+{
+	/* configure mocks */
+	will_return_maybe(__wrap__test_malloc, MOCK_OK);
+
+	/* run test */
+	int ret = rpma_srq_cfg_new(NULL);
+
+	/* verify the results */
+	assert_int_equal(ret, RPMA_E_INVAL);
+}
+
+/*
+ * new__malloc_ERRNO -- malloc() fails with MOCK_ERRNO
+ */
+static void
+new__malloc_ERRNO(void **unused)
+{
+	/* configure mocks */
+	will_return(__wrap__test_malloc, MOCK_ERRNO);
+
+	/* run test */
+	struct rpma_srq_cfg *cfg = NULL;
+	int ret = rpma_srq_cfg_new(&cfg);
+
+	/* verify the results */
+	assert_int_equal(ret, RPMA_E_NOMEM);
+	assert_null(cfg);
+}
+
+/*
+ * new__success -- all is OK
+ */
+static void
+new__success(void **cstate_ptr)
+{
+	struct srq_cfg_test_state *cstate = *cstate_ptr;
+
+	uint32_t rq_size, rcq_size;
+	int ret;
+
+	/* collect values and compare to defaults */
+	ret = rpma_srq_cfg_get_rq_size(cstate->cfg, &rq_size);
+	assert_int_equal(ret, MOCK_OK);
+	assert_int_equal(rq_size, 100);
+
+	ret = rpma_srq_cfg_get_rcq_size(cstate->cfg, &rcq_size);
+	assert_int_equal(ret, MOCK_OK);
+	assert_int_equal(rcq_size, 100);
+}
+
+static const struct CMUnitTest test_new[] = {
+	/* rpma_srq_cfg_new() unit tests */
+	cmocka_unit_test(new__cfg_ptr_NULL),
+	cmocka_unit_test(new__malloc_ERRNO),
+	cmocka_unit_test_setup_teardown(new__success,
+			setup__srq_cfg, teardown__srq_cfg),
+};
+
+int
+main(int argc, char *argv[])
+{
+	return cmocka_run_group_tests(test_new, NULL, NULL);
+}

--- a/tests/unit/srq_cfg/srq_cfg-rcq_size.c
+++ b/tests/unit/srq_cfg/srq_cfg-rcq_size.c
@@ -1,0 +1,99 @@
+// SPDX-License-Identifier: BSD-3-Clause
+/* Copyright 2022, Fujitsu */
+
+/*
+ * srq_cfg-cq_size.c -- the rpma_srq_cfg_set/get_rcq_size() unit tests
+ *
+ * APIs covered:
+ * - rpma_srq_cfg_set_rcq_size()
+ * - rpma_srq_cfg_get_rcq_size()
+ */
+
+#include "srq_cfg-common.h"
+#include "test-common.h"
+
+/*
+ * set__cfg_NULL -- NULL cfg is invalid
+ */
+static void
+set__cfg_NULL(void **unused)
+{
+	/* run test */
+	int ret = rpma_srq_cfg_set_rcq_size(NULL, MOCK_Q_SIZE);
+
+	/* verify the results */
+	assert_int_equal(ret, RPMA_E_INVAL);
+}
+
+/*
+ * get__cfg_NULL -- NULL cfg is invalid
+ */
+static void
+get__cfg_NULL(void **unused)
+{
+	/* run test */
+	uint32_t rcq_size;
+	int ret = rpma_srq_cfg_get_rcq_size(NULL, &rcq_size);
+
+	/* verify the results */
+	assert_int_equal(ret, RPMA_E_INVAL);
+}
+
+/*
+ * get__rcq_size_NULL -- NULL rcq_size is invalid
+ */
+static void
+get__rcq_size_NULL(void **cstate_ptr)
+{
+	struct srq_cfg_test_state *cstate = *cstate_ptr;
+
+	/* run test */
+	int ret = rpma_srq_cfg_get_rcq_size(cstate->cfg, NULL);
+
+	/* verify the results */
+	assert_int_equal(ret, RPMA_E_INVAL);
+}
+
+/*
+ * rcq_size__lifecycle -- happy day scenario
+ */
+static void
+rcq_size__lifecycle(void **cstate_ptr)
+{
+	struct srq_cfg_test_state *cstate = *cstate_ptr;
+
+	/* run test */
+	int ret = rpma_srq_cfg_set_rcq_size(cstate->cfg, MOCK_Q_SIZE);
+
+	/* verify the results */
+	assert_int_equal(ret, MOCK_OK);
+
+	/* run test */
+	uint32_t rcq_size;
+	ret = rpma_srq_cfg_get_rcq_size(cstate->cfg, &rcq_size);
+
+	/* verify the results */
+	assert_int_equal(ret, MOCK_OK);
+	assert_int_equal(rcq_size, MOCK_Q_SIZE);
+}
+
+
+static const struct CMUnitTest test_rcq_size[] = {
+	/* rpma_srq_cfg_set_rcq_size() unit tests */
+	cmocka_unit_test(set__cfg_NULL),
+
+	/* rpma_srq_cfg_get_rcq_size() unit tests */
+	cmocka_unit_test(get__cfg_NULL),
+	cmocka_unit_test_setup_teardown(get__rcq_size_NULL,
+		setup__srq_cfg, teardown__srq_cfg),
+
+	/* rpma_srq_cfg_set/get_rcq_size() lifecycle */
+	cmocka_unit_test_setup_teardown(rcq_size__lifecycle,
+		setup__srq_cfg, teardown__srq_cfg),
+};
+
+int
+main(int argc, char *argv[])
+{
+	return cmocka_run_group_tests(test_rcq_size, NULL, NULL);
+}

--- a/tests/unit/srq_cfg/srq_cfg-rq_size.c
+++ b/tests/unit/srq_cfg/srq_cfg-rq_size.c
@@ -1,0 +1,95 @@
+// SPDX-License-Identifier: BSD-3-Clause
+/* Copyright 2022, Fujitsu */
+
+/*
+ * srq_cfg-rq_size.c -- the rpma_srq_cfg_set/get_rq_size() unit tests
+ *
+ * APIs covered:
+ * - rpma_srq_cfg_set_rq_size()
+ * - rpma_srq_cfg_get_rq_size()
+ */
+
+#include "srq_cfg-common.h"
+#include "test-common.h"
+
+/*
+ * set__cfg_NULL -- NULL cfg is invalid
+ */
+static void
+set__cfg_NULL(void **unused)
+{
+	/* run test */
+	int ret = rpma_srq_cfg_set_rq_size(NULL, MOCK_Q_SIZE);
+
+	/* verify the results */
+	assert_int_equal(ret, RPMA_E_INVAL);
+}
+
+/*
+ * get__cfg_NULL -- NULL cfg is invalid
+ */
+static void
+get__cfg_NULL(void **unused)
+{
+	/* run test */
+	uint32_t rq_size;
+	int ret = rpma_srq_cfg_get_rq_size(NULL, &rq_size);
+
+	/* verify the results */
+	assert_int_equal(ret, RPMA_E_INVAL);
+}
+
+/*
+ * get__rq_size_NULL -- NULL rq_size is invalid
+ */
+static void
+get__rq_size_NULL(void **cstate_ptr)
+{
+	struct srq_cfg_test_state *cstate = *cstate_ptr;
+
+	/* run test */
+	int ret = rpma_srq_cfg_get_rq_size(cstate->cfg, NULL);
+
+	/* verify the results */
+	assert_int_equal(ret, RPMA_E_INVAL);
+}
+
+/*
+ * rq_size__lifecycle -- happy day scenario
+ */
+static void
+rq_size__lifecycle(void **cstate_ptr)
+{
+	struct srq_cfg_test_state *cstate = *cstate_ptr;
+
+	/* run test */
+	int ret = rpma_srq_cfg_set_rq_size(cstate->cfg, MOCK_Q_SIZE);
+
+	/* verify the results */
+	assert_int_equal(ret, MOCK_OK);
+	uint32_t rq_size;
+	ret = rpma_srq_cfg_get_rq_size(cstate->cfg, &rq_size);
+	assert_int_equal(ret, MOCK_OK);
+	assert_int_equal(rq_size, MOCK_Q_SIZE);
+}
+
+
+static const struct CMUnitTest test_rq_size[] = {
+	/* rpma_srq_cfg_set_rq_size() unit tests */
+	cmocka_unit_test(set__cfg_NULL),
+
+	/* rpma_srq_cfg_get_rq_size() unit tests */
+	cmocka_unit_test(get__cfg_NULL),
+	cmocka_unit_test_setup_teardown(get__rq_size_NULL,
+		setup__srq_cfg, teardown__srq_cfg),
+
+	/* rpma_srq_cfg_set/get_rq_size() lifecycle */
+	cmocka_unit_test_setup_teardown(rq_size__lifecycle,
+		setup__srq_cfg, teardown__srq_cfg),
+};
+
+int
+main(int argc, char *argv[])
+{
+	return cmocka_run_group_tests(test_rq_size, NULL, NULL);
+}


### PR DESCRIPTION
add shared RQ configuration APIs and related unit tests.

Ref: #958

Note: this patch is the part of shared RQ feature.