### PR TITLE
test: fix the delete__dealloc_pd_ERRNO unit test

### DIFF
--- a/tests/unit/peer/peer-common.c
+++ b/tests/unit/peer/peer-common.c
@@ -54,9 +54,6 @@ setup__peer(void **in_out)
 int
 teardown__peer(void **peer_ptr)
 {
-	if (*peer_ptr == NULL)
-		return 0;
-
 	/*
 	 * configure mocks for rpma_peer_delete():
 	 * NOTE: it is not allowed to call ibv_alloc_pd() nor malloc() in

--- a/tests/unit/peer/peer-new.c
+++ b/tests/unit/peer/peer-new.c
@@ -292,9 +292,12 @@ delete__null_peer(void **unused)
  * delete__dealloc_pd_ERRNO -- ibv_dealloc_pd() fails with MOCK_ERRNO
  */
 static void
-delete__dealloc_pd_ERRNO(void **peer_ptr)
+delete__dealloc_pd_ERRNO(void **unused)
 {
-	struct rpma_peer *peer = *peer_ptr;
+	int *inout = &OdpCapable;
+	assert_int_equal(setup__peer((void **)&inout), 0);
+	struct rpma_peer *peer = (struct rpma_peer *)inout;
+	assert_non_null(peer);
 
 	/*
 	 * configure mocks for rpma_peer_delete():
@@ -311,9 +314,7 @@ delete__dealloc_pd_ERRNO(void **peer_ptr)
 
 	/* verify the results */
 	assert_int_equal(ret, RPMA_E_PROVIDER);
-
-	/* save changed peer */
-	*peer_ptr = peer;
+	assert_null(peer);
 }
 
 int
@@ -334,9 +335,7 @@ main(int argc, char *argv[])
 		/* rpma_peer_delete() unit tests */
 		cmocka_unit_test(delete__invalid_peer_ptr),
 		cmocka_unit_test(delete__null_peer),
-		cmocka_unit_test_prestate_setup_teardown(
-				delete__dealloc_pd_ERRNO,
-				setup__peer, teardown__peer, &OdpCapable),
+		cmocka_unit_test(delete__dealloc_pd_ERRNO)
 	};
 
 	return cmocka_run_group_tests(tests, NULL, NULL);


### PR DESCRIPTION
Roll back changes in teardown__peer() from 879ca10.

It fixes the following failed unit test on CentOS-7:
https://github.com/pmem/rpma/runs/6121538988

```
[ RUN      ] delete__dealloc_pd_ERRNO
[  FAILED  ] delete__dealloc_pd_ERRNO
[==========] tests: 12 test(s) run.

-- Stderr:
[  ERROR   ] --- Test failed with exception: Bus error(7)
[  PASSED  ] 11 test(s).
[  FAILED  ] tests: 1 test(s), listed below:
[  FAILED  ] delete__dealloc_pd_ERRNO
```

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/pmem/rpma/1692)
<!-- Reviewable:end -->
