### PR TITLE
common: temporarily downgrade python3-wrapt in Fedora Rawhide

### DIFF
--- a/utils/docker/images/Dockerfile.fedora-rawhide
+++ b/utils/docker/images/Dockerfile.fedora-rawhide
@@ -64,8 +64,19 @@ RUN dnf install -y \
 	$EXAMPLES_DEPS \
 	$TOOLS_DEPS \
 	$TESTS_DEPS \
-	$RPMA_DEPS \
-&& dnf clean all
+	$RPMA_DEPS
+
+# Temporarily downgrade python3-wrapt from v1.14.0 to v1.13.3-2
+# to fix the following error:
+#    pkg_resources.ContextualVersionConflict: \
+#      (wrapt 1.14.0 (/usr/lib64/python3.10/site-packages), \
+#       Requirement.parse('wrapt<1.14,>=1.11'), {'astroid'})
+RUN dnf install -y wget
+RUN wget https://kojipkgs.fedoraproject.org//packages/python-wrapt/1.13.3/2.fc36/x86_64/python3-wrapt-1.13.3-2.fc36.x86_64.rpm
+RUN dnf install -y ./python3-wrapt-1.13.3-2.fc36.x86_64.rpm
+RUN rm ./python3-wrapt-1.13.3-2.fc36.x86_64.rpm
+
+RUN dnf clean all
 
 RUN pip3 install --upgrade pip
 


### PR DESCRIPTION
Temporarily downgrade `python3-wrapt` in Fedora Rawhide
from v1.14.0 to v1.13.3-2 to fix the following error:
```
pkg_resources.ContextualVersionConflict: \
  (wrapt 1.14.0 (/usr/lib64/python3.10/site-packages), \
   Requirement.parse('wrapt<1.14,>=1.11'), {'astroid'})
```

Failed build: https://github.com/pmem/rpma/runs/5715501437
Build with this fix: https://github.com/ldorau/rpma/runs/5716445498

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/pmem/rpma/1632)
<!-- Reviewable:end -->
