### PR TITLE
test: extract common code for MT tests

### DIFF
--- a/tests/multithreaded/common/mtt_connect.c
+++ b/tests/multithreaded/common/mtt_connect.c
@@ -1,0 +1,285 @@
+// SPDX-License-Identifier: BSD-3-Clause
+/* Copyright 2022, Intel Corporation */
+
+/*
+ * mtt_connect.c -- common connection code of multithreaded tests
+ */
+
+#include <stdlib.h>
+#include <librpma.h>
+
+#include "mtt.h"
+
+/* maximum number of client's connection retries */
+#define MAX_CONN_RETRY 10
+
+/*
+ * mtt_server_listen -- start a listening endpoint at addr:port
+ */
+int
+mtt_server_listen(char *addr, unsigned port, struct rpma_peer **peer_ptr,
+		struct rpma_ep **ep_ptr)
+{
+	struct ibv_context *ibv_ctx = NULL;
+	int ret;
+
+	*peer_ptr = NULL;
+	*ep_ptr = NULL;
+
+	/* configure logging thresholds to see more details */
+	rpma_log_set_threshold(RPMA_LOG_THRESHOLD, RPMA_LOG_LEVEL_INFO);
+	rpma_log_set_threshold(RPMA_LOG_THRESHOLD_AUX, RPMA_LOG_LEVEL_INFO);
+
+	/* lookup an ibv_context via the address */
+	if ((ret = rpma_utils_get_ibv_context(addr,
+			RPMA_UTIL_IBV_CONTEXT_LOCAL, &ibv_ctx))) {
+		SERVER_RPMA_ERR("rpma_utils_get_ibv_context", ret);
+		return ret;
+	}
+
+	/* create a new peer object */
+	if ((ret = rpma_peer_new(ibv_ctx, peer_ptr))) {
+		SERVER_RPMA_ERR("rpma_peer_new", ret);
+		return ret;
+	}
+
+	MTT_PORT_INIT;
+	MTT_PORT_SET(port, 0);
+
+	/* start a listening endpoint at addr:port */
+	if ((ret = rpma_ep_listen(*peer_ptr, addr, MTT_PORT_STR, ep_ptr))) {
+		SERVER_RPMA_ERR("rpma_ep_listen", ret);
+		/* delete the peer object */
+		(void) rpma_peer_delete(peer_ptr);
+		return ret;
+	}
+
+	return 0;
+}
+
+/*
+ * mtt_server_accept_connection -- wait for an incoming connection request,
+ * accept it and wait for its establishment
+ */
+int
+mtt_server_accept_connection(struct rpma_ep *ep,
+		struct rpma_conn_private_data *pdata,
+		struct rpma_conn **conn_ptr)
+{
+	struct rpma_conn_req *req = NULL;
+	enum rpma_conn_event conn_event = RPMA_CONN_UNDEFINED;
+	int ret;
+
+	/* receive an incoming connection request */
+	if ((ret = rpma_ep_next_conn_req(ep, NULL, &req))) {
+		SERVER_RPMA_ERR("rpma_ep_next_conn_req", ret);
+		return ret;
+	}
+
+	/*
+	 * connect / accept the connection request and obtain the connection
+	 * object
+	 */
+	if ((ret = rpma_conn_req_connect(&req, pdata, conn_ptr))) {
+		SERVER_RPMA_ERR("rpma_conn_req_connect", ret);
+		(void) rpma_conn_req_delete(&req);
+		return ret;
+	}
+
+	/* wait for the connection to be established */
+	if ((ret = rpma_conn_next_event(*conn_ptr, &conn_event)))
+		SERVER_RPMA_ERR("rpma_conn_next_event", ret);
+	else if (conn_event != RPMA_CONN_ESTABLISHED) {
+		SERVER_ERR_MSG(
+			"rpma_conn_next_event returned an unexpected event");
+		SERVER_ERR_MSG(rpma_utils_conn_event_2str(conn_event));
+		ret = -1;
+	}
+
+	if (ret)
+		(void) rpma_conn_delete(conn_ptr);
+
+	return ret;
+}
+
+/*
+ * mtt_server_wait_for_conn_close_and_disconnect -- wait for RPMA_CONN_CLOSED,
+ * disconnect and delete the connection structure
+ */
+void
+mtt_server_wait_for_conn_close_and_disconnect(struct rpma_conn **conn_ptr)
+{
+	enum rpma_conn_event conn_event = RPMA_CONN_UNDEFINED;
+	int ret = 0;
+
+	/* wait for the connection to be closed */
+	if ((ret = rpma_conn_next_event(*conn_ptr, &conn_event)))
+		SERVER_RPMA_ERR("rpma_conn_next_event", ret);
+	else if (conn_event != RPMA_CONN_CLOSED) {
+		SERVER_ERR_MSG(
+			"rpma_conn_next_event returned an unexpected event");
+		SERVER_ERR_MSG(rpma_utils_conn_event_2str(conn_event));
+	}
+
+	if ((ret = rpma_conn_disconnect(*conn_ptr)))
+		SERVER_RPMA_ERR("rpma_conn_disconnect", ret);
+
+	if ((ret = rpma_conn_delete(conn_ptr)))
+		SERVER_RPMA_ERR("rpma_conn_delete", ret);
+}
+
+/*
+ * mtt_server_shutdown -- shutdown the endpoint and delete the peer object
+ */
+void
+mtt_server_shutdown(struct rpma_peer **peer_ptr, struct rpma_ep **ep_ptr)
+{
+	/* shutdown the endpoint */
+	(void) rpma_ep_shutdown(ep_ptr);
+
+	/* delete the peer object */
+	(void) rpma_peer_delete(peer_ptr);
+}
+
+/*
+ * mtt_client_connect -- connect with the server and get the private data
+ */
+int
+mtt_client_connect(struct mtt_result *tr, char *addr, unsigned port,
+	struct rpma_peer **peer_ptr, struct rpma_conn **conn_ptr,
+	struct rpma_conn_private_data *pdata)
+{
+	struct ibv_context *ibv_ctx;
+	struct rpma_conn_req *req = NULL;
+	enum rpma_conn_event conn_event = RPMA_CONN_UNDEFINED;
+
+	int ret;
+
+	if ((ret = rpma_utils_get_ibv_context(addr,
+			RPMA_UTIL_IBV_CONTEXT_REMOTE, &ibv_ctx))) {
+		MTT_RPMA_ERR(tr, "rpma_utils_get_ibv_context", ret);
+		return -1;
+	}
+
+	if ((ret = rpma_peer_new(ibv_ctx, peer_ptr))) {
+		MTT_RPMA_ERR(tr, "rpma_peer_new", ret);
+		return -1;
+	}
+
+	MTT_PORT_INIT;
+	MTT_PORT_SET(port, 0);
+
+	int retry = 0;
+	do {
+		/* create a connection request */
+		ret = rpma_conn_req_new(*peer_ptr, addr, MTT_PORT_STR,
+					NULL, &req);
+		if (ret) {
+			MTT_RPMA_ERR(tr, "rpma_conn_req_new", ret);
+			goto err_peer_delete;
+		}
+
+		/*
+		 * Connect the connection request and obtain
+		 * the connection object.
+		 */
+		ret = rpma_conn_req_connect(&req, NULL, conn_ptr);
+		if (ret) {
+			(void) rpma_conn_req_delete(&req);
+			MTT_RPMA_ERR(tr, "rpma_conn_req_connect", ret);
+			goto err_peer_delete;
+		}
+
+		/* wait for the connection to establish */
+		ret = rpma_conn_next_event(*conn_ptr, &conn_event);
+		if (ret) {
+			MTT_RPMA_ERR(tr, "rpma_conn_next_event", ret);
+			goto err_conn_delete;
+		}
+
+		if (conn_event == RPMA_CONN_ESTABLISHED)
+			break;
+
+		retry++;
+
+		if (conn_event != RPMA_CONN_REJECTED ||
+		    retry == MAX_CONN_RETRY) {
+			MTT_ERR_MSG(tr,
+				"rpma_conn_next_event returned an unexpected event",
+				-1);
+			goto err_conn_delete;
+		}
+
+		/* received the RPMA_CONN_REJECTED event, retrying ... */
+		(void) rpma_conn_disconnect(*conn_ptr);
+		(void) rpma_conn_delete(conn_ptr);
+
+	} while (retry < MAX_CONN_RETRY);
+
+	/* get the connection private data */
+	ret = rpma_conn_get_private_data(*conn_ptr, pdata);
+	if (ret) {
+		MTT_RPMA_ERR(tr, "rpma_conn_get_private_data", ret);
+		goto err_conn_disconnect;
+	} else if (pdata->ptr == NULL) {
+		MTT_ERR_MSG(tr,
+			"The server has not provided the connection's private data",
+			-1);
+		goto err_conn_disconnect;
+	}
+
+	return 0;
+
+err_conn_disconnect:
+	(void) rpma_conn_disconnect(*conn_ptr);
+
+err_conn_delete:
+	(void) rpma_conn_delete(conn_ptr);
+
+err_peer_delete:
+	(void) rpma_peer_delete(peer_ptr);
+
+	return -1;
+}
+
+/*
+ * mtt_client_err_disconnect -- force disconnect and delete the peer object
+ *                          in case of an error
+ */
+void
+mtt_client_err_disconnect(struct rpma_conn **conn_ptr,
+			struct rpma_peer **peer_ptr)
+{
+	(void) rpma_conn_disconnect(*conn_ptr);
+	(void) rpma_conn_delete(conn_ptr);
+	(void) rpma_peer_delete(peer_ptr);
+}
+
+/*
+ * mtt_client_disconnect -- disconnect and delete the peer object
+ */
+void
+mtt_client_disconnect(struct mtt_result *tr, struct rpma_conn **conn_ptr,
+			struct rpma_peer **peer_ptr)
+{
+	enum rpma_conn_event conn_event = RPMA_CONN_UNDEFINED;
+	int ret;
+
+	if ((ret = rpma_conn_disconnect(*conn_ptr))) {
+		MTT_RPMA_ERR(tr, "rpma_conn_disconnect", ret);
+	} else {
+		/* wait for the connection to be closed */
+		if ((ret = rpma_conn_next_event(*conn_ptr, &conn_event)))
+			MTT_RPMA_ERR(tr, "rpma_conn_next_event", ret);
+		else if (conn_event != RPMA_CONN_CLOSED)
+			MTT_ERR_MSG(tr,
+				"rpma_conn_next_event returned an unexpected event",
+				-1);
+	}
+
+	if ((ret = rpma_conn_delete(conn_ptr)))
+		MTT_RPMA_ERR(tr, "rpma_conn_delete", ret);
+
+	if ((ret = rpma_peer_delete(peer_ptr)))
+		MTT_RPMA_ERR(tr, "rpma_peer_delete", ret);
+}

--- a/tests/multithreaded/common/mtt_connect.h
+++ b/tests/multithreaded/common/mtt_connect.h
@@ -1,0 +1,32 @@
+/* SPDX-License-Identifier: BSD-3-Clause */
+/* Copyright 2022, Intel Corporation */
+
+/*
+ * mtt_connect.h -- header for common connection code of multithreaded tests
+ */
+
+#ifndef MTT_CONNECT_H
+#define MTT_CONNECT_H
+
+int mtt_server_listen(char *addr, unsigned port, struct rpma_peer **peer_ptr,
+		struct rpma_ep **ep_ptr);
+
+int mtt_server_accept_connection(struct rpma_ep *ep,
+		struct rpma_conn_private_data *pdata,
+		struct rpma_conn **conn_ptr);
+
+void mtt_server_wait_for_conn_close_and_disconnect(struct rpma_conn **conn_ptr);
+
+void mtt_server_shutdown(struct rpma_peer **peer_ptr, struct rpma_ep **ep_ptr);
+
+int mtt_client_connect(struct mtt_result *tr, char *addr, unsigned port,
+		struct rpma_peer **peer_ptr, struct rpma_conn **conn_ptr,
+		struct rpma_conn_private_data *pdata);
+
+void mtt_client_err_disconnect(struct rpma_conn **conn_ptr,
+		struct rpma_peer **peer_ptr);
+
+void mtt_client_disconnect(struct mtt_result *tr, struct rpma_conn **conn_ptr,
+		struct rpma_peer **peer_ptr);
+
+#endif /* MTT_CONNECT_H */

--- a/tests/multithreaded/conn/CMakeLists.txt
+++ b/tests/multithreaded/conn/CMakeLists.txt
@@ -24,6 +24,7 @@ add_multithreaded(NAME conn BIN rpma_conn_cfg_set_sq_size
 add_multithreaded(NAME conn BIN rpma_conn_cfg_set_timeout
 	SRCS rpma_conn_cfg_set_timeout.c)
 add_multithreaded(NAME conn BIN rpma_conn_get_private_data
-	SRCS rpma_conn_get_private_data.c server_rpma_conn_get_private_data.c)
+	SRCS rpma_conn_get_private_data.c server_rpma_conn_get_private_data.c
+		../common/mtt_connect.c)
 add_multithreaded(NAME conn BIN rpma_conn_req_new
 	SRCS rpma_conn_req_new.c)

--- a/tests/multithreaded/conn/rpma_conn_get_private_data.c
+++ b/tests/multithreaded/conn/rpma_conn_get_private_data.c
@@ -9,8 +9,7 @@
 #include <librpma.h>
 
 #include "mtt.h"
-
-#define MAX_CONN_RETRY 10
+#include "mtt_connect.h"
 
 /* the client's part */
 
@@ -21,103 +20,20 @@ struct prestate {
 	struct rpma_conn *conn;
 
 	/* the expected value of the private data */
-	struct rpma_conn_private_data pdata_exp;
+	struct rpma_conn_private_data pdata;
 };
 
 /*
- * prestate_init -- connect with the server, get the private date
- * and save it in order to verify it later.
+ * prestate_init -- connect with the server, get the private data
+ * and save it in order to verify it later
  */
 static void
 prestate_init(void *prestate, struct mtt_result *tr)
 {
 	struct prestate *pr = (struct prestate *)prestate;
-	struct ibv_context *ibv_ctx;
-	struct rpma_conn_req *req = NULL;
-	enum rpma_conn_event conn_event = RPMA_CONN_UNDEFINED;
 
-	int ret;
-
-	if ((ret = rpma_utils_get_ibv_context(pr->addr,
-			RPMA_UTIL_IBV_CONTEXT_REMOTE, &ibv_ctx))) {
-		MTT_RPMA_ERR(tr, "rpma_utils_get_ibv_context", ret);
-		return;
-	}
-
-	if ((ret = rpma_peer_new(ibv_ctx, &pr->peer))) {
-		MTT_RPMA_ERR(tr, "rpma_peer_new", ret);
-		return;
-	}
-
-	MTT_PORT_INIT;
-	MTT_PORT_SET(pr->port, 0);
-
-	int retry = 0;
-	do {
-		/* create a connection request */
-		ret = rpma_conn_req_new(pr->peer, pr->addr, MTT_PORT_STR,
-					NULL, &req);
-		if (ret) {
-			MTT_RPMA_ERR(tr, "rpma_conn_req_new", ret);
-			goto err_peer_delete;
-		}
-
-		/*
-		 * Connect the connection request and obtain
-		 * the connection object.
-		 */
-		ret = rpma_conn_req_connect(&req, NULL, &pr->conn);
-		if (ret) {
-			(void) rpma_conn_req_delete(&req);
-			MTT_RPMA_ERR(tr, "rpma_conn_req_connect", ret);
-			goto err_peer_delete;
-		}
-
-		/* wait for the connection to establish */
-		ret = rpma_conn_next_event(pr->conn, &conn_event);
-		if (ret) {
-			MTT_RPMA_ERR(tr, "rpma_conn_next_event", ret);
-			goto err_conn_delete;
-		}
-
-		if (conn_event == RPMA_CONN_ESTABLISHED)
-			break;
-
-		retry++;
-
-		if (conn_event != RPMA_CONN_REJECTED ||
-		    retry == MAX_CONN_RETRY) {
-			MTT_ERR_MSG(tr,
-				"rpma_conn_next_event returned an unexpected event",
-				-1);
-			goto err_conn_delete;
-		}
-
-		/* received the RPMA_CONN_REJECTED event, retrying ... */
-		(void) rpma_conn_disconnect(pr->conn);
-		(void) rpma_conn_delete(&pr->conn);
-
-	} while (retry < MAX_CONN_RETRY);
-
-	/* get the connection private data */
-	ret = rpma_conn_get_private_data(pr->conn, &pr->pdata_exp);
-	if (ret) {
-		MTT_RPMA_ERR(tr, "rpma_conn_get_private_data", ret);
-		goto err_conn_delete;
-	} else if (pr->pdata_exp.ptr == NULL) {
-		MTT_ERR_MSG(tr,
-			"The server has not provided the connection's private data",
-			-1);
-		goto err_conn_delete;
-	}
-
-	return;
-
-err_conn_delete:
-	(void) rpma_conn_delete(&pr->conn);
-
-err_peer_delete:
-	(void) rpma_peer_delete(&pr->peer);
+	(void) mtt_client_connect(tr, pr->addr, pr->port, &pr->peer,
+			&pr->conn, &pr->pdata);
 }
 
 /*
@@ -143,13 +59,13 @@ thread(unsigned id, void *prestate, void *state,
 	}
 
 	/* verify the length of the received private data */
-	if (pdata.len != pr->pdata_exp.len) {
+	if (pdata.len != pr->pdata.len) {
 		MTT_ERR_MSG(result, "Wrong length of the private data", -1);
 		return;
 	}
 
 	/* verify the content of the received private data */
-	if (memcmp(pdata.ptr, pr->pdata_exp.ptr, pdata.len) != 0)
+	if (memcmp(pdata.ptr, pr->pdata.ptr, pdata.len) != 0)
 		MTT_ERR_MSG(result, "Wrong content of the private data", -1);
 }
 
@@ -160,26 +76,8 @@ static void
 prestate_fini(void *prestate, struct mtt_result *tr)
 {
 	struct prestate *pr = (struct prestate *)prestate;
-	enum rpma_conn_event conn_event = RPMA_CONN_UNDEFINED;
-	int ret;
 
-	if ((ret = rpma_conn_disconnect(pr->conn))) {
-		MTT_RPMA_ERR(tr, "rpma_conn_disconnect", ret);
-	} else {
-		/* wait for the connection to be closed */
-		if ((ret = rpma_conn_next_event(pr->conn, &conn_event)))
-			MTT_RPMA_ERR(tr, "rpma_conn_next_event", ret);
-		else if (conn_event != RPMA_CONN_CLOSED)
-			MTT_ERR_MSG(tr,
-				"rpma_conn_next_event returned an unexpected event",
-				-1);
-	}
-
-	if ((ret = rpma_conn_delete(&pr->conn)))
-		MTT_RPMA_ERR(tr, "rpma_conn_delete", ret);
-
-	if ((ret = rpma_peer_delete(&pr->peer)))
-		MTT_RPMA_ERR(tr, "rpma_peer_delete", ret);
+	mtt_client_disconnect(tr, &pr->conn, &pr->peer);
 }
 
 /* the server's part */

--- a/tests/multithreaded/conn/server_rpma_conn_get_private_data.c
+++ b/tests/multithreaded/conn/server_rpma_conn_get_private_data.c
@@ -1,125 +1,28 @@
 // SPDX-License-Identifier: BSD-3-Clause
-/* Copyright 2021, Intel Corporation */
+/* Copyright 2021-2022, Intel Corporation */
 
 /*
  * server.c -- a server of the rpma_conn_get_private_data MT test
  */
 
-#include <stdlib.h>
-#include <stdio.h>
-#include <string.h>
-#include <inttypes.h>
 #include <librpma.h>
 
 #include "mtt.h"
+#include "mtt_connect.h"
 
 const char data[] = "Hello client!";
-
-/*
- * server_accept_connection -- wait for an incoming connection request,
- * accept it and wait for its establishment
- */
-int
-server_accept_connection(struct rpma_ep *ep,
-		struct rpma_conn_private_data *pdata,
-		struct rpma_conn **conn_ptr)
-{
-	struct rpma_conn_req *req = NULL;
-	enum rpma_conn_event conn_event = RPMA_CONN_UNDEFINED;
-	int ret;
-
-	/* receive an incoming connection request */
-	if ((ret = rpma_ep_next_conn_req(ep, NULL, &req))) {
-		SERVER_RPMA_ERR("rpma_ep_next_conn_req", ret);
-		return ret;
-	}
-
-	/*
-	 * connect / accept the connection request and obtain the connection
-	 * object
-	 */
-	if ((ret = rpma_conn_req_connect(&req, pdata, conn_ptr))) {
-		SERVER_RPMA_ERR("rpma_conn_req_connect", ret);
-		(void) rpma_conn_req_delete(&req);
-		return ret;
-	}
-
-	/* wait for the connection to be established */
-	if ((ret = rpma_conn_next_event(*conn_ptr, &conn_event)))
-		SERVER_RPMA_ERR("rpma_conn_next_event", ret);
-	else if (conn_event != RPMA_CONN_ESTABLISHED) {
-		SERVER_ERR_MSG(
-			"rpma_conn_next_event returned an unexpected event");
-		SERVER_ERR_MSG(rpma_utils_conn_event_2str(conn_event));
-		ret = -1;
-	}
-
-	if (ret)
-		(void) rpma_conn_delete(conn_ptr);
-
-	return ret;
-}
-
-/*
- * common_wait_for_conn_close_and_disconnect -- wait for RPMA_CONN_CLOSED,
- * disconnect and delete the connection structure
- */
-void
-common_wait_for_conn_close_and_disconnect(struct rpma_conn **conn_ptr)
-{
-	enum rpma_conn_event conn_event = RPMA_CONN_UNDEFINED;
-	int ret = 0;
-
-	/* wait for the connection to be closed */
-	if ((ret = rpma_conn_next_event(*conn_ptr, &conn_event)))
-		SERVER_RPMA_ERR("rpma_conn_next_event", ret);
-	else if (conn_event != RPMA_CONN_CLOSED) {
-		SERVER_ERR_MSG(
-			"rpma_conn_next_event returned an unexpected event");
-		SERVER_ERR_MSG(rpma_utils_conn_event_2str(conn_event));
-	}
-
-	if ((ret = rpma_conn_disconnect(*conn_ptr)))
-		SERVER_RPMA_ERR("rpma_conn_disconnect", ret);
-
-	if ((ret = rpma_conn_delete(conn_ptr)))
-		SERVER_RPMA_ERR("rpma_conn_delete", ret);
-}
 
 int
 server_main(char *addr, unsigned port)
 {
-	struct ibv_context *ibv_ctx = NULL;
 	struct rpma_peer *peer = NULL;
 	struct rpma_ep *ep = NULL;
 	struct rpma_conn *conn = NULL;
 	int ret;
 
-	/* configure logging thresholds to see more details */
-	rpma_log_set_threshold(RPMA_LOG_THRESHOLD, RPMA_LOG_LEVEL_INFO);
-	rpma_log_set_threshold(RPMA_LOG_THRESHOLD_AUX, RPMA_LOG_LEVEL_INFO);
-
-	/* lookup an ibv_context via the address */
-	if ((ret = rpma_utils_get_ibv_context(addr,
-			RPMA_UTIL_IBV_CONTEXT_LOCAL, &ibv_ctx))) {
-		SERVER_RPMA_ERR("rpma_utils_get_ibv_context", ret);
+	ret = mtt_server_listen(addr, port, &peer, &ep);
+	if (ret)
 		return ret;
-	}
-
-	/* create a new peer object */
-	if ((ret = rpma_peer_new(ibv_ctx, &peer))) {
-		SERVER_RPMA_ERR("rpma_peer_new", ret);
-		return ret;
-	}
-
-	MTT_PORT_INIT;
-	MTT_PORT_SET(port, 0);
-
-	/* start a listening endpoint at addr:port */
-	if ((ret = rpma_ep_listen(peer, addr, MTT_PORT_STR, &ep))) {
-		SERVER_RPMA_ERR("rpma_ep_listen", ret);
-		goto err_peer_delete;
-	}
 
 	struct rpma_conn_private_data pdata;
 	pdata.ptr = (void *)data;
@@ -129,23 +32,19 @@ server_main(char *addr, unsigned port)
 	 * Wait for an incoming connection request, accept it and wait for its
 	 * establishment.
 	 */
-	ret = server_accept_connection(ep, &pdata, &conn);
+	ret = mtt_server_accept_connection(ep, &pdata, &conn);
 	if (ret)
-		goto err_ep_shutdown;
+		goto err_shutdown;
 
 	/*
 	 * Wait for RPMA_CONN_CLOSED, disconnect and delete the connection
 	 * structure.
 	 */
-	common_wait_for_conn_close_and_disconnect(&conn);
+	mtt_server_wait_for_conn_close_and_disconnect(&conn);
 
-err_ep_shutdown:
-	/* shutdown the endpoint */
-	(void) rpma_ep_shutdown(&ep);
-
-err_peer_delete:
-	/* delete the peer object */
-	(void) rpma_peer_delete(&peer);
+err_shutdown:
+	/* shutdown the endpoint and delete the peer object */
+	mtt_server_shutdown(&peer, &ep);
 
 	return ret;
 }


### PR DESCRIPTION
Extract common connection code from `rpma_conn_get_private_data.c` for a future use.

This patch only refactors the code and does not make any functional modifications.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/pmem/rpma/1635)
<!-- Reviewable:end -->
