### PR TITLE
examples: fix a compiler error about undeclared variable

### DIFF
--- a/examples/03-read-to-persistent/server.c
+++ b/examples/03-read-to-persistent/server.c
@@ -150,7 +150,7 @@ main(int argc, char *argv[])
 		ret = rpma_mr_advise(dst_mr, 0, mr_size,
 			IBV_ADVISE_MR_ADVICE_PREFETCH_WRITE,
 			IBV_ADVISE_MR_FLAG_FLUSH);
-		if (ret)
+		if (ret && ret != RPMA_E_NOSUPP)
 			goto err_mr_dereg;
 	}
 #endif /* USE_LIBPMEM */

--- a/examples/04-write-to-persistent/server.c
+++ b/examples/04-write-to-persistent/server.c
@@ -162,7 +162,7 @@ main(int argc, char *argv[])
 		ret = rpma_mr_advise(mr, 0, mr_size,
 			IBV_ADVISE_MR_ADVICE_PREFETCH_WRITE,
 			IBV_ADVISE_MR_FLAG_FLUSH);
-		if (ret)
+		if (ret && ret != RPMA_E_NOSUPP)
 			goto err_mr_dereg;
 	}
 #endif /* USE_LIBPMEM */

--- a/examples/05-flush-to-persistent/server.c
+++ b/examples/05-flush-to-persistent/server.c
@@ -182,7 +182,7 @@ main(int argc, char *argv[])
 		ret = rpma_mr_advise(mr, 0, mr_size,
 			IBV_ADVISE_MR_ADVICE_PREFETCH_WRITE,
 			IBV_ADVISE_MR_FLAG_FLUSH);
-		if (ret)
+		if (ret && ret != RPMA_E_NOSUPP)
 			goto err_mr_dereg;
 	}
 #endif /* USE_LIBPMEM */

--- a/examples/07-atomic-write/server.c
+++ b/examples/07-atomic-write/server.c
@@ -167,7 +167,7 @@ main(int argc, char *argv[])
 		ret = rpma_mr_advise(mr, 0, mr_size,
 			IBV_ADVISE_MR_ADVICE_PREFETCH_WRITE,
 			IBV_ADVISE_MR_FLAG_FLUSH);
-		if (ret)
+		if (ret && ret != RPMA_E_NOSUPP)
 			goto err_mr_dereg;
 	}
 #endif /* USE_LIBPMEM */

--- a/examples/09-flush-to-persistent-GPSPM/server.c
+++ b/examples/09-flush-to-persistent-GPSPM/server.c
@@ -180,7 +180,7 @@ main(int argc, char *argv[])
 		ret = rpma_mr_advise(mr, 0, mr_size,
 			IBV_ADVISE_MR_ADVICE_PREFETCH_WRITE,
 			IBV_ADVISE_MR_FLAG_FLUSH);
-		if (ret)
+		if (ret && ret != RPMA_E_NOSUPP)
 			goto err_mr_dereg;
 	}
 #endif /* USE_LIBPMEM */

--- a/src/include/librpma.h
+++ b/src/include/librpma.h
@@ -1162,6 +1162,22 @@ int rpma_mr_remote_get_flush_type(const struct rpma_mr_remote *mr,
  */
 int rpma_mr_remote_delete(struct rpma_mr_remote **mr_ptr);
 
+#ifndef IBV_ADVISE_MR_ADVICE_PREFETCH
+#define IBV_ADVISE_MR_ADVICE_PREFETCH	0
+#endif
+
+#ifndef IBV_ADVISE_MR_ADVICE_PREFETCH_WRITE
+#define IBV_ADVISE_MR_ADVICE_PREFETCH_WRITE	1
+#endif
+
+#ifndef IBV_ADVISE_MR_ADVICE_PREFETCH_NO_FAULT
+#define IBV_ADVISE_MR_ADVICE_PREFETCH_NO_FAULT	2
+#endif
+
+#ifndef IBV_ADVISE_MR_FLAG_FLUSH
+#define IBV_ADVISE_MR_FLAG_FLUSH	1
+#endif
+
 /** 3
  * rpma_mr_advise - give advice about an address range in a memory registration
  *

--- a/src/include/librpma.h
+++ b/src/include/librpma.h
@@ -1206,7 +1206,9 @@ int rpma_mr_remote_delete(struct rpma_mr_remote **mr_ptr);
  *	- the requested range is out of the memory registration bounds
  *	- the memory registration usage does not allow the specific advice
  *	- the flags are invalid
- * - RPMA_E_NOSUPP - the operation is not supported by the system
+ * - RPMA_E_NOSUPP - in one of the following:
+ *	- ibv_mr_advise(3) is not supported by libibverbs
+ *	- ibv_mr_advise(3) or the advise is not supported by provider driver
  * - RPMA_E_PROVIDER - ibv_mr_advise(3) failed for other errors
  *
  * SEE ALSO

--- a/src/mr.c
+++ b/src/mr.c
@@ -576,6 +576,10 @@ rpma_mr_advise(struct rpma_mr_local *mr, size_t offset, size_t len,
 			(enum ibv_advise_mr_advice)advice, flags, &sg_list, 1);
 	if (ret) {
 		RPMA_LOG_ERROR_WITH_ERRNO(ret, "ibv_advise_mr()");
+		/*
+		 * ibv_advise_mr() or advise is not supported
+		 * by provider driver
+		 */
 		if (ret == EOPNOTSUPP || ret == ENOTSUP)
 			return RPMA_E_NOSUPP;
 		else if (ret == EFAULT || ret == EINVAL)
@@ -586,7 +590,7 @@ rpma_mr_advise(struct rpma_mr_local *mr, size_t offset, size_t len,
 
 	return 0;
 #else
-	RPMA_LOG_ERROR("ibv_advise_mr() is not supported by the system");
+	RPMA_LOG_ERROR("ibv_advise_mr() is not supported by libibverbs");
 
 	return RPMA_E_NOSUPP;
 #endif


### PR DESCRIPTION
Undeclared IBV_ADVISE_MR_ADVICE_PREFETCH_WRITE and IBV_ADVISE_MR_FLAG_FLUSH
on old libibverbs broke the compilation of examples.  Fix the issue by
defining them internally.

Signed-off-by: Xiao Yang <yangx.jy@fujitsu.com>

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/pmem/rpma/1657)
<!-- Reviewable:end -->
