### PR TITLE
common: install shadow package in OpenSUSE Tumbleweed

### DIFF
--- a/utils/docker/images/Dockerfile.opensuse-tumbleweed-latest
+++ b/utils/docker/images/Dockerfile.opensuse-tumbleweed-latest
@@ -25,6 +25,7 @@ ENV BASE_DEPS "\
 	git \
 	make \
 	pkgconf-pkg-config \
+	shadow \
 	sudo \
 	which"
 


### PR DESCRIPTION
Install the 'shadow' package in OpenSUSE Tumbleweed,
because it contains the required command: 'useradd'.

Failed build: https://github.com/ldorau/rpma/runs/5644264113
Build with this fix: https://github.com/ldorau/rpma/actions/runs/2022470624

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/pmem/rpma/1627)
<!-- Reviewable:end -->
