### PR TITLE
rpma: add shared completion channel

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,8 +7,18 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 ### Added
+- APIs:
+  - rpma_conn_cfg_get_compl_channel
+  - rpma_conn_cfg_set_compl_channel
+  - rpma_conn_get_compl_fd
+  - rpma_conn_wait
+  - error RPMA_E_SHARED_CHANNEL
 - logging of the source and the destination GID addresses in rpma_conn_req_from_id()
 - error message for RPMA_E_AGAIN: "Temporary error, try again"
+
+### Changed
+- APIs:
+  - rpma_cq_wait - returns RPMA_E_SHARED_CHANNEL if the completion channel is shared
 
 ## [0.14.0] - 2022-03-15
 ### Added

--- a/src/conn.c
+++ b/src/conn.c
@@ -15,6 +15,7 @@
 #include "log_internal.h"
 #include "mr.h"
 #include "private_data.h"
+#include "rpma.h"
 
 #ifdef TEST_MOCK_ALLOC
 #include "cmocka_alloc.h"
@@ -25,6 +26,7 @@ struct rpma_conn {
 	struct rdma_event_channel *evch; /* event channel of the CM ID */
 	struct rpma_cq *cq; /* main CQ */
 	struct rpma_cq *rcq; /* receive CQ */
+	struct ibv_comp_channel *channel; /* shared completion channel */
 
 	struct rpma_conn_private_data data; /* private data of the CM ID */
 	struct rpma_flush *flush; /* flushing object */
@@ -44,7 +46,7 @@ struct rpma_conn {
 int
 rpma_conn_new(struct rpma_peer *peer, struct rdma_cm_id *id,
 		struct rpma_cq *cq, struct rpma_cq *rcq,
-		struct rpma_conn **conn_ptr)
+		struct ibv_comp_channel *channel, struct rpma_conn **conn_ptr)
 {
 	if (peer == NULL || id == NULL || cq == NULL || conn_ptr == NULL)
 		return RPMA_E_INVAL;
@@ -78,6 +80,7 @@ rpma_conn_new(struct rpma_peer *peer, struct rdma_cm_id *id,
 	conn->evch = evch;
 	conn->cq = cq;
 	conn->rcq = rcq;
+	conn->channel = channel;
 	conn->data.ptr = NULL;
 	conn->data.len = 0;
 	conn->flush = flush;
@@ -203,6 +206,66 @@ err_private_data_discard:
 }
 
 /*
+ * rpma_conn_wait -- wait for a completion event on the shared completion
+ * channel from CQ or RCQ, ack it and return the CQ that caused the event.
+ */
+int
+rpma_conn_wait(struct rpma_conn *conn, struct rpma_cq **cq)
+{
+	if (conn == NULL || cq == NULL || conn->channel == NULL)
+		return RPMA_E_INVAL;
+
+	/* wait for the completion event */
+	struct ibv_cq *ev_cq;	/* CQ that got the event */
+	void *ev_ctx;		/* unused */
+	if (ibv_get_cq_event(conn->channel, &ev_cq, &ev_ctx))
+		return RPMA_E_NO_COMPLETION;
+
+	if (ev_cq == rpma_cq_get_ibv_cq(conn->cq)) {
+		*cq = conn->cq;
+	} else if (ev_cq == rpma_cq_get_ibv_cq(conn->rcq)) {
+		*cq = conn->rcq;
+	} else {
+		*cq = NULL;
+		RPMA_LOG_ERROR("ibv_get_cq_event() returned unknown CQ");
+		return RPMA_E_UNKNOWN;
+	}
+
+	/*
+	 * ACK the collected CQ event.
+	 *
+	 * XXX for performance reasons, it may be beneficial to ACK more than
+	 * one CQ event at the same time.
+	 */
+	ibv_ack_cq_events(ev_cq, 1 /* # of CQ events */);
+
+	/* request for the next event on the CQ channel */
+	errno = ibv_req_notify_cq(ev_cq, 0 /* all completions */);
+	if (errno) {
+		*cq = NULL;
+		RPMA_LOG_ERROR_WITH_ERRNO(errno, "ibv_req_notify_cq()");
+		return RPMA_E_PROVIDER;
+	}
+
+	return 0;
+}
+
+/*
+ * rpma_conn_get_compl_fd -- get a file descriptor of the shared
+ * completion channel from the connection
+ */
+int
+rpma_conn_get_compl_fd(const struct rpma_conn *conn, int *fd)
+{
+	if (conn == NULL || fd == NULL)
+		return RPMA_E_INVAL;
+
+	*fd = conn->channel->fd;
+
+	return 0;
+}
+
+/*
  * rpma_conn_get_private_data -- hand a pointer to the connection's private data
  */
 int
@@ -269,7 +332,13 @@ rpma_conn_delete(struct rpma_conn **conn_ptr)
 	if (rdma_destroy_id(conn->id)) {
 		RPMA_LOG_ERROR_WITH_ERRNO(errno, "rdma_destroy_id()");
 		ret = RPMA_E_PROVIDER;
-		goto err_destroy_event_channel;
+		goto err_destroy_comp_channel;
+	}
+
+	if (conn->channel) {
+		ret = rpma_ibv_destroy_comp_channel(conn->channel);
+		if (ret)
+			goto err_destroy_event_channel;
 	}
 
 	rdma_destroy_event_channel(conn->evch);
@@ -287,6 +356,9 @@ err_rpma_cq_delete:
 	(void) rpma_cq_delete(&conn->cq);
 err_destroy_id:
 	(void) rdma_destroy_id(conn->id);
+err_destroy_comp_channel:
+	if (conn->channel)
+		(void) rpma_ibv_destroy_comp_channel(conn->channel);
 err_destroy_event_channel:
 	rdma_destroy_event_channel(conn->evch);
 	rpma_private_data_discard(&conn->data);

--- a/src/conn.h
+++ b/src/conn.h
@@ -1,5 +1,5 @@
 /* SPDX-License-Identifier: BSD-3-Clause */
-/* Copyright 2020-2021, Intel Corporation */
+/* Copyright 2020-2022, Intel Corporation */
 /* Copyright 2021, Fujitsu */
 
 /*
@@ -25,7 +25,7 @@
  */
 int rpma_conn_new(struct rpma_peer *peer, struct rdma_cm_id *id,
 		struct rpma_cq *cq, struct rpma_cq *rcq,
-		struct rpma_conn **conn_ptr);
+		struct ibv_comp_channel *channel, struct rpma_conn **conn_ptr);
 
 /*
  * rpma_conn_transfer_private_data -- transfer the private data to

--- a/src/conn_cfg.c
+++ b/src/conn_cfg.c
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: BSD-3-Clause
-/* Copyright 2020, Intel Corporation */
+/* Copyright 2020-2022, Intel Corporation */
 /* Copyright 2021, Fujitsu */
 
 /*
@@ -31,12 +31,18 @@
  */
 #define RPMA_DEFAULT_RCQ_SIZE	0
 
+/*
+ * By default the completion channel is NOT shared by CQ and RCQ.
+ */
+#define RPMA_DEFAULT_SHARED_COMPL_CHANNEL false
+
 struct rpma_conn_cfg {
 	int timeout_ms;	/* connection establishment timeout */
 	uint32_t cq_size;	/* main CQ size */
 	uint32_t rcq_size;	/* receive CQ size */
 	uint32_t sq_size;	/* SQ size */
 	uint32_t rq_size;	/* RQ size */
+	bool shared_comp_channel; /* completion channel shared by CQ and RCQ */
 };
 
 static struct rpma_conn_cfg Conn_cfg_default  = {
@@ -44,7 +50,8 @@ static struct rpma_conn_cfg Conn_cfg_default  = {
 	.cq_size = RPMA_DEFAULT_Q_SIZE,
 	.rcq_size = RPMA_DEFAULT_RCQ_SIZE,
 	.sq_size = RPMA_DEFAULT_Q_SIZE,
-	.rq_size = RPMA_DEFAULT_Q_SIZE
+	.rq_size = RPMA_DEFAULT_Q_SIZE,
+	.shared_comp_channel = RPMA_DEFAULT_SHARED_COMPL_CHANNEL
 };
 
 /* internal librpma API */
@@ -275,6 +282,36 @@ rpma_conn_cfg_get_rq_size(const struct rpma_conn_cfg *cfg, uint32_t *rq_size)
 		return RPMA_E_INVAL;
 
 	*rq_size = cfg->rq_size;
+
+	return 0;
+}
+
+/*
+ * rpma_conn_cfg_set_compl_channel -- set if the completion channel
+ * is shared by CQ and RCQ
+ */
+int
+rpma_conn_cfg_set_compl_channel(struct rpma_conn_cfg *cfg, bool shared)
+{
+	if (cfg == NULL)
+		return RPMA_E_INVAL;
+
+	cfg->shared_comp_channel = shared;
+
+	return 0;
+}
+
+/*
+ * rpma_conn_cfg_get_compl_channel -- get if the completion channel
+ * is shared by CQ and RCQ
+ */
+int
+rpma_conn_cfg_get_compl_channel(const struct rpma_conn_cfg *cfg, bool *shared)
+{
+	if (cfg == NULL || shared == NULL)
+		return RPMA_E_INVAL;
+
+	*shared = cfg->shared_comp_channel;
 
 	return 0;
 }

--- a/src/conn_cfg.h
+++ b/src/conn_cfg.h
@@ -1,5 +1,5 @@
 /* SPDX-License-Identifier: BSD-3-Clause */
-/* Copyright 2020, Intel Corporation */
+/* Copyright 2020-2022, Intel Corporation */
 /* Copyright 2021, Fujitsu */
 
 /*
@@ -32,5 +32,14 @@ int rpma_conn_cfg_get_cqe(const struct rpma_conn_cfg *cfg, int *cqe);
  * - RPMA_E_INVAL - cfg or rcqe is NULL
  */
 int rpma_conn_cfg_get_rcqe(const struct rpma_conn_cfg *cfg, int *rcqe);
+
+/*
+ * ERRORS
+ * rpma_conn_cfg_get_compl_channel() can fail with the following error:
+ *
+ * - RPMA_E_INVAL - cfg or shared is NULL
+ */
+int rpma_conn_cfg_get_compl_channel(const struct rpma_conn_cfg *cfg,
+		bool *shared);
 
 #endif /* LIBRPMA_CONN_CFG_H */

--- a/src/conn_req.c
+++ b/src/conn_req.c
@@ -18,6 +18,7 @@
 #include "mr.h"
 #include "peer.h"
 #include "private_data.h"
+#include "rpma.h"
 
 #ifdef TEST_MOCK_ALLOC
 #include "cmocka_alloc.h"
@@ -32,6 +33,8 @@ struct rpma_conn_req {
 	struct rpma_cq *cq;
 	/* receive CQ */
 	struct rpma_cq *rcq;
+	/* shared completion channel */
+	struct ibv_comp_channel *channel;
 
 	/* private data of the CM ID (incoming only) */
 	struct rpma_conn_private_data data;
@@ -75,19 +78,29 @@ rpma_conn_req_from_id(struct rpma_peer *peer, struct rdma_cm_id *id,
 	int ret = 0;
 
 	int cqe, rcqe;
+	bool shared;
 	/* read the main CQ size from the configuration */
 	(void) rpma_conn_cfg_get_cqe(cfg, &cqe);
 	/* read the receive CQ size from the configuration */
 	(void) rpma_conn_cfg_get_rcqe(cfg, &rcqe);
+	/* get if the completion channel should be shared by CQ and RCQ */
+	(void) rpma_conn_cfg_get_compl_channel(cfg, &shared);
+
+	struct ibv_comp_channel *channel = NULL;
+	if (shared && rcqe) {
+		ret = rpma_ibv_create_comp_channel(id->verbs, &channel);
+		if (ret)
+			return ret;
+	}
 
 	struct rpma_cq *cq = NULL;
-	ret = rpma_cq_new(id->verbs, cqe, &cq);
+	ret = rpma_cq_new(id->verbs, cqe, channel, &cq);
 	if (ret)
-		return ret;
+		goto err_comp_channel_destroy;
 
 	struct rpma_cq *rcq = NULL;
 	if (rcqe) {
-		ret = rpma_cq_new(id->verbs, rcqe, &rcq);
+		ret = rpma_cq_new(id->verbs, rcqe, channel, &rcq);
 		if (ret)
 			goto err_rpma_cq_delete;
 	}
@@ -134,6 +147,7 @@ rpma_conn_req_from_id(struct rpma_peer *peer, struct rdma_cm_id *id,
 	(*req_ptr)->id = id;
 	(*req_ptr)->cq = cq;
 	(*req_ptr)->rcq = rcq;
+	(*req_ptr)->channel = channel;
 	(*req_ptr)->data.ptr = NULL;
 	(*req_ptr)->data.len = 0;
 	(*req_ptr)->peer = peer;
@@ -148,6 +162,10 @@ err_rpma_rcq_delete:
 
 err_rpma_cq_delete:
 	(void) rpma_cq_delete(&cq);
+
+err_comp_channel_destroy:
+	if (channel)
+		(void) rpma_ibv_destroy_comp_channel(channel);
 
 	return ret;
 }
@@ -182,7 +200,8 @@ rpma_conn_req_accept(struct rpma_conn_req *req,
 	}
 
 	struct rpma_conn *conn = NULL;
-	ret = rpma_conn_new(req->peer, req->id, req->cq, req->rcq, &conn);
+	ret = rpma_conn_new(req->peer, req->id, req->cq, req->rcq,
+				req->channel, &conn);
 	if (ret)
 		goto err_conn_disconnect;
 
@@ -198,6 +217,8 @@ err_conn_req_delete:
 	rdma_destroy_qp(req->id);
 	(void) rpma_cq_delete(&req->rcq);
 	(void) rpma_cq_delete(&req->cq);
+	if (req->channel)
+		(void) rpma_ibv_destroy_comp_channel(req->channel);
 
 	return ret;
 }
@@ -218,12 +239,15 @@ rpma_conn_req_connect_active(struct rpma_conn_req *req,
 	int ret = 0;
 
 	struct rpma_conn *conn = NULL;
-	ret = rpma_conn_new(req->peer, req->id, req->cq, req->rcq, &conn);
+	ret = rpma_conn_new(req->peer, req->id, req->cq, req->rcq,
+				req->channel, &conn);
 	if (ret) {
 		rdma_destroy_qp(req->id);
 		(void) rpma_cq_delete(&req->rcq);
 		(void) rpma_cq_delete(&req->cq);
 		(void) rdma_destroy_id(req->id);
+		if (req->channel)
+			(void) rpma_ibv_destroy_comp_channel(req->channel);
 		return ret;
 	}
 
@@ -466,6 +490,12 @@ rpma_conn_req_delete(struct rpma_conn_req **req_ptr)
 		ret = rpma_conn_req_reject(req);
 	else
 		ret = rpma_conn_req_destroy(req);
+
+	if (req->channel) {
+		int ret2 = rpma_ibv_destroy_comp_channel(req->channel);
+		if (ret2 && !ret)
+			ret = ret2;
+	}
 
 	rpma_private_data_discard(&req->data);
 

--- a/src/cq.h
+++ b/src/cq.h
@@ -1,4 +1,5 @@
 /* SPDX-License-Identifier: BSD-3-Clause */
+/* Copyright 2022, Intel Corporation */
 /* Copyright 2021, Fujitsu */
 
 /*
@@ -27,7 +28,9 @@ struct ibv_cq *rpma_cq_get_ibv_cq(const struct rpma_cq *cq);
  * ibv_req_notify_cq(3) failed with a provider error
  * - RPMA_E_NOMEM - out of memory
  */
-int rpma_cq_new(struct ibv_context *ibv_ctx, int cqe, struct rpma_cq **cq_ptr);
+int rpma_cq_new(struct ibv_context *ibv_ctx, int cqe,
+		struct ibv_comp_channel *shared_channel,
+		struct rpma_cq **cq_ptr);
 
 /*
  * ERRORS

--- a/src/include/librpma.h
+++ b/src/include/librpma.h
@@ -322,10 +322,12 @@ extern "C" {
  * NOT thread-safe API calls:
  *
  * - rpma_conn_apply_remote_peer_cfg()
+ * - rpma_conn_cfg_get_compl_channel()
  * - rpma_conn_cfg_get_cq_size()
  * - rpma_conn_cfg_get_rq_size()
  * - rpma_conn_cfg_get_sq_size()
  * - rpma_conn_cfg_get_timeout()
+ * - rpma_conn_cfg_set_compl_channel()
  * - rpma_conn_cfg_set_cq_size()
  * - rpma_conn_cfg_set_rq_size()
  * - rpma_conn_cfg_set_sq_size()
@@ -429,6 +431,7 @@ extern "C" {
 #define RPMA_E_NO_COMPLETION	(-100005) /* No next completion available */
 #define RPMA_E_NO_EVENT		(-100006) /* No next event available */
 #define RPMA_E_AGAIN		(-100007) /* Temporary error */
+#define RPMA_E_SHARED_CHANNEL	(-100008) /* Completion channel is shared */
 
 /* picking up an RDMA-capable device */
 
@@ -1360,6 +1363,17 @@ int rpma_conn_cfg_get_timeout(const struct rpma_conn_cfg *cfg, int *timeout_ms);
  */
 int rpma_conn_cfg_set_cq_size(struct rpma_conn_cfg *cfg, uint32_t cq_size);
 
+/*
+ * XXXXXX write the full documentation for this function
+ */
+int rpma_conn_cfg_get_compl_channel(const struct rpma_conn_cfg *cfg,
+		bool *shared);
+
+/*
+ * XXXXXX write the full documentation for this function
+ */
+int rpma_conn_cfg_set_compl_channel(struct rpma_conn_cfg *cfg, bool shared);
+
 /** 3
  * rpma_conn_cfg_get_cq_size - get CQ size for the connection
  *
@@ -2069,6 +2083,20 @@ int rpma_conn_req_connect(struct rpma_conn_req **req_ptr,
 		const struct rpma_conn_private_data *pdata,
 		struct rpma_conn **conn_ptr);
 
+/*
+ * XXXXXX write the full documentation
+ * rpma_conn_get_compl_fd -- get a file descriptor of the shared
+ * completion channel from the connection
+ */
+int rpma_conn_get_compl_fd(const struct rpma_conn *conn, int *fd);
+
+/*
+ * XXXXXX write the full documentation
+ * rpma_conn_wait -- wait for a completion event on the shared completion
+ * channel from CQ or RCQ, ack it and return the CQ that caused the event.
+ */
+int rpma_conn_wait(struct rpma_conn *conn, struct rpma_cq **cq);
+
 /** 3
  * rpma_conn_req_recv - initiate the receive operation
  *
@@ -2761,6 +2789,8 @@ int rpma_cq_get_fd(const struct rpma_cq *cq, int *fd);
  * - RPMA_E_INVAL - cq is NULL
  * - RPMA_E_PROVIDER - ibv_req_notify_cq(3) failed with a provider error
  * - RPMA_E_NO_COMPLETION - no completions available
+ * - RPMA_E_SHARED_CHANNEL - cannot proceed, because the completion channel
+ *   is shared
  *
  * SEE ALSO
  * rpma_conn_get_cq(3), rpma_conn_get_rcq(3), rpma_cq_get_wc(3),

--- a/src/librpma.map
+++ b/src/librpma.map
@@ -11,12 +11,14 @@ LIBRPMA_0.14 {
 		rpma_atomic_write;
 		rpma_conn_apply_remote_peer_cfg;
 		rpma_conn_cfg_delete;
+		rpma_conn_cfg_get_compl_channel;
 		rpma_conn_cfg_get_cq_size;
 		rpma_conn_cfg_get_rcq_size;
 		rpma_conn_cfg_get_rq_size;
 		rpma_conn_cfg_get_sq_size;
 		rpma_conn_cfg_get_timeout;
 		rpma_conn_cfg_new;
+		rpma_conn_cfg_set_compl_channel;
 		rpma_conn_cfg_set_cq_size;
 		rpma_conn_cfg_set_rcq_size;
 		rpma_conn_cfg_set_rq_size;
@@ -25,6 +27,7 @@ LIBRPMA_0.14 {
 		rpma_conn_delete;
 		rpma_conn_disconnect;
 		rpma_conn_get_cq;
+		rpma_conn_get_compl_fd;
 		rpma_conn_get_event_fd;
 		rpma_conn_get_private_data;
 		rpma_conn_get_qp_num;
@@ -35,6 +38,7 @@ LIBRPMA_0.14 {
 		rpma_conn_req_get_private_data;
 		rpma_conn_req_new;
 		rpma_conn_req_recv;
+		rpma_conn_wait;
 		rpma_cq_get_fd;
 		rpma_cq_get_wc;
 		rpma_cq_wait;

--- a/src/rpma.c
+++ b/src/rpma.c
@@ -135,3 +135,43 @@ rpma_utils_conn_event_2str(enum rpma_conn_event conn_event)
 		return "Unsupported connection event";
 	}
 }
+
+/* internal librpma API */
+
+/*
+ * rpma_ibv_create_comp_channel -- create a completion channel
+ *
+ * ASSUMPTIONS
+ * - ibv_ctx != NULL && channel_ptr != NULL
+ */
+int
+rpma_ibv_create_comp_channel(struct ibv_context *ibv_ctx,
+		struct ibv_comp_channel **channel_ptr)
+{
+	/* create a completion channel */
+	*channel_ptr = ibv_create_comp_channel(ibv_ctx);
+	if (*channel_ptr == NULL) {
+		RPMA_LOG_ERROR_WITH_ERRNO(errno, "ibv_create_comp_channel()");
+		return RPMA_E_PROVIDER;
+	}
+
+	return 0;
+}
+
+/*
+ * rpma_ibv_destroy_comp_channel -- destroy a completion channel
+ *
+ * ASSUMPTIONS
+ * - channel != NULL
+ */
+int
+rpma_ibv_destroy_comp_channel(struct ibv_comp_channel *channel)
+{
+	errno = ibv_destroy_comp_channel(channel);
+	if (errno) {
+		RPMA_LOG_ERROR_WITH_ERRNO(errno, "ibv_destroy_comp_channel()");
+		return RPMA_E_PROVIDER;
+	}
+
+	return 0;
+}

--- a/src/rpma.h
+++ b/src/rpma.h
@@ -1,0 +1,32 @@
+/* SPDX-License-Identifier: BSD-3-Clause */
+/* Copyright 2022, Intel Corporation */
+
+/*
+ * rpma.h -- librpma internal definitions
+ */
+
+#ifndef LIBRPMA_RPMA_H
+#define LIBRPMA_RPMA_H
+
+#include <infiniband/verbs.h>
+
+#include "librpma.h"
+
+/*
+ * ERRORS
+ * rpma_ibv_create_comp_channel() can fail with the following errors:
+ *
+ * - RPMA_E_PROVIDER - ibv_create_comp_channel(3) failed with a provider error
+ */
+int rpma_ibv_create_comp_channel(struct ibv_context *ibv_ctx,
+		struct ibv_comp_channel **channel_ptr);
+
+/*
+ * ERRORS
+ * rpma_ibv_destroy_comp_channel() can fail with the following errors:
+ *
+ * - RPMA_E_PROVIDER - ibv_destroy_comp_channel(3) failed with a provider error
+ */
+int rpma_ibv_destroy_comp_channel(struct ibv_comp_channel *channel);
+
+#endif /* LIBRPMA_RPMA_H */

--- a/src/rpma_err.c
+++ b/src/rpma_err.c
@@ -33,6 +33,8 @@ rpma_err_2str(int ret)
 		return "No next event available";
 	case RPMA_E_AGAIN:
 		return "Temporary error, try again";
+	case RPMA_E_SHARED_CHANNEL:
+		return "Completion channel is shared";
 	case RPMA_E_UNKNOWN:
 	default:
 		return "Unknown error";

--- a/tests/unit/common/mocks-rpma-conn.c
+++ b/tests/unit/common/mocks-rpma-conn.c
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: BSD-3-Clause
-/* Copyright 2020-2021, Intel Corporation */
+/* Copyright 2020-2022, Intel Corporation */
 /* Copyright 2021, Fujitsu */
 
 /*
@@ -19,12 +19,13 @@
 int
 rpma_conn_new(struct rpma_peer *peer, struct rdma_cm_id *id,
 		struct rpma_cq *cq, struct rpma_cq *rcq,
-		struct rpma_conn **conn_ptr)
+		struct ibv_comp_channel *channel, struct rpma_conn **conn_ptr)
 {
 	assert_ptr_equal(peer, MOCK_PEER);
 	check_expected_ptr(id);
 	assert_ptr_equal(cq, MOCK_RPMA_CQ);
 	check_expected_ptr(rcq);
+	/* XXXXXX check channel */
 
 	assert_non_null(conn_ptr);
 

--- a/tests/unit/common/mocks-rpma-conn_cfg.c
+++ b/tests/unit/common/mocks-rpma-conn_cfg.c
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: BSD-3-Clause
-/* Copyright 2020, Intel Corporation */
+/* Copyright 2020-2022, Intel Corporation */
 /* Copyright 2021, Fujitsu */
 
 /*
@@ -104,5 +104,20 @@ rpma_conn_cfg_get_rq_size(const struct rpma_conn_cfg *cfg, uint32_t *rq_size)
 
 	*rq_size = args->q_size;
 
+	return 0;
+}
+
+/*
+ * rpma_conn_cfg_get_compl_channel -- rpma_conn_cfg_get_compl_channel() mock
+ */
+int
+rpma_conn_cfg_get_compl_channel(const struct rpma_conn_cfg *cfg, bool *shared)
+{
+	/*
+	 * XXXXXX write the full mock for this function.
+	 * "*shared = mock_type(bool);" should be used here,
+	 * instead of "*shared = false;"
+	 */
+	*shared = false;
 	return 0;
 }

--- a/tests/unit/common/mocks-rpma-cq.c
+++ b/tests/unit/common/mocks-rpma-cq.c
@@ -44,10 +44,16 @@ rpma_cq_wait(struct rpma_cq *cq)
  * rpma_cq_new -- rpma_cq_new() mock
  */
 int
-rpma_cq_new(struct ibv_context *ibv_ctx, int cqe, struct rpma_cq **cq_ptr)
+rpma_cq_new(struct ibv_context *ibv_ctx, int cqe,
+		struct ibv_comp_channel *shared_channel,
+		struct rpma_cq **cq_ptr)
 {
 	assert_non_null(ibv_ctx);
 	check_expected(cqe);
+	/*
+	 * XXXXXX finish the mock for this function.
+	 * check_expected(shared_channel); should be used here.
+	 */
 	assert_non_null(cq_ptr);
 
 	struct rpma_cq *cq = mock_type(struct rpma_cq *);
@@ -92,4 +98,29 @@ rpma_cq_get_ibv_cq(const struct rpma_cq *cq)
 	check_expected_ptr(cq);
 
 	return mock_type(struct ibv_cq *);
+}
+
+/*
+ * rpma_ibv_create_comp_channel -- rpma_ibv_create_comp_channel() mock
+ */
+int
+rpma_ibv_create_comp_channel(struct ibv_context *ibv_ctx,
+		struct ibv_comp_channel **channel_ptr)
+{
+	/*
+	 * XXXXXX write the full mock for this function.
+	 */
+	return 0;
+}
+
+/*
+ * rpma_ibv_destroy_comp_channel -- rpma_ibv_destroy_comp_channel() mock
+ */
+int
+rpma_ibv_destroy_comp_channel(struct ibv_comp_channel *channel)
+{
+	/*
+	 * XXXXXX write the full mock for this function.
+	 */
+	return 0;
 }

--- a/tests/unit/conn/conn-common.c
+++ b/tests/unit/conn/conn-common.c
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: BSD-3-Clause
-/* Copyright 2020-2021, Intel Corporation */
+/* Copyright 2020-2022, Intel Corporation */
 /* Copyright 2021, Fujitsu */
 
 /*
@@ -85,9 +85,10 @@ setup__conn_new(void **cstate_ptr)
 	will_return(rpma_flush_new, MOCK_OK);
 	will_return(__wrap__test_malloc, MOCK_OK);
 
+	/* XXXXXX fix channel */
 	/* prepare an object */
 	int ret = rpma_conn_new(MOCK_PEER, MOCK_CM_ID,
-			MOCK_RPMA_CQ, cstate->rcq, &cstate->conn);
+			MOCK_RPMA_CQ, cstate->rcq, NULL, &cstate->conn);
 
 	/* verify the results */
 	assert_int_equal(ret, MOCK_OK);

--- a/tests/unit/conn/conn-new.c
+++ b/tests/unit/conn/conn-new.c
@@ -23,7 +23,8 @@ new__peer_NULL(void **unused)
 {
 	/* run test */
 	struct rpma_conn *conn = NULL;
-	int ret = rpma_conn_new(NULL, MOCK_CM_ID, MOCK_RPMA_CQ, NULL, &conn);
+	int ret = rpma_conn_new(NULL, MOCK_CM_ID, MOCK_RPMA_CQ, NULL, NULL,
+				&conn);
 
 	/* verify the results */
 	assert_int_equal(ret, RPMA_E_INVAL);
@@ -38,7 +39,8 @@ new__id_NULL(void **unused)
 {
 	/* run test */
 	struct rpma_conn *conn = NULL;
-	int ret = rpma_conn_new(MOCK_PEER, NULL, MOCK_RPMA_CQ, NULL, &conn);
+	int ret = rpma_conn_new(MOCK_PEER, NULL, MOCK_RPMA_CQ, NULL, NULL,
+				&conn);
 
 	/* verify the results */
 	assert_int_equal(ret, RPMA_E_INVAL);
@@ -53,7 +55,7 @@ new__cq_NULL(void **unused)
 {
 	/* run test */
 	struct rpma_conn *conn = NULL;
-	int ret = rpma_conn_new(MOCK_PEER, MOCK_CM_ID, NULL, NULL, &conn);
+	int ret = rpma_conn_new(MOCK_PEER, MOCK_CM_ID, NULL, NULL, NULL, &conn);
 
 	/* verify the results */
 	assert_int_equal(ret, RPMA_E_INVAL);
@@ -68,7 +70,7 @@ new__conn_ptr_NULL(void **unused)
 {
 	/* run test */
 	int ret = rpma_conn_new(MOCK_PEER, MOCK_CM_ID, MOCK_RPMA_CQ, NULL,
-			NULL);
+			NULL, NULL);
 
 	/* verify the results */
 	assert_int_equal(ret, RPMA_E_INVAL);
@@ -82,7 +84,7 @@ static void
 new__peer_id_cq_conn_ptr_NULL(void **unused)
 {
 	/* run test */
-	int ret = rpma_conn_new(NULL, NULL, NULL, NULL, NULL);
+	int ret = rpma_conn_new(NULL, NULL, NULL, NULL, NULL, NULL);
 
 	/* verify the results */
 	assert_int_equal(ret, RPMA_E_INVAL);
@@ -103,7 +105,7 @@ new__create_evch_ERRNO(void **unused)
 	/* run test */
 	struct rpma_conn *conn = NULL;
 	int ret = rpma_conn_new(MOCK_PEER, MOCK_CM_ID, MOCK_RPMA_CQ, NULL,
-			&conn);
+			NULL, &conn);
 
 	/* verify the results */
 	assert_int_equal(ret, RPMA_E_PROVIDER);
@@ -126,7 +128,7 @@ new__migrate_id_ERRNO(void **unused)
 	/* run test */
 	struct rpma_conn *conn = NULL;
 	int ret = rpma_conn_new(MOCK_PEER, MOCK_CM_ID, MOCK_RPMA_CQ, NULL,
-			&conn);
+			NULL, &conn);
 
 	/* verify the results */
 	assert_int_equal(ret, RPMA_E_PROVIDER);
@@ -148,7 +150,7 @@ new__flush_E_NOMEM(void **unused)
 	/* run test */
 	struct rpma_conn *conn = NULL;
 	int ret = rpma_conn_new(MOCK_PEER, MOCK_CM_ID, MOCK_RPMA_CQ, NULL,
-			&conn);
+			NULL, &conn);
 
 	/* verify the results */
 	assert_int_equal(ret, RPMA_E_NOMEM);
@@ -172,7 +174,7 @@ new__malloc_ERRNO(void **unused)
 	/* run test */
 	struct rpma_conn *conn = NULL;
 	int ret = rpma_conn_new(MOCK_PEER, MOCK_CM_ID, MOCK_RPMA_CQ, NULL,
-			&conn);
+			NULL, &conn);
 
 	/* verify the results */
 	assert_int_equal(ret, RPMA_E_NOMEM);

--- a/tests/unit/cq/cq-common.c
+++ b/tests/unit/cq/cq-common.c
@@ -1,4 +1,5 @@
 // SPDX-License-Identifier: BSD-3-Clause
+/* Copyright 2022, Intel Corporation */
 /* Copyright 2021, Fujitsu */
 
 /*
@@ -28,8 +29,9 @@ setup__cq_new(void **cq_ptr)
 	will_return(ibv_req_notify_cq_mock, MOCK_OK);
 	will_return(__wrap__test_malloc, MOCK_OK);
 
+	/* XXXXXX fix channel */
 	/* run test */
-	int ret = rpma_cq_new(MOCK_VERBS, MOCK_CQ_SIZE_DEFAULT, &cq);
+	int ret = rpma_cq_new(MOCK_VERBS, MOCK_CQ_SIZE_DEFAULT, NULL, &cq);
 
 	/* verify the result */
 	assert_int_equal(ret, MOCK_OK);

--- a/tests/unit/cq/cq-new_delete.c
+++ b/tests/unit/cq/cq-new_delete.c
@@ -1,4 +1,5 @@
 // SPDX-License-Identifier: BSD-3-Clause
+/* Copyright 2022, Intel Corporation */
 /* Copyright 2021, Fujitsu */
 
 /*
@@ -30,8 +31,9 @@ new__create_comp_channel_ERRNO(void **unused)
 	will_return(ibv_create_comp_channel, NULL);
 	will_return(ibv_create_comp_channel, MOCK_ERRNO);
 
+	/* XXXXXX fix channel */
 	/* run test */
-	int ret = rpma_cq_new(MOCK_VERBS, MOCK_CQ_SIZE_DEFAULT, &cq);
+	int ret = rpma_cq_new(MOCK_VERBS, MOCK_CQ_SIZE_DEFAULT, NULL, &cq);
 
 	/* verify the result */
 	assert_int_equal(ret, RPMA_E_PROVIDER);
@@ -52,8 +54,9 @@ new__create_cq_ERRNO(void **unused)
 	will_return(ibv_create_cq, MOCK_ERRNO);
 	will_return(ibv_destroy_comp_channel, MOCK_OK);
 
+	/* XXXXXX fix channel */
 	/* run test */
-	int ret = rpma_cq_new(MOCK_VERBS, MOCK_CQ_SIZE_DEFAULT, &cq);
+	int ret = rpma_cq_new(MOCK_VERBS, MOCK_CQ_SIZE_DEFAULT, NULL, &cq);
 
 	/* verify the result */
 	assert_int_equal(ret, RPMA_E_PROVIDER);
@@ -75,8 +78,9 @@ new__create_cq_ERRNO_subsequent_ERRNO2(void **unused)
 	will_return(ibv_create_cq, MOCK_ERRNO);
 	will_return(ibv_destroy_comp_channel, MOCK_ERRNO2);
 
+	/* XXXXXX fix channel */
 	/* run test */
-	int ret = rpma_cq_new(MOCK_VERBS, MOCK_CQ_SIZE_DEFAULT, &cq);
+	int ret = rpma_cq_new(MOCK_VERBS, MOCK_CQ_SIZE_DEFAULT, NULL, &cq);
 
 	/* verify the result */
 	assert_int_equal(ret, RPMA_E_PROVIDER);
@@ -98,8 +102,9 @@ new__req_notify_cq_ERRNO(void **unused)
 	will_return(ibv_destroy_cq, MOCK_OK);
 	will_return(ibv_destroy_comp_channel, MOCK_OK);
 
+	/* XXXXXX fix channel */
 	/* run test */
-	int ret = rpma_cq_new(MOCK_VERBS, MOCK_CQ_SIZE_DEFAULT, &cq);
+	int ret = rpma_cq_new(MOCK_VERBS, MOCK_CQ_SIZE_DEFAULT, NULL, &cq);
 
 	/* verify the result */
 	assert_int_equal(ret, RPMA_E_PROVIDER);
@@ -123,8 +128,9 @@ new__req_notify_cq_ERRNO_subsequent_ERRNO2(void **unused)
 	will_return(ibv_destroy_cq, MOCK_ERRNO2);
 	will_return(ibv_destroy_comp_channel, MOCK_ERRNO2);
 
+	/* XXXXXX fix channel */
 	/* run test */
-	int ret = rpma_cq_new(MOCK_VERBS, MOCK_CQ_SIZE_DEFAULT, &cq);
+	int ret = rpma_cq_new(MOCK_VERBS, MOCK_CQ_SIZE_DEFAULT, NULL, &cq);
 
 	/* verify the result */
 	assert_int_equal(ret, RPMA_E_PROVIDER);
@@ -147,8 +153,9 @@ new__malloc_ERRNO(void **unused)
 	will_return(ibv_destroy_cq, MOCK_OK);
 	will_return(ibv_destroy_comp_channel, MOCK_OK);
 
+	/* XXXXXX fix channel */
 	/* run test */
-	int ret = rpma_cq_new(MOCK_VERBS, MOCK_CQ_SIZE_DEFAULT, &cq);
+	int ret = rpma_cq_new(MOCK_VERBS, MOCK_CQ_SIZE_DEFAULT, NULL, &cq);
 
 	/* verify the result */
 	assert_int_equal(ret, RPMA_E_NOMEM);
@@ -173,8 +180,9 @@ new__malloc_ERRNO_subsequent_ERRNO2(void **unused)
 	will_return(ibv_destroy_cq, MOCK_ERRNO2);
 	will_return(ibv_destroy_comp_channel, MOCK_ERRNO2);
 
+	/* XXXXXX fix channel */
 	/* run test */
-	int ret = rpma_cq_new(MOCK_VERBS, MOCK_CQ_SIZE_DEFAULT, &cq);
+	int ret = rpma_cq_new(MOCK_VERBS, MOCK_CQ_SIZE_DEFAULT, NULL, &cq);
 
 	/* verify the result */
 	assert_int_equal(ret, RPMA_E_NOMEM);

--- a/tests/unit/error/error.c
+++ b/tests/unit/error/error.c
@@ -88,6 +88,16 @@ err_2str__E_AGAIN(void **unused)
 }
 
 /*
+ * err_2str__E_SHARED_CHANNEL - sanity test for rpma_err_2str()
+ */
+static void
+err_2str__E_SHARED_CHANNEL(void **unused)
+{
+	assert_string_equal(rpma_err_2str(RPMA_E_SHARED_CHANNEL),
+				"Completion channel is shared");
+}
+
+/*
  * err_2str__E_UNKOWN - sanity test for rpma_err_2str()
  */
 static void
@@ -108,6 +118,7 @@ main(int argc, char *argv[])
 		cmocka_unit_test(err_2str__E_NO_COMPLETION),
 		cmocka_unit_test(err_2str__E_NO_NEXT),
 		cmocka_unit_test(err_2str__E_AGAIN),
+		cmocka_unit_test(err_2str__E_SHARED_CHANNEL),
 		cmocka_unit_test(err_2str__E_UNKNOWN),
 	};
 


### PR DESCRIPTION
Add the common completion channel, shared by CQ and RCQ.

Missing:
- [ ] Write documentation for rpma_conn_cfg_get_compl_channel() in librpma.h
- [ ] Write documentation for rpma_conn_cfg_set_compl_channel() in librpma.h
- [ ] Write documentation for rpma_conn_get_compl_fd() in librpma.h
- [ ] Write documentation for rpma_conn_wait() in librpma.h
- [ ] Update documentation for rpma_cq_wait() in librpma.h
- [ ] Complete unit tests and the mock for rpma_cq_new()
- [ ] Complete unit tests for rpma_cq_wait()
- [ ] Complete unit tests for rpma_conn_req_from_id()
- [ ] Complete unit tests and the mock for rpma_conn_new()
- [ ] Write unit tests for rpma_conn_cfg_set_compl_channel()
- [ ] Write unit tests for rpma_conn_cfg_get_compl_channel()
- [ ] Write unit tests for rpma_comp_channel_new()
- [ ] Write unit tests for rpma_comp_channel_destroy()
- [ ] Write unit tests for rpma_conn_get_compl_fd()
- [ ] Write unit tests for rpma_conn_wait()
- [ ] Write a new example, analogous to example 09, but with the common completion channel
- [ ] Write a new example, analogous to example 12, but with the common completion channel
- [ ] Finish CHANGELOG
- [ ] Fix and remove all "XXXXXX"
- [ ] Make code coverage is 100%: https://app.codecov.io/gh/pmem/rpma/compare/1637/tree

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/pmem/rpma/1637)
<!-- Reviewable:end -->
