### PR TITLE
rpma: include log_default.h in log_internal.h (fix)

### DIFF
--- a/src/log_internal.h
+++ b/src/log_internal.h
@@ -11,6 +11,7 @@
 #include <stdlib.h>
 #include <string.h>
 #include "librpma.h"
+#include "log_default.h"
 
 /* pointer to the logging function */
 extern rpma_log_function *Rpma_log_function;


### PR DESCRIPTION
It fixes the following error:
```
rpma/src/log_internal.h:38:9: error: implicit declaration of function \
 ‘rpma_log_default_function’
```

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/pmem/rpma/1701)
<!-- Reviewable:end -->
