### PR TITLE
test: rename predefined structures

### DIFF
--- a/tests/unit/conn/conn-common.c
+++ b/tests/unit/conn/conn-common.c
@@ -15,17 +15,17 @@
 const char Private_data[] = "Random data";
 const char Private_data_2[] = "Another random data";
 
-struct conn_test_state Conn_without_rcq = {
+struct conn_test_state Conn_no_rcq_no_channel = {
 	.rcq = NULL,
 	.channel = NULL
 };
 
-struct conn_test_state Conn_with_rcq = {
+struct conn_test_state Conn_with_rcq_no_channel = {
 	.rcq = MOCK_RPMA_RCQ,
 	.channel = NULL
 };
 
-struct conn_test_state Conn_with_rcq_channel = {
+struct conn_test_state Conn_with_rcq_and_channel = {
 	.rcq = MOCK_RPMA_RCQ,
 	.channel = MOCK_COMP_CHANNEL
 };
@@ -76,9 +76,9 @@ rpma_private_data_discard(struct rpma_conn_private_data *pdata)
 int
 setup__conn_new(void **cstate_ptr)
 {
-	/* the default is Conn_without_rcq */
+	/* the default is Conn_no_rcq_no_channel */
 	struct conn_test_state *cstate = *cstate_ptr ? *cstate_ptr :
-			&Conn_without_rcq;
+			&Conn_no_rcq_no_channel;
 	cstate->conn = NULL;
 	cstate->data.ptr = NULL;
 	cstate->data.len = 0;

--- a/tests/unit/conn/conn-common.h
+++ b/tests/unit/conn/conn-common.h
@@ -21,9 +21,9 @@
 #define CONN_TEST_SETUP_TEARDOWN_WITH_AND_WITHOUT_RCQ(test_func, \
 		setup_func, teardown_func) \
 	{#test_func "__without_rcq", (test_func), (setup_func), \
-		(teardown_func), &Conn_without_rcq}, \
+		(teardown_func), &Conn_no_rcq_no_channel}, \
 	{#test_func "__with_rcq", (test_func), (setup_func), \
-		(teardown_func), &Conn_with_rcq}
+		(teardown_func), &Conn_with_rcq_no_channel}
 #define CONN_TEST_WITH_AND_WITHOUT_RCQ(test_func) \
 	CONN_TEST_SETUP_TEARDOWN_WITH_AND_WITHOUT_RCQ(test_func, NULL, NULL)
 
@@ -35,9 +35,9 @@ struct conn_test_state {
 	struct ibv_comp_channel *channel;
 };
 
-extern struct conn_test_state Conn_without_rcq;
-extern struct conn_test_state Conn_with_rcq;
-extern struct conn_test_state Conn_with_rcq_channel;
+extern struct conn_test_state Conn_no_rcq_no_channel;
+extern struct conn_test_state Conn_with_rcq_no_channel;
+extern struct conn_test_state Conn_with_rcq_and_channel;
 
 int setup__conn_new(void **cstate_ptr);
 int teardown__conn_delete(void **cstate_ptr);

--- a/tests/unit/conn/conn-get_compl_fd.c
+++ b/tests/unit/conn/conn-get_compl_fd.c
@@ -112,10 +112,10 @@ static const struct CMUnitTest tests_get_compl_fd[] = {
 	cmocka_unit_test(get_compl_fd__conn_fd_NULL),
 	cmocka_unit_test_prestate_setup_teardown(
 		get_compl_fd__E_NOT_SHARED_CHNL, setup__conn_new,
-		teardown__conn_delete, &Conn_without_rcq),
+		teardown__conn_delete, &Conn_no_rcq_no_channel),
 	cmocka_unit_test_prestate_setup_teardown(
 		get_compl_fd__success, setup__conn_new,
-		teardown__conn_delete, &Conn_with_rcq_channel),
+		teardown__conn_delete, &Conn_with_rcq_and_channel),
 	cmocka_unit_test(NULL)
 };
 

--- a/tests/unit/conn/conn-new.c
+++ b/tests/unit/conn/conn-new.c
@@ -520,9 +520,11 @@ static const struct CMUnitTest tests_new[] = {
 	cmocka_unit_test(delete__conn_NULL),
 	CONN_TEST_WITH_AND_WITHOUT_RCQ(delete__flush_delete_ERRNO),
 	CONN_TEST_WITH_AND_WITHOUT_RCQ(delete__flush_delete_E_INVAL),
-	cmocka_unit_test_prestate(delete__rcq_delete_ERRNO, &Conn_with_rcq),
+	cmocka_unit_test_prestate(delete__rcq_delete_ERRNO,
+		&Conn_with_rcq_no_channel),
 	cmocka_unit_test_prestate(
-		delete__rcq_delete_ERRNO_subsequent_ERRNO2, &Conn_with_rcq),
+		delete__rcq_delete_ERRNO_subsequent_ERRNO2,
+		&Conn_with_rcq_no_channel),
 	CONN_TEST_WITH_AND_WITHOUT_RCQ(delete__cq_delete_ERRNO),
 	CONN_TEST_WITH_AND_WITHOUT_RCQ(
 		delete__cq_delete_ERRNO_subsequent_ERRNO2),

--- a/tests/unit/conn/conn-wait.c
+++ b/tests/unit/conn/conn-wait.c
@@ -206,15 +206,20 @@ static const struct CMUnitTest tests_new[] = {
 	cmocka_unit_test_setup_teardown(wait__channel_not_shared,
 		setup__conn_new, teardown__conn_delete),
 	cmocka_unit_test_prestate_setup_teardown(wait__get_cq_event_ERRNO,
-		setup__conn_new, teardown__conn_delete, &Conn_with_rcq_channel),
+		setup__conn_new, teardown__conn_delete,
+		&Conn_with_rcq_and_channel),
 	cmocka_unit_test_prestate_setup_teardown(wait__get_cq_event_UNKNOWN,
-		setup__conn_new, teardown__conn_delete, &Conn_with_rcq_channel),
+		setup__conn_new, teardown__conn_delete,
+		&Conn_with_rcq_and_channel),
 	cmocka_unit_test_prestate_setup_teardown(wait__req_notify_cq_ERRNO,
-		setup__conn_new, teardown__conn_delete, &Conn_with_rcq_channel),
+		setup__conn_new, teardown__conn_delete,
+		&Conn_with_rcq_and_channel),
 	cmocka_unit_test_prestate_setup_teardown(wait__success_is_rcq_NULL,
-		setup__conn_new, teardown__conn_delete, &Conn_with_rcq_channel),
+		setup__conn_new, teardown__conn_delete,
+		&Conn_with_rcq_and_channel),
 	cmocka_unit_test_prestate_setup_teardown(wait__success,
-		setup__conn_new, teardown__conn_delete, &Conn_with_rcq_channel)
+		setup__conn_new, teardown__conn_delete,
+		&Conn_with_rcq_and_channel)
 };
 
 int


### PR DESCRIPTION
Rename predefined structures:
- Conn_without_rcq to Conn_no_rcq_no_channel
- Conn_with_rcq to Conn_with_rcq_no_channel
- Conn_with_rcq_channel to Conn_with_rcq_and_channel

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/pmem/rpma/1669)
<!-- Reviewable:end -->
