### PR TITLE
examples: fix EXAMPLE_USE_LIBPMEM_IF_FOUND variable in CMakeLists.txt

### DIFF
--- a/examples/CMakeLists.txt
+++ b/examples/CMakeLists.txt
@@ -77,7 +77,7 @@ function(add_example)
 			PRIVATE USE_LIBPMEM)
 	endif()
 
-	if(EXAMPLE_USE_LIBPMEM2_IF_FOUND AND LIBPMEM2_FOUND)
+	if(EXAMPLE_USE_LIBPMEM_IF_FOUND AND LIBPMEM2_FOUND)
 		target_include_directories(${target}
 			PRIVATE ${LIBPMEM2_INCLUDE_DIRS})
 		target_link_libraries(${target} ${LIBPMEM2_LIBRARIES})


### PR DESCRIPTION
There is no `USE_LIBPMEM2_IF_FOUND` variable,
but there is only `USE_LIBPMEM_IF_FOUND` variable,
so we have to use `EXAMPLE_USE_LIBPMEM_IF_FOUND`
instead of `EXAMPLE_USE_LIBPMEM2_IF_FOUND` here.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/pmem/rpma/1690)
<!-- Reviewable:end -->
