### PR TITLE
rpma: fix rpma_log_init() and log's unit test

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Fixed
+- APIs:
+  - rpma_log_init - cannot fail to set the default log function now
+- unit tests of rpma_log_set_threshold and RPMA_LOG_* macros
 
 ## [0.13.0] - 2022-03-09
 ### Added

--- a/tests/unit/common/mocks-rpma-log_default.c
+++ b/tests/unit/common/mocks-rpma-log_default.c
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: BSD-3-Clause
-/* Copyright 2020, Intel Corporation */
+/* Copyright 2020-2022, Intel Corporation */
 
 /*
  * mocks-rpma-log_default.c -- librpma log_default.c module mocks
@@ -35,4 +35,28 @@ void
 rpma_log_default_fini(void)
 {
 	function_called();
+}
+
+int
+mock__sync_bool_compare_and_swap__function(rpma_log_function **ptr,
+	rpma_log_function *oldval, rpma_log_function *newval)
+{
+	static int run_orig = 1;
+	run_orig = run_orig ? 0 : 1;
+	if (run_orig)
+		return __sync_bool_compare_and_swap(ptr, oldval, newval);
+
+	return 0;
+}
+
+int
+mock__sync_bool_compare_and_swap__threshold(enum rpma_log_level *ptr,
+	enum rpma_log_level oldval, enum rpma_log_level newval)
+{
+	static int run_orig = 1;
+	run_orig = run_orig ? 0 : 1;
+	if (run_orig)
+		return __sync_bool_compare_and_swap(ptr, oldval, newval);
+
+	return 0;
 }

--- a/tests/unit/log/CMakeLists.txt
+++ b/tests/unit/log/CMakeLists.txt
@@ -1,6 +1,6 @@
 #
 # SPDX-License-Identifier: BSD-3-Clause
-# Copyright 2020, Intel Corporation
+# Copyright 2020-2022, Intel Corporation
 #
 
 include(../../cmake/ctest_helpers.cmake)
@@ -16,6 +16,8 @@ function(add_test_log name)
 		${name}.c
 		${TEST_UNIT_COMMON_DIR}/mocks-rpma-log_default.c
 		${LIBRPMA_SOURCE_DIR}/log.c)
+
+	target_compile_definitions(${test} PRIVATE RPMA_UNIT_TESTS)
 
 	if ("${ARGV1}" STREQUAL "DEBUG")
 		target_compile_definitions(${test} PRIVATE DEBUG)

--- a/tests/unit/log/macros.c
+++ b/tests/unit/log/macros.c
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: BSD-3-Clause
-/* Copyright 2020, Intel Corporation */
+/* Copyright 2020-2022, Intel Corporation */
 
 /*
  * macros.c -- RPMA_LOG_* macros unit tests
@@ -43,8 +43,9 @@ int
 setup_threshold(void **level_ptr)
 {
 	enum rpma_log_level level = **(enum rpma_log_level **)level_ptr;
-	rpma_log_set_threshold(RPMA_LOG_THRESHOLD, level);
-
+	while (RPMA_E_AGAIN == rpma_log_set_threshold(
+				RPMA_LOG_THRESHOLD, level))
+		;
 	return 0;
 }
 
@@ -75,7 +76,9 @@ log__all(void **level_ptr)
 		 * The secondary threshold should not affect the macros
 		 * behaviour.
 		 */
-		rpma_log_set_threshold(RPMA_LOG_THRESHOLD_AUX, secondary);
+		while (RPMA_E_AGAIN == rpma_log_set_threshold(
+					RPMA_LOG_THRESHOLD_AUX, secondary))
+			;
 
 		if (RPMA_LOG_LEVEL_NOTICE <= primary) {
 			MOCK_CONFIGURE_LOG_FUNC(RPMA_LOG_LEVEL_NOTICE);
@@ -103,7 +106,9 @@ int
 main(int argc, char *argv[])
 {
 	/* set a custom logging function */
-	rpma_log_set_function(mock_log_function);
+	while (RPMA_E_AGAIN == rpma_log_set_function(
+				mock_log_function))
+		;
 
 	/* prestates */
 	enum rpma_log_level Level_disabled = RPMA_LOG_DISABLED;

--- a/tests/unit/log/threshold.c
+++ b/tests/unit/log/threshold.c
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: BSD-3-Clause
-/* Copyright 2020, Intel Corporation */
+/* Copyright 2020-2022, Intel Corporation */
 
 /*
  * threshold.c -- rpma_log_[get/set]_threshold unit tests
@@ -95,8 +95,12 @@ threshold_lifecycle(void **unused)
 	for (int i = RPMA_LOG_THRESHOLD; i <= RPMA_LOG_THRESHOLD_AUX; i++) {
 		for (int j = RPMA_LOG_DISABLED; j <= RPMA_LOG_LEVEL_DEBUG;
 				j++) {
-			int ret = rpma_log_set_threshold(
+			int ret;
+			do {
+				ret = rpma_log_set_threshold(
 					(enum rpma_log_threshold)i, j);
+			} while (ret == RPMA_E_AGAIN);
+
 			assert_int_equal(ret, 0);
 
 			ret = rpma_log_get_threshold(


### PR DESCRIPTION
Fix `rpma_log_init()` - it cannot fail to set the default log function since now.
Fix unit tests of `rpma_log_set_threshold()` and `RPMA_LOG_*` macros.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/pmem/rpma/1617)
<!-- Reviewable:end -->
