### PR TITLE
test: change type of arguments of setup__peer() and teardown__peer()

### DIFF
--- a/tests/unit/peer/peer-common.c
+++ b/tests/unit/peer/peer-common.c
@@ -15,69 +15,15 @@
 #include "peer-common.h"
 #include "test-common.h"
 
-int OdpCapable = MOCK_ODP_CAPABLE;
-int OdpIncapable = MOCK_ODP_INCAPABLE;
+struct prestate prestate_OdpCapable = {0, 0, 0, MOCK_ODP_CAPABLE, NULL};
+struct prestate prestate_OdpIncapable = {0, 0, 0, MOCK_ODP_INCAPABLE, NULL};
 
 /*
  * setup__peer -- prepare a valid rpma_peer object
  * (encapsulating the MOCK_IBV_PD)
- *
- * Note:
- * - in - int **is_odp_capable
- * - out - struct rpma_peer **
  */
 int
-setup__peer(void **in_out)
-{
-	/*
-	 * configure mocks for rpma_peer_new():
-	 * NOTE: it is not allowed to call ibv_dealloc_pd() if ibv_alloc_pd()
-	 * succeeded.
-	 */
-	will_return(rpma_utils_ibv_context_is_odp_capable, **(int **)in_out);
-	struct ibv_alloc_pd_mock_args alloc_args = {MOCK_VALIDATE, MOCK_IBV_PD};
-	will_return(ibv_alloc_pd, &alloc_args);
-	expect_value(ibv_alloc_pd, ibv_ctx, MOCK_VERBS);
-	will_return(__wrap__test_malloc, MOCK_OK);
-
-	/* setup */
-	int ret = rpma_peer_new(MOCK_VERBS, (struct rpma_peer **)in_out);
-	assert_int_equal(ret, 0);
-	assert_non_null(*in_out);
-
-	return 0;
-}
-
-/*
- * teardown__peer -- delete the rpma_peer object
- */
-int
-teardown__peer(void **peer_ptr)
-{
-	/*
-	 * configure mocks for rpma_peer_delete():
-	 * NOTE: it is not allowed to call ibv_alloc_pd() nor malloc() in
-	 * rpma_peer_delete().
-	 */
-	struct ibv_dealloc_pd_mock_args dealloc_args =
-		{MOCK_VALIDATE, MOCK_OK};
-	will_return(ibv_dealloc_pd, &dealloc_args);
-	expect_value(ibv_dealloc_pd, pd, MOCK_IBV_PD);
-
-	/* teardown */
-	int ret = rpma_peer_delete((struct rpma_peer **)peer_ptr);
-	assert_int_equal(ret, MOCK_OK);
-	assert_null(*peer_ptr);
-
-	return 0;
-}
-
-/*
- * setup__peer_prestates -- prepare a valid rpma_peer object
- * (encapsulating the MOCK_IBV_PD)
- */
-int
-setup__peer_prestates(void **pprestate)
+setup__peer(void **pprestate)
 {
 	struct prestate *prestate = *pprestate;
 
@@ -102,10 +48,10 @@ setup__peer_prestates(void **pprestate)
 }
 
 /*
- * teardown__peer_prestates -- delete the rpma_peer object
+ * teardown__peer -- delete the rpma_peer object
  */
 int
-teardown__peer_prestates(void **pprestate)
+teardown__peer(void **pprestate)
 {
 	struct prestate *prestate = *pprestate;
 

--- a/tests/unit/peer/peer-common.h
+++ b/tests/unit/peer/peer-common.h
@@ -1,5 +1,5 @@
 /* SPDX-License-Identifier: BSD-3-Clause */
-/* Copyright 2020-2021, Intel Corporation */
+/* Copyright 2020-2022, Intel Corporation */
 
 /*
  * peer-common.h -- the header of the common part of the peer unit test
@@ -38,12 +38,6 @@
 	RPMA_MR_USAGE_SEND |\
 	RPMA_MR_USAGE_RECV)
 
-extern int OdpCapable;
-extern int OdpIncapable;
-
-int setup__peer(void **in_out);
-int teardown__peer(void **peer_ptr);
-
 struct prestate {
 	enum ibv_transport_type transport_type;
 	int usage;
@@ -52,7 +46,10 @@ struct prestate {
 	struct rpma_peer *peer;
 };
 
-int setup__peer_prestates(void **pprestate);
-int teardown__peer_prestates(void **pprestate);
+extern struct prestate prestate_OdpCapable;
+extern struct prestate prestate_OdpIncapable;
+
+int setup__peer(void **pprestate);
+int teardown__peer(void **pprestate);
 
 #endif /* PEER_COMMON_H */

--- a/tests/unit/peer/peer-create_qp.c
+++ b/tests/unit/peer/peer-create_qp.c
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: BSD-3-Clause
-/* Copyright 2020, Intel Corporation */
+/* Copyright 2020-2022, Intel Corporation */
 /* Copyright 2021, Fujitsu */
 
 /*
@@ -87,12 +87,12 @@ create_qp__peer_NULL(void **unused)
  * create_qp__id_NULL -- NULL id is invalid
  */
 static void
-create_qp__id_NULL(void **peer_ptr)
+create_qp__id_NULL(void **pprestate)
 {
-	struct rpma_peer *peer = *peer_ptr;
+	struct prestate *prestate = *pprestate;
 
 	/* run test */
-	int ret = rpma_peer_create_qp(peer, NULL, MOCK_RPMA_CQ, NULL,
+	int ret = rpma_peer_create_qp(prestate->peer, NULL, MOCK_RPMA_CQ, NULL,
 			MOCK_CONN_CFG_DEFAULT);
 
 	/* verify the results */
@@ -103,12 +103,12 @@ create_qp__id_NULL(void **peer_ptr)
  * create_qp__cq_NULL -- NULL cq is invalid
  */
 static void
-create_qp__cq_NULL(void **peer_ptr)
+create_qp__cq_NULL(void **pprestate)
 {
-	struct rpma_peer *peer = *peer_ptr;
+	struct prestate *prestate = *pprestate;
 
 	/* run test */
-	int ret = rpma_peer_create_qp(peer, MOCK_CM_ID, NULL,
+	int ret = rpma_peer_create_qp(prestate->peer, MOCK_CM_ID, NULL,
 			NULL, MOCK_CONN_CFG_DEFAULT);
 
 	/* verify the results */
@@ -119,9 +119,9 @@ create_qp__cq_NULL(void **peer_ptr)
  * create_qp__rdma_create_qp_ERRNO -- rdma_create_qp() fails with MOCK_ERRNO
  */
 static void
-create_qp__rdma_create_qp_ERRNO(void **peer_ptr)
+create_qp__rdma_create_qp_ERRNO(void **pprestate)
 {
-	struct rpma_peer *peer = *peer_ptr;
+	struct prestate *prestate = *pprestate;
 
 	for (int i = 0; i < num_rcqs; i++) {
 		/* configure mock */
@@ -129,7 +129,7 @@ create_qp__rdma_create_qp_ERRNO(void **peer_ptr)
 		will_return(rdma_create_qp, MOCK_ERRNO);
 
 		/* run test */
-		int ret = rpma_peer_create_qp(peer, MOCK_CM_ID, MOCK_RPMA_CQ,
+		int ret = rpma_peer_create_qp(prestate->peer, MOCK_CM_ID, MOCK_RPMA_CQ,
 				rcqs[i], MOCK_CONN_CFG_CUSTOM);
 
 		/* verify the results */
@@ -141,9 +141,9 @@ create_qp__rdma_create_qp_ERRNO(void **peer_ptr)
  * create_qp__success -- happy day scenario
  */
 static void
-create_qp__success(void **peer_ptr)
+create_qp__success(void **pprestate)
 {
-	struct rpma_peer *peer = *peer_ptr;
+	struct prestate *prestate = *pprestate;
 
 	for (int i = 0; i < num_rcqs; i++) {
 		/* configure mock */
@@ -151,7 +151,7 @@ create_qp__success(void **peer_ptr)
 		will_return(rdma_create_qp, MOCK_OK);
 
 		/* run test */
-		int ret = rpma_peer_create_qp(peer, MOCK_CM_ID, MOCK_RPMA_CQ,
+		int ret = rpma_peer_create_qp(prestate->peer, MOCK_CM_ID, MOCK_RPMA_CQ,
 				rcqs[i], MOCK_CONN_CFG_CUSTOM);
 
 		/* verify the results */
@@ -166,14 +166,14 @@ main(int argc, char *argv[])
 		/* rpma_peer_create_qp() unit tests */
 		cmocka_unit_test(create_qp__peer_NULL),
 		cmocka_unit_test_prestate_setup_teardown(create_qp__id_NULL,
-				setup__peer, teardown__peer, &OdpCapable),
+				setup__peer, teardown__peer, &prestate_OdpCapable),
 		cmocka_unit_test_prestate_setup_teardown(create_qp__cq_NULL,
-				setup__peer, teardown__peer, &OdpCapable),
+				setup__peer, teardown__peer, &prestate_OdpCapable),
 		cmocka_unit_test_prestate_setup_teardown(
 				create_qp__rdma_create_qp_ERRNO,
-				setup__peer, teardown__peer, &OdpCapable),
+				setup__peer, teardown__peer, &prestate_OdpCapable),
 		cmocka_unit_test_prestate_setup_teardown(create_qp__success,
-				setup__peer, teardown__peer, &OdpCapable),
+				setup__peer, teardown__peer, &prestate_OdpCapable),
 	};
 
 	return cmocka_run_group_tests(tests, NULL, NULL);

--- a/tests/unit/peer/peer-mr_reg.c
+++ b/tests/unit/peer/peer-mr_reg.c
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: BSD-3-Clause
-/* Copyright 2020-2021, Intel Corporation */
+/* Copyright 2020-2022, Intel Corporation */
 /* Copyright 2021, Fujitsu */
 
 /*
@@ -75,9 +75,9 @@ static struct prestate prestates[] = {
  * mr_reg__reg_mr_ERRNO -- ibv_reg_mr() fails with MOCK_ERRNO
  */
 static void
-mr_reg__reg_mr_ERRNO(void **peer_ptr)
+mr_reg__reg_mr_ERRNO(void **pprestate)
 {
-	struct rpma_peer *peer = *peer_ptr;
+	struct prestate *prestate = *pprestate;
 
 	/* configure mocks */
 	expect_value(ibv_reg_mr, pd, MOCK_IBV_PD);
@@ -89,7 +89,7 @@ mr_reg__reg_mr_ERRNO(void **peer_ptr)
 
 	/* run test */
 	struct ibv_mr *mr = NULL;
-	int ret = rpma_peer_mr_reg(peer, &mr, MOCK_ADDR,
+	int ret = rpma_peer_mr_reg(prestate->peer, &mr, MOCK_ADDR,
 				MOCK_LEN, MOCK_USAGE);
 
 	/* verify the results */
@@ -101,9 +101,9 @@ mr_reg__reg_mr_ERRNO(void **peer_ptr)
  * mr_reg__reg_mr_EOPNOTSUPP_no_odp -- ibv_reg_mr() fails with EOPNOTSUPP
  */
 static void
-mr_reg__reg_mr_EOPNOTSUPP_no_odp(void **peer_ptr)
+mr_reg__reg_mr_EOPNOTSUPP_no_odp(void **pprestate)
 {
-	struct rpma_peer *peer = *peer_ptr;
+	struct prestate *prestate = *pprestate;
 
 	/* configure mocks */
 	expect_value(ibv_reg_mr, pd, MOCK_IBV_PD);
@@ -115,7 +115,7 @@ mr_reg__reg_mr_EOPNOTSUPP_no_odp(void **peer_ptr)
 
 	/* run test */
 	struct ibv_mr *mr = NULL;
-	int ret = rpma_peer_mr_reg(peer, &mr, MOCK_ADDR,
+	int ret = rpma_peer_mr_reg(prestate->peer, &mr, MOCK_ADDR,
 				MOCK_LEN, MOCK_USAGE);
 
 	/* verify the results */
@@ -128,9 +128,9 @@ mr_reg__reg_mr_EOPNOTSUPP_no_odp(void **peer_ptr)
  * EOPNOTSUPP whereas the second one fails with MOCK_ERRNO
  */
 static void
-mr_reg__reg_mr_EOPNOTSUPP_ERRNO(void **peer_ptr)
+mr_reg__reg_mr_EOPNOTSUPP_ERRNO(void **pprestate)
 {
-	struct rpma_peer *peer = *peer_ptr;
+	struct prestate *prestate = *pprestate;
 
 	/* configure mocks */
 	expect_value(ibv_reg_mr, pd, MOCK_IBV_PD);
@@ -151,7 +151,7 @@ mr_reg__reg_mr_EOPNOTSUPP_ERRNO(void **peer_ptr)
 
 	/* run test */
 	struct ibv_mr *mr = NULL;
-	int ret = rpma_peer_mr_reg(peer, &mr, MOCK_ADDR,
+	int ret = rpma_peer_mr_reg(prestate->peer, &mr, MOCK_ADDR,
 				MOCK_LEN, MOCK_USAGE);
 
 	/* verify the results */
@@ -192,9 +192,9 @@ mr_reg__success(void **pprestate)
  * mr_reg__success_odp -- happy day scenario ODP style
  */
 static void
-mr_reg__success_odp(void **peer_ptr)
+mr_reg__success_odp(void **pprestate)
 {
-	struct rpma_peer *peer = *peer_ptr;
+	struct prestate *prestate = *pprestate;
 
 	/* configure mocks */
 	expect_value(ibv_reg_mr, pd, MOCK_IBV_PD);
@@ -214,7 +214,7 @@ mr_reg__success_odp(void **peer_ptr)
 
 	/* run test */
 	struct ibv_mr *mr;
-	int ret = rpma_peer_mr_reg(peer, &mr, MOCK_ADDR,
+	int ret = rpma_peer_mr_reg(prestate->peer, &mr, MOCK_ADDR,
 				MOCK_LEN, MOCK_USAGE);
 
 	/* verify the results */
@@ -233,48 +233,38 @@ main(int argc, char *argv[])
 	const struct CMUnitTest tests[] = {
 		/* rpma_peer_mr_reg() unit tests */
 		{ "mr_reg__reg_mr_ERRNO_no_odp", mr_reg__reg_mr_ERRNO,
-				setup__peer, teardown__peer, &OdpIncapable},
+				setup__peer, teardown__peer, &prestate_OdpIncapable},
 		{ "mr_reg__reg_mr_ERRNO_odp", mr_reg__reg_mr_ERRNO,
-				setup__peer, teardown__peer, &OdpCapable},
+				setup__peer, teardown__peer, &prestate_OdpCapable},
 		cmocka_unit_test_prestate_setup_teardown(
 				mr_reg__reg_mr_EOPNOTSUPP_no_odp,
-				setup__peer, teardown__peer, &OdpIncapable),
+				setup__peer, teardown__peer, &prestate_OdpIncapable),
 		cmocka_unit_test_prestate_setup_teardown(
 				mr_reg__reg_mr_EOPNOTSUPP_ERRNO,
-				setup__peer, teardown__peer, &OdpCapable),
+				setup__peer, teardown__peer, &prestate_OdpCapable),
 		{ "mr_reg__USAGE_READ_SRC_IB", mr_reg__success,
-				setup__peer_prestates,
-				teardown__peer_prestates, prestates + 0},
+				setup__peer, teardown__peer, prestates + 0},
 		{ "mr_reg__USAGE_READ_SRC_iWARP", mr_reg__success,
-				setup__peer_prestates,
-				teardown__peer_prestates, prestates + 1},
+				setup__peer, teardown__peer, prestates + 1},
 		{ "mr_reg__USAGE_READ_DST_IB", mr_reg__success,
-				setup__peer_prestates,
-				teardown__peer_prestates, prestates + 2},
+				setup__peer, teardown__peer, prestates + 2},
 		{ "mr_reg__USAGE_READ_DST_iWARP", mr_reg__success,
-				setup__peer_prestates,
-				teardown__peer_prestates, prestates + 3},
+				setup__peer, teardown__peer, prestates + 3},
 		{ "mr_reg__USAGE_WRITE_SRC_IB", mr_reg__success,
-				setup__peer_prestates,
-				teardown__peer_prestates, prestates + 4},
+				setup__peer, teardown__peer, prestates + 4},
 		{ "mr_reg__USAGE_WRITE_SRC_iWARP", mr_reg__success,
-				setup__peer_prestates,
-				teardown__peer_prestates, prestates + 5},
+				setup__peer, teardown__peer, prestates + 5},
 		{ "mr_reg__USAGE_WRITE_DST_IB", mr_reg__success,
-				setup__peer_prestates,
-				teardown__peer_prestates, prestates + 6},
+				setup__peer, teardown__peer, prestates + 6},
 		{ "mr_reg__USAGE_WRITE_DST_iWARP", mr_reg__success,
-				setup__peer_prestates,
-				teardown__peer_prestates, prestates + 7},
+				setup__peer, teardown__peer, prestates + 7},
 		{ "mr_reg__USAGE_RECV_IB", mr_reg__success,
-				setup__peer_prestates,
-				teardown__peer_prestates, prestates + 8},
+				setup__peer, teardown__peer, prestates + 8},
 		{ "mr_reg__USAGE_RECV_iWARP", mr_reg__success,
-				setup__peer_prestates,
-				teardown__peer_prestates, prestates + 9},
+				setup__peer, teardown__peer, prestates + 9},
 		cmocka_unit_test_prestate_setup_teardown(
 				mr_reg__success_odp,
-				setup__peer, teardown__peer, &OdpCapable),
+				setup__peer, teardown__peer, &prestate_OdpCapable),
 	};
 
 	return cmocka_run_group_tests(tests, NULL, NULL);

--- a/tests/unit/peer/peer-new.c
+++ b/tests/unit/peer/peer-new.c
@@ -294,10 +294,9 @@ delete__null_peer(void **unused)
 static void
 delete__dealloc_pd_ERRNO(void **unused)
 {
-	int *inout = &OdpCapable;
-	assert_int_equal(setup__peer((void **)&inout), 0);
-	struct rpma_peer *peer = (struct rpma_peer *)inout;
-	assert_non_null(peer);
+	struct prestate *prestate = &prestate_OdpCapable;
+	assert_int_equal(setup__peer((void **)&prestate), 0);
+	assert_non_null(prestate->peer);
 
 	/*
 	 * configure mocks for rpma_peer_delete():
@@ -310,11 +309,11 @@ delete__dealloc_pd_ERRNO(void **unused)
 	expect_value(ibv_dealloc_pd, pd, MOCK_IBV_PD);
 
 	/* run test */
-	int ret = rpma_peer_delete(&peer);
+	int ret = rpma_peer_delete(&prestate->peer);
 
 	/* verify the results */
 	assert_int_equal(ret, RPMA_E_PROVIDER);
-	assert_null(peer);
+	assert_null(prestate->peer);
 }
 
 int


### PR DESCRIPTION
Use `struct prestate` as an argument in both `setup__peer()`
and `teardown__peer()` instead of `in_out`.
Replace `setup__peer_prestates` with `setup__peer`
and `teardown__peer_prestates` with `teardown__peer`.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/pmem/rpma/1693)
<!-- Reviewable:end -->
