### PR TITLE
rpma: fix memory leak in error handling of rpma_conn_req_connect()

### DIFF
--- a/src/conn_req.c
+++ b/src/conn_req.c
@@ -175,24 +175,22 @@ err_comp_channel_destroy:
 
 /*
  * rpma_conn_req_accept -- call rdma_accept()+rdma_ack_cm_event(). If succeeds
- * request re-packing the connection request to a connection object. Otherwise,
- * rdma_disconnect()+rdma_destroy_qp()+rpma_cq_delete() to destroy
- * the unsuccessful connection request.
+ * request re-packing the connection request to a connection object.
  *
  * ASSUMPTIONS
- * - req != NULL && conn_param != NULL && conn_ptr != NULL
+ * - req_ptr != NULL && *req_ptr != NULL && conn_param != NULL && conn_ptr != NULL
  */
 static int
-rpma_conn_req_accept(struct rpma_conn_req *req,
+rpma_conn_req_accept(struct rpma_conn_req **req_ptr,
 	struct rdma_conn_param *conn_param, struct rpma_conn **conn_ptr)
 {
 	int ret = 0;
 
+	struct rpma_conn_req *req = *req_ptr;
 	if (rdma_accept(req->id, conn_param)) {
 		RPMA_LOG_ERROR_WITH_ERRNO(errno, "rdma_accept()");
-		ret = RPMA_E_PROVIDER;
 		(void) rdma_ack_cm_event(req->edata);
-		goto err_conn_req_delete;
+		return RPMA_E_PROVIDER;
 	}
 
 	/* ACK the connection request event */
@@ -203,56 +201,37 @@ rpma_conn_req_accept(struct rpma_conn_req *req,
 	}
 
 	struct rpma_conn *conn = NULL;
-	ret = rpma_conn_new(req->peer, req->id, req->cq, req->rcq,
-				req->channel, &conn);
+	ret = rpma_conn_new(req->peer, req->id, req->cq, req->rcq, req->channel, &conn);
 	if (ret)
 		goto err_conn_disconnect;
 
 	rpma_conn_transfer_private_data(conn, &req->data);
 
 	*conn_ptr = conn;
+
 	return 0;
 
 err_conn_disconnect:
 	(void) rdma_disconnect(req->id);
-
-err_conn_req_delete:
-	rdma_destroy_qp(req->id);
-	(void) rpma_cq_delete(&req->rcq);
-	(void) rpma_cq_delete(&req->cq);
-	if (req->channel)
-		(void) ibv_destroy_comp_channel(req->channel);
-
 	return ret;
 }
 
 /*
  * rpma_conn_req_connect_active -- call rdma_connect(). If succeeds request
- * re-packing the connection request to a connection object. Otherwise,
- * rdma_destroy_qp()+rpma_cq_delete()+rdma_destroy_id() to destroy
- * the unsuccessful connection request.
+ * re-packing the connection request to a connection object.
  *
  * ASSUMPTIONS
- * - req != NULL && conn_param != NULL && conn_ptr != NULL
+ * - req_ptr != NULL && *req_ptr != NULL && conn_param != NULL && conn_ptr != NULL
  */
 static int
-rpma_conn_req_connect_active(struct rpma_conn_req *req,
+rpma_conn_req_connect_active(struct rpma_conn_req **req_ptr,
 	struct rdma_conn_param *conn_param, struct rpma_conn **conn_ptr)
 {
-	int ret = 0;
-
 	struct rpma_conn *conn = NULL;
-	ret = rpma_conn_new(req->peer, req->id, req->cq, req->rcq,
-				req->channel, &conn);
-	if (ret) {
-		rdma_destroy_qp(req->id);
-		(void) rpma_cq_delete(&req->rcq);
-		(void) rpma_cq_delete(&req->cq);
-		(void) rdma_destroy_id(req->id);
-		if (req->channel)
-			(void) ibv_destroy_comp_channel(req->channel);
+	struct rpma_conn_req *req = *req_ptr;
+	int ret = rpma_conn_new(req->peer, req->id, req->cq, req->rcq, req->channel, &conn);
+	if (ret)
 		return ret;
-	}
 
 	if (rdma_connect(req->id, conn_param)) {
 		RPMA_LOG_ERROR_WITH_ERRNO(errno, "rdma_connect()");
@@ -261,6 +240,7 @@ rpma_conn_req_connect_active(struct rpma_conn_req *req,
 	}
 
 	*conn_ptr = conn;
+
 	return 0;
 }
 
@@ -436,11 +416,7 @@ int
 rpma_conn_req_connect(struct rpma_conn_req **req_ptr,
 	const struct rpma_conn_private_data *pdata, struct rpma_conn **conn_ptr)
 {
-	if (req_ptr == NULL || conn_ptr == NULL)
-		return RPMA_E_INVAL;
-
-	struct rpma_conn_req *req = *req_ptr;
-	if (req == NULL)
+	if (req_ptr == NULL || *req_ptr == NULL || conn_ptr == NULL)
 		return RPMA_E_INVAL;
 
 	if (pdata != NULL) {
@@ -459,15 +435,20 @@ rpma_conn_req_connect(struct rpma_conn_req **req_ptr,
 
 	int ret = 0;
 
-	if (req->edata)
-		ret = rpma_conn_req_accept(req, &conn_param, conn_ptr);
+	if ((*req_ptr)->edata)
+		ret = rpma_conn_req_accept(req_ptr, &conn_param, conn_ptr);
 	else
-		ret = rpma_conn_req_connect_active(req, &conn_param, conn_ptr);
+		ret = rpma_conn_req_connect_active(req_ptr, &conn_param, conn_ptr);
 
-	free(req);
+	if (ret) {
+		rpma_conn_req_delete(req_ptr);
+		return ret;
+	}
+
+	free(*req_ptr);
 	*req_ptr = NULL;
 
-	return ret;
+	return 0;
 }
 
 /*
@@ -506,7 +487,7 @@ rpma_conn_req_delete(struct rpma_conn_req **req_ptr)
 
 	rpma_private_data_discard(&req->data);
 
-	free(req);
+	free(*req_ptr);
 	*req_ptr = NULL;
 
 	return ret;

--- a/tests/unit/conn_req/conn_req-connect.c
+++ b/tests/unit/conn_req/conn_req-connect.c
@@ -142,6 +142,11 @@ connect_via_accept__accept_ERRNO(void **cstate_ptr)
 	will_return(rpma_cq_delete, MOCK_OK);
 	if (cstate->get_cqe.shared)
 		will_return(ibv_destroy_comp_channel, MOCK_OK);
+	expect_value(rdma_reject, id, &cstate->id);
+	will_return(rdma_reject, MOCK_OK);
+	expect_value(rdma_ack_cm_event, event, &cstate->event);
+	will_return(rdma_ack_cm_event, MOCK_OK);
+	expect_function_call(rpma_private_data_discard);
 
 	/* run test */
 	struct rpma_conn *conn = NULL;
@@ -185,6 +190,11 @@ connect_via_accept__accept_ERRNO_subsequent_ERRNO2(void **cstate_ptr)
 	will_return(rpma_cq_delete, MOCK_ERRNO2); /* third or fourth error */
 	if (cstate->get_cqe.shared)
 		will_return(ibv_destroy_comp_channel, MOCK_OK);
+	expect_value(rdma_reject, id, &cstate->id);
+	will_return(rdma_reject, MOCK_OK);
+	expect_value(rdma_ack_cm_event, event, &cstate->event);
+	will_return(rdma_ack_cm_event, MOCK_OK);
+	expect_function_call(rpma_private_data_discard);
 
 	/* run test */
 	struct rpma_conn *conn = NULL;
@@ -221,6 +231,11 @@ connect_via_accept__ack_ERRNO(void **cstate_ptr)
 	will_return(rpma_cq_delete, MOCK_OK);
 	if (cstate->get_cqe.shared)
 		will_return(ibv_destroy_comp_channel, MOCK_OK);
+	expect_value(rdma_reject, id, &cstate->id);
+	will_return(rdma_reject, MOCK_OK);
+	expect_value(rdma_ack_cm_event, event, &cstate->event);
+	will_return(rdma_ack_cm_event, MOCK_OK);
+	expect_function_call(rpma_private_data_discard);
 
 	/* run test */
 	struct rpma_conn *conn = NULL;
@@ -266,6 +281,11 @@ connect_via_accept__ack_ERRNO_subsequent_ERRNO2(void **cstate_ptr)
 	will_return(rpma_cq_delete, MOCK_ERRNO2); /* third or fourth error */
 	if (cstate->get_cqe.shared)
 		will_return(ibv_destroy_comp_channel, MOCK_OK);
+	expect_value(rdma_reject, id, &cstate->id);
+	will_return(rdma_reject, MOCK_OK);
+	expect_value(rdma_ack_cm_event, event, &cstate->event);
+	will_return(rdma_ack_cm_event, MOCK_OK);
+	expect_function_call(rpma_private_data_discard);
 
 	/* run test */
 	struct rpma_conn *conn = NULL;
@@ -309,6 +329,11 @@ connect_via_accept__conn_new_ERRNO(void **cstate_ptr)
 	will_return(rpma_cq_delete, MOCK_OK);
 	if (cstate->get_cqe.shared)
 		will_return(ibv_destroy_comp_channel, MOCK_OK);
+	expect_value(rdma_reject, id, &cstate->id);
+	will_return(rdma_reject, MOCK_OK);
+	expect_value(rdma_ack_cm_event, event, &cstate->event);
+	will_return(rdma_ack_cm_event, MOCK_OK);
+	expect_function_call(rpma_private_data_discard);
 
 	/* run test */
 	struct rpma_conn *conn = NULL;
@@ -360,6 +385,11 @@ connect_via_accept__conn_new_ERRNO_subsequent_ERRNO2(void **cstate_ptr)
 	will_return(rpma_cq_delete, MOCK_ERRNO2); /* third or fourth error */
 	if (cstate->get_cqe.shared)
 		will_return(ibv_destroy_comp_channel, MOCK_OK);
+	expect_value(rdma_reject, id, &cstate->id);
+	will_return(rdma_reject, MOCK_OK);
+	expect_value(rdma_ack_cm_event, event, &cstate->event);
+	will_return(rdma_ack_cm_event, MOCK_OK);
+	expect_function_call(rpma_private_data_discard);
 
 	/* run test */
 	struct rpma_conn *conn = NULL;
@@ -428,6 +458,16 @@ connect_via_connect__connect_ERRNO(void **cstate_ptr)
 	will_return(rdma_connect, MOCK_ERRNO);
 	expect_value(rpma_conn_delete, conn, MOCK_CONN);
 	will_return(rpma_conn_delete, MOCK_OK);
+	expect_value(rdma_destroy_qp, id, &cstate->id);
+	expect_value(rpma_cq_delete, *cq_ptr, MOCK_GET_RCQ(cstate));
+	will_return(rpma_cq_delete, MOCK_OK);
+	expect_value(rpma_cq_delete, *cq_ptr, MOCK_RPMA_CQ);
+	will_return(rpma_cq_delete, MOCK_OK);
+	expect_value(rdma_destroy_id, id, &cstate->id);
+	will_return(rdma_destroy_id, MOCK_OK);
+	if (cstate->get_cqe.shared)
+		will_return(ibv_destroy_comp_channel, MOCK_OK);
+	expect_function_call(rpma_private_data_discard);
 
 	/* run test */
 	struct rpma_conn *conn = NULL;
@@ -461,6 +501,16 @@ connect_via_connect__connect_ERRNO_subsequent_ERRNO2(void **cstate_ptr)
 	expect_value(rpma_conn_delete, conn, MOCK_CONN);
 	will_return(rpma_conn_delete, RPMA_E_PROVIDER);
 	will_return(rpma_conn_delete, MOCK_ERRNO2); /* second error */
+	expect_value(rdma_destroy_qp, id, &cstate->id);
+	expect_value(rpma_cq_delete, *cq_ptr, MOCK_GET_RCQ(cstate));
+	will_return(rpma_cq_delete, MOCK_OK);
+	expect_value(rpma_cq_delete, *cq_ptr, MOCK_RPMA_CQ);
+	will_return(rpma_cq_delete, MOCK_OK);
+	expect_value(rdma_destroy_id, id, &cstate->id);
+	will_return(rdma_destroy_id, MOCK_OK);
+	if (cstate->get_cqe.shared)
+		will_return(ibv_destroy_comp_channel, MOCK_OK);
+	expect_function_call(rpma_private_data_discard);
 
 	/* run test */
 	struct rpma_conn *conn = NULL;
@@ -500,6 +550,7 @@ connect_via_connect__conn_new_ERRNO(void **cstate_ptr)
 	will_return(rdma_destroy_id, MOCK_OK);
 	if (cstate->get_cqe.shared)
 		will_return(ibv_destroy_comp_channel, MOCK_OK);
+	expect_function_call(rpma_private_data_discard);
 
 	/* run test */
 	struct rpma_conn *conn = NULL;
@@ -548,6 +599,7 @@ connect_via_connect__conn_new_ERRNO_subsequent_ERRNO2(void **cstate_ptr)
 	will_return(rdma_destroy_id, MOCK_ERRNO2); /* third or fourth error */
 	if (cstate->get_cqe.shared)
 		will_return(ibv_destroy_comp_channel, MOCK_OK);
+	expect_function_call(rpma_private_data_discard);
 
 	/* run test */
 	struct rpma_conn *conn = NULL;


### PR DESCRIPTION
It fixes the following memory leak:
```
==43181== HEAP SUMMARY:
==43181==     in use at exit: 36,788 bytes in 92 blocks
==43181==   total heap usage: 457 allocs, 365 frees,
==43181==                     540,985 bytes allocated
==43181==
==43181== 24 bytes in 1 blocks are definitely lost
==43181== in loss record 6 of 22
==43181==    at 0x483B7F3: malloc (in /usr/lib/x86_64-linux-gnu/\
==43181==       valgrind/vgpreload_memcheck-amd64-linux.so)
==43181==    by 0x4852BFF: rpma_cq_new (cq.c:92)
==43181==    by 0x485108D: rpma_conn_req_from_id (conn_req.c:107)
==43181==    by 0x48521AB: rpma_conn_req_new (conn_req.c:434)
==43181==    by 0x1094BB: main (client.c:67)
==43181==
==43181== LEAK SUMMARY:
==43181==    definitely lost: 24 bytes in 1 blocks
==43181==    indirectly lost: 0 bytes in 0 blocks
==43181==      possibly lost: 0 bytes in 0 blocks
==43181==    still reachable: 33,788 bytes in 87 blocks
==43181==         suppressed: 2,976 bytes in 4 blocks
```

rdma_ack_cm_event() has just freed this communication event.
Set it to NULL so that rpma_conn_req_delete->rpma_conn_req_reject
does not ack and free it again.

It fixes the following valgrind's error:
```
==32527== Invalid read of size 8
==32527==    at 0x4A85991: rdma_ack_cm_event (cma.c:1965)
==32527==    by 0x4850EA2: rpma_conn_req_reject (conn_req.c:286)
==32527==    by 0x48517EF: rpma_conn_req_delete (conn_req.c:508)
==32527==    by 0x4851746: rpma_conn_req_connect (conn_req.c:476)
==32527==    by 0x1094F5: main (server.c:73)
==32527==  Address 0x4bb3998 is 344 bytes inside a block \
==32527==    of size 352 free'd at 0x483CA3F: free (in \
==32527==    /usr/lib/x86_64-linux-gnu/valgrind/\
==32527==        /vgpreload_memcheck-amd64-linux.so)
==32527==    by 0x4A859EB: rdma_ack_cm_event (cma.c:1969)
==32527==    by 0x4850AF1: rpma_conn_req_accept (conn_req.c:207)
==32527==    by 0x4851715: rpma_conn_req_connect (conn_req.c:471)
==32527==    by 0x1094F5: main (server.c:73)
==32527==  Block was alloc'd at
==32527==    at 0x483B7F3: malloc (in /usr/lib/x86_64-linux-gnu/\
==32527==          /valgrind/vgpreload_memcheck-amd64-linux.so)
==32527==    by 0x4A866F6: rdma_get_cm_event.part.0 (cma.c:2174)
==32527==    by 0x4852C4B: rpma_ep_next_conn_req (ep.c:181)
==32527==    by 0x1094AC: main (server.c:61)
```

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/pmem/rpma/1689)
<!-- Reviewable:end -->
