### PR TITLE
rpma: make shared always initialized (fix)

### DIFF
--- a/src/conn_req.c
+++ b/src/conn_req.c
@@ -77,7 +77,7 @@ rpma_conn_req_from_id(struct rpma_peer *peer, struct rdma_cm_id *id,
 	int ret = 0;
 
 	int cqe, rcqe;
-	bool shared;
+	bool shared = false;
 	/* read the main CQ size from the configuration */
 	(void) rpma_conn_cfg_get_cqe(cfg, &cqe);
 	/* read the receive CQ size from the configuration */


### PR DESCRIPTION
It fixes the following valgrind issue:
```
==34306== Conditional jump or move depends on uninitialised value(s)
==34306==    at 0x4850FD6: rpma_conn_req_from_id (conn_req.c:96)
==34306==    by 0x48521A7: rpma_conn_req_new (conn_req.c:434)
==34306==    by 0x1094BB: main (client.c:67)
```

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/pmem/rpma/1688)
<!-- Reviewable:end -->
