### PR TITLE
common: temporarily do not verify SSL certificates in VzLinux

### DIFF
--- a/utils/docker/images/Dockerfile.vzlinux-latest
+++ b/utils/docker/images/Dockerfile.vzlinux-latest
@@ -12,6 +12,10 @@
 FROM virtuozzo/vzlinux8:latest
 MAINTAINER tomasz.gromadzki@intel.com
 
+# Temporary workaround for the error:
+# Curl error (60): Peer certificate cannot be authenticated with given CA certificates
+RUN echo "sslverify=false" >> /etc/yum.conf
+
 RUN dnf update -y
 RUN dnf install -y epel-release
 RUN dnf install -y 'dnf-command(config-manager)'


### PR DESCRIPTION
Apply the workaround (WA): temporarily do not verify SSL certificates in VzLinux,
because they have expired and the Docker image fails to rebuild:

```
Step 3/28 : RUN dnf update -y
Errors during downloading metadata for repository 'virtuozzolinux-base':
  - Curl error (60): Peer certificate cannot be authenticated with \
                     given CA certificates for
    https://repo.virtuozzo.com/vzlinux/mirrorlist/mirrors-8-os
    [SSL certificate problem: certificate has expired]

Error: Failed to download metadata for repo 'virtuozzolinux-base': \
  Cannot prepare internal mirrorlist: \
  Curl error (60): Peer certificate cannot be authenticated with \
                   given CA certificates for \
  https://repo.virtuozzo.com/vzlinux/mirrorlist/mirrors-8-os \
  [SSL certificate problem: certificate has expired]

The command '/bin/sh -c dnf update -y' returned a non-zero code: 1
```

Failed build: https://github.com/ldorau/rpma/runs/5644263692
Build with this fix: https://github.com/ldorau/rpma/runs/5644710799

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/pmem/rpma/1628)
<!-- Reviewable:end -->
