### PR TITLE
rpma: make timeout_ms always initialized (fix)

### DIFF
--- a/src/conn_req.c
+++ b/src/conn_req.c
@@ -377,7 +377,7 @@ rpma_conn_req_new(struct rpma_peer *peer, const char *addr,
 	if (cfg == NULL)
 		cfg = rpma_conn_cfg_default();
 
-	int timeout_ms;
+	int timeout_ms = 0;
 	(void) rpma_conn_cfg_get_timeout(cfg, &timeout_ms);
 
 	struct rpma_info *info;


### PR DESCRIPTION
It fixes the following valgrind issue:
```
==34690== Syscall param write(buf) points to uninitialised byte(s)
==34690==    at 0x497F1E7: write (write.c:26)
==34690==    by 0x4A893B4: rdma_resolve_addr2 (cma.c:961)
==34690==    by 0x4A89575: rdma_resolve_addr (cma.c:985)
==34690==    by 0x4854A84: rpma_info_resolve_addr (info.c:127)
==34690==    by 0x48520EC: rpma_conn_req_new (conn_req.c:421)
==34690==    by 0x1094BB: main (client.c:67)
==34690==  Address 0x1ffefff7ac is on thread 1's stack
==34690==  in frame #1, created by rdma_resolve_addr2 (cma.c:947)
==34690==
==34690== Syscall param write(buf) points to uninitialised byte(s)
==34690==    at 0x497F1E7: write (write.c:26)
==34690==    by 0x4A896A8: rdma_resolve_route (cma.c:1048)
==34690==    by 0x485210A: rpma_conn_req_new (conn_req.c:426)
==34690==    by 0x1094BB: main (client.c:67)
==34690==  Address 0x1ffefff94c is on thread 1's stack
==34690==  in frame #1, created by rdma_resolve_route (cma.c:1032)
```

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/pmem/rpma/1687)
<!-- Reviewable:end -->
