### PR TITLE
rpma: ack the connection request event in rpma_ep_next_conn_req()

### DIFF
--- a/src/conn_req.c
+++ b/src/conn_req.c
@@ -24,8 +24,8 @@
 #endif
 
 struct rpma_conn_req {
-	/* RDMA_CM_EVENT_CONNECT_REQUEST event (if applicable) */
-	struct rdma_cm_event *edata;
+	/* it is the passive side */
+	int is_passive;
 	/* CM ID of the connection request */
 	struct rdma_cm_id *id;
 	/* main CQ */
@@ -146,7 +146,7 @@ rpma_conn_req_from_id(struct rpma_peer *peer, struct rdma_cm_id *id,
 	}
 #undef GID_STR_LEN
 
-	(*req_ptr)->edata = NULL;
+	(*req_ptr)->is_passive = 0;
 	(*req_ptr)->id = id;
 	(*req_ptr)->cq = cq;
 	(*req_ptr)->rcq = rcq;
@@ -191,15 +191,7 @@ rpma_conn_req_accept(struct rpma_conn_req *req,
 	if (rdma_accept(req->id, conn_param)) {
 		RPMA_LOG_ERROR_WITH_ERRNO(errno, "rdma_accept()");
 		ret = RPMA_E_PROVIDER;
-		(void) rdma_ack_cm_event(req->edata);
 		goto err_conn_req_delete;
-	}
-
-	/* ACK the connection request event */
-	if (rdma_ack_cm_event(req->edata)) {
-		RPMA_LOG_ERROR_WITH_ERRNO(errno, "rdma_ack_cm_event()");
-		ret = RPMA_E_PROVIDER;
-		goto err_conn_disconnect;
 	}
 
 	struct rpma_conn *conn = NULL;
@@ -289,13 +281,6 @@ rpma_conn_req_reject(struct rpma_conn_req *req)
 		}
 	}
 
-	if (rdma_ack_cm_event(req->edata)) {
-		if (!ret) {
-			RPMA_LOG_ERROR_WITH_ERRNO(errno, "rdma_ack_cm_event()");
-			ret = RPMA_E_PROVIDER;
-		}
-	}
-
 	return ret;
 }
 
@@ -335,29 +320,31 @@ rpma_conn_req_destroy(struct rpma_conn_req *req)
  */
 int
 rpma_conn_req_from_cm_event(struct rpma_peer *peer,
-		struct rdma_cm_event *edata, const struct rpma_conn_cfg *cfg,
+		struct rdma_cm_event *event, const struct rpma_conn_cfg *cfg,
 		struct rpma_conn_req **req_ptr)
 {
-	if (peer == NULL || edata == NULL || req_ptr == NULL)
-		return RPMA_E_INVAL;
-
-	if (edata->event != RDMA_CM_EVENT_CONNECT_REQUEST)
+	if (peer == NULL || event == NULL || event->event != RDMA_CM_EVENT_CONNECT_REQUEST ||
+	    req_ptr == NULL)
 		return RPMA_E_INVAL;
 
 	struct rpma_conn_req *req = NULL;
-	int ret = rpma_conn_req_from_id(peer, edata->id, cfg, &req);
+	int ret = rpma_conn_req_from_id(peer, event->id, cfg, &req);
 	if (ret)
 		return ret;
 
-	ret = rpma_private_data_store(edata, &req->data);
-	if (ret) {
-		(void) rpma_conn_req_delete(&req);
-		return ret;
-	}
-	req->edata = edata;
+	ret = rpma_private_data_store(event, &req->data);
+	if (ret)
+		goto err_conn_req_delete;
+
+	req->is_passive = 1;
 	*req_ptr = req;
 
 	return 0;
+
+err_conn_req_delete:
+	(void) rpma_conn_req_delete(&req);
+
+	return ret;
 }
 
 /* public librpma API */
@@ -455,7 +442,7 @@ rpma_conn_req_connect(struct rpma_conn_req **req_ptr,
 	conn_param.rnr_retry_count = 7; /* max 3-bit value */
 
 	int ret = 0;
-	if ((*req_ptr)->edata)
+	if ((*req_ptr)->is_passive)
 		ret = rpma_conn_req_accept(*req_ptr, &conn_param, conn_ptr);
 	else
 		ret = rpma_conn_req_connect_active(*req_ptr, &conn_param, conn_ptr);
@@ -485,7 +472,7 @@ rpma_conn_req_delete(struct rpma_conn_req **req_ptr)
 
 	int ret = 0;
 
-	if (req->edata)
+	if (req->is_passive)
 		ret = rpma_conn_req_reject(req);
 	else
 		ret = rpma_conn_req_destroy(req);

--- a/src/ep.c
+++ b/src/ep.c
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: BSD-3-Clause
-/* Copyright 2020, Intel Corporation */
+/* Copyright 2020-2022, Intel Corporation */
 
 /*
  * ep.c -- librpma endpoint-related implementations
@@ -184,6 +184,13 @@ rpma_ep_next_conn_req(struct rpma_ep *ep, const struct rpma_conn_cfg *cfg,
 	ret = rpma_conn_req_from_cm_event(ep->peer, event, cfg, req_ptr);
 	if (ret)
 		goto err_ack;
+
+	/* ACK the connection request event */
+	if (rdma_ack_cm_event(event)) {
+		RPMA_LOG_ERROR_WITH_ERRNO(errno, "rdma_ack_cm_event()");
+		(void) rpma_conn_req_delete(req_ptr);
+		return RPMA_E_PROVIDER;
+	}
 
 	return 0;
 

--- a/tests/unit/conn_req/conn_req-common.c
+++ b/tests/unit/conn_req/conn_req-common.c
@@ -143,8 +143,6 @@ teardown__conn_req_from_cm_event(void **cstate_ptr)
 	will_return(rpma_cq_delete, MOCK_OK);
 	expect_value(rdma_reject, id, &cstate->id);
 	will_return(rdma_reject, MOCK_OK);
-	expect_value(rdma_ack_cm_event, event, &cstate->event);
-	will_return(rdma_ack_cm_event, MOCK_OK);
 	if (cstate->get_cqe.shared)
 		will_return(ibv_destroy_comp_channel, MOCK_OK);
 	expect_function_call(rpma_private_data_discard);

--- a/tests/unit/conn_req/conn_req-connect.c
+++ b/tests/unit/conn_req/conn_req-connect.c
@@ -58,8 +58,6 @@ configure_mocks_conn_req_delete(struct conn_req_test_state *cstate)
 	will_return(rpma_cq_delete, MOCK_OK);
 	expect_value(rdma_reject, id, &cstate->id);
 	will_return(rdma_reject, MOCK_OK);
-	expect_value(rdma_ack_cm_event, event, &cstate->event);
-	will_return(rdma_ack_cm_event, MOCK_OK);
 	if (cstate->get_cqe.shared)
 		will_return(ibv_destroy_comp_channel, MOCK_OK);
 	expect_function_call(rpma_private_data_discard);
@@ -178,8 +176,6 @@ connect_via_accept__accept_ERRNO(void **cstate_ptr)
 	/* configure mocks */
 	expect_value(rdma_accept, id, &cstate->id);
 	will_return(rdma_accept, MOCK_ERRNO);
-	expect_value(rdma_ack_cm_event, event, &cstate->event);
-	will_return(rdma_ack_cm_event, MOCK_OK);
 	expect_value(rdma_destroy_qp, id, &cstate->id);
 	expect_value(rpma_cq_delete, *cq_ptr, MOCK_GET_RCQ(cstate));
 	will_return(rpma_cq_delete, MOCK_OK);
@@ -215,91 +211,6 @@ connect_via_accept__accept_ERRNO_subsequent_ERRNO2(void **cstate_ptr)
 	/* configure mocks */
 	expect_value(rdma_accept, id, &cstate->id);
 	will_return(rdma_accept, MOCK_ERRNO); /* first error */
-	expect_value(rdma_ack_cm_event, event, &cstate->event);
-	will_return(rdma_ack_cm_event, MOCK_ERRNO2); /* second error */
-	expect_value(rdma_destroy_qp, id, &cstate->id);
-	expect_value(rpma_cq_delete, *cq_ptr, MOCK_GET_RCQ(cstate));
-	if (cstate->get_cqe.rcq_size) {
-		will_return(rpma_cq_delete, RPMA_E_PROVIDER);
-		will_return(rpma_cq_delete, MOCK_ERRNO2); /* third error */
-	} else {
-		/* rcq == NULL cannot fail */
-		will_return(rpma_cq_delete, MOCK_OK);
-	}
-	expect_value(rpma_cq_delete, *cq_ptr, MOCK_RPMA_CQ);
-	will_return(rpma_cq_delete, RPMA_E_PROVIDER);
-	will_return(rpma_cq_delete, MOCK_ERRNO2); /* third or fourth error */
-	if (cstate->get_cqe.shared)
-		will_return(ibv_destroy_comp_channel, MOCK_OK);
-	expect_function_call(rpma_private_data_discard);
-
-	/* run test */
-	struct rpma_conn *conn = NULL;
-	int ret = rpma_conn_req_connect(&cstate->req, NULL, &conn);
-
-	/* verify the results */
-	assert_int_equal(ret, RPMA_E_PROVIDER);
-	assert_null(cstate->req);
-	assert_null(conn);
-}
-
-/*
- * connect_via_accept__ack_ERRNO -- rdma_ack_cm_event() fails with MOCK_ERRNO
- */
-static void
-connect_via_accept__ack_ERRNO(void **cstate_ptr)
-{
-	/* WA for cmocka/issues#47 */
-	struct conn_req_test_state *cstate = *cstate_ptr;
-	assert_int_equal(setup__conn_req_from_cm_event((void **)&cstate), 0);
-	assert_non_null(cstate);
-
-	/* configure mocks */
-	expect_value(rdma_accept, id, &cstate->id);
-	will_return(rdma_accept, MOCK_OK);
-	expect_value(rdma_ack_cm_event, event, &cstate->event);
-	will_return(rdma_ack_cm_event, MOCK_ERRNO);
-	expect_value(rdma_disconnect, id, &cstate->id);
-	will_return(rdma_disconnect, MOCK_OK);
-	expect_value(rdma_destroy_qp, id, &cstate->id);
-	expect_value(rpma_cq_delete, *cq_ptr, MOCK_GET_RCQ(cstate));
-	will_return(rpma_cq_delete, MOCK_OK);
-	expect_value(rpma_cq_delete, *cq_ptr, MOCK_RPMA_CQ);
-	will_return(rpma_cq_delete, MOCK_OK);
-	if (cstate->get_cqe.shared)
-		will_return(ibv_destroy_comp_channel, MOCK_OK);
-	expect_function_call(rpma_private_data_discard);
-
-	/* run test */
-	struct rpma_conn *conn = NULL;
-	int ret = rpma_conn_req_connect(&cstate->req, NULL, &conn);
-
-	/* verify the results */
-	assert_int_equal(ret, RPMA_E_PROVIDER);
-	assert_null(cstate->req);
-	assert_null(conn);
-}
-
-/*
- * connect_via_accept__ack_ERRNO_subsequent_ERRNO2 -- rdma_ack_cm_event()
- * fails with MOCK_ERRNO whereas subsequent (rdma_disconnect(),
- * rpma_cq_delete(&req->rcq), rpma_cq_delete(&req->cq)) fail with MOCK_ERRNO2
- */
-static void
-connect_via_accept__ack_ERRNO_subsequent_ERRNO2(void **cstate_ptr)
-{
-	/* WA for cmocka/issues#47 */
-	struct conn_req_test_state *cstate = *cstate_ptr;
-	assert_int_equal(setup__conn_req_from_cm_event((void **)&cstate), 0);
-	assert_non_null(cstate);
-
-	/* configure mocks */
-	expect_value(rdma_accept, id, &cstate->id);
-	will_return(rdma_accept, MOCK_OK);
-	expect_value(rdma_ack_cm_event, event, &cstate->event);
-	will_return(rdma_ack_cm_event, MOCK_ERRNO); /* first error */
-	expect_value(rdma_disconnect, id, &cstate->id);
-	will_return(rdma_disconnect, MOCK_ERRNO2); /* second error */
 	expect_value(rdma_destroy_qp, id, &cstate->id);
 	expect_value(rpma_cq_delete, *cq_ptr, MOCK_GET_RCQ(cstate));
 	if (cstate->get_cqe.rcq_size) {
@@ -341,8 +252,6 @@ connect_via_accept__conn_new_ERRNO(void **cstate_ptr)
 	/* configure mocks */
 	expect_value(rdma_accept, id, &cstate->id);
 	will_return(rdma_accept, MOCK_OK);
-	expect_value(rdma_ack_cm_event, event, &cstate->event);
-	will_return(rdma_ack_cm_event, MOCK_OK);
 	expect_value(rpma_conn_new, id, &cstate->id);
 	expect_value(rpma_conn_new, rcq, MOCK_GET_RCQ(cstate));
 	expect_value(rpma_conn_new, channel, MOCK_GET_CHANNEL(cstate));
@@ -386,8 +295,6 @@ connect_via_accept__conn_new_ERRNO_subsequent_ERRNO2(void **cstate_ptr)
 	/* configure mocks */
 	expect_value(rdma_accept, id, &cstate->id);
 	will_return(rdma_accept, MOCK_OK);
-	expect_value(rdma_ack_cm_event, event, &cstate->event);
-	will_return(rdma_ack_cm_event, MOCK_OK);
 	expect_value(rpma_conn_new, id, &cstate->id);
 	expect_value(rpma_conn_new, rcq, MOCK_GET_RCQ(cstate));
 	expect_value(rpma_conn_new, channel, MOCK_GET_CHANNEL(cstate));
@@ -437,8 +344,6 @@ connect_via_accept__success_incoming(void **cstate_ptr)
 	/* configure mocks */
 	expect_value(rdma_accept, id, &cstate->id);
 	will_return(rdma_accept, MOCK_OK);
-	expect_value(rdma_ack_cm_event, event, &cstate->event);
-	will_return(rdma_ack_cm_event, MOCK_OK);
 	expect_value(rpma_conn_new, id, &cstate->id);
 	expect_value(rpma_conn_new, rcq, MOCK_GET_RCQ(cstate));
 	expect_value(rpma_conn_new, channel, MOCK_GET_CHANNEL(cstate));
@@ -652,9 +557,6 @@ static const struct CMUnitTest test_connect[] = {
 	CONN_REQ_TEST_WITH_AND_WITHOUT_RCQ(connect_via_accept__accept_ERRNO),
 	CONN_REQ_TEST_WITH_AND_WITHOUT_RCQ(
 		connect_via_accept__accept_ERRNO_subsequent_ERRNO2),
-	CONN_REQ_TEST_WITH_AND_WITHOUT_RCQ(connect_via_accept__ack_ERRNO),
-	CONN_REQ_TEST_WITH_AND_WITHOUT_RCQ(
-		connect_via_accept__ack_ERRNO_subsequent_ERRNO2),
 	CONN_REQ_TEST_WITH_AND_WITHOUT_RCQ(connect_via_accept__conn_new_ERRNO),
 	CONN_REQ_TEST_WITH_AND_WITHOUT_RCQ(
 		connect_via_accept__conn_new_ERRNO_subsequent_ERRNO2),

--- a/tests/unit/conn_req/conn_req-delete.c
+++ b/tests/unit/conn_req/conn_req-delete.c
@@ -59,8 +59,6 @@ delete_via_reject__rcq_delete_ERRNO(void **unused)
 	will_return(rpma_cq_delete, MOCK_OK);
 	expect_value(rdma_reject, id, &cstate->id);
 	will_return(rdma_reject, MOCK_OK);
-	expect_value(rdma_ack_cm_event, event, &cstate->event);
-	will_return(rdma_ack_cm_event, MOCK_OK);
 	expect_function_call(rpma_private_data_discard);
 	if (cstate->get_cqe.shared)
 		will_return(ibv_destroy_comp_channel, MOCK_OK);
@@ -97,8 +95,6 @@ delete_via_reject__rcq_delete_ERRNO_subsequent_ERRNO2(void **unused)
 	will_return(rpma_cq_delete, MOCK_ERRNO2); /* second error */
 	expect_value(rdma_reject, id, &cstate->id);
 	will_return(rdma_reject, MOCK_ERRNO2); /* third error */
-	expect_value(rdma_ack_cm_event, event, &cstate->event);
-	will_return(rdma_ack_cm_event, MOCK_ERRNO2); /* fourth error */
 	expect_function_call(rpma_private_data_discard);
 	if (cstate->get_cqe.shared)
 		will_return(ibv_destroy_comp_channel, MOCK_OK);
@@ -132,8 +128,6 @@ delete_via_reject__cq_delete_ERRNO(void **cstate_ptr)
 	will_return(rpma_cq_delete, MOCK_ERRNO);
 	expect_value(rdma_reject, id, &cstate->id);
 	will_return(rdma_reject, MOCK_OK);
-	expect_value(rdma_ack_cm_event, event, &cstate->event);
-	will_return(rdma_ack_cm_event, MOCK_OK);
 	expect_function_call(rpma_private_data_discard);
 	if (cstate->get_cqe.shared)
 		will_return(ibv_destroy_comp_channel, MOCK_OK);
@@ -168,8 +162,6 @@ delete_via_reject__cq_delete_ERRNO_subsequent_ERRNO2(void **cstate_ptr)
 	will_return(rpma_cq_delete, MOCK_ERRNO); /* first error */
 	expect_value(rdma_reject, id, &cstate->id);
 	will_return(rdma_reject, MOCK_ERRNO2); /* second error */
-	expect_value(rdma_ack_cm_event, event, &cstate->event);
-	will_return(rdma_ack_cm_event, MOCK_ERRNO2); /* third error */
 	expect_function_call(rpma_private_data_discard);
 	if (cstate->get_cqe.shared)
 		will_return(ibv_destroy_comp_channel, MOCK_OK);
@@ -201,8 +193,6 @@ delete_via_reject__reject_ERRNO(void **cstate_ptr)
 	will_return(rpma_cq_delete, MOCK_OK);
 	expect_value(rdma_reject, id, &cstate->id);
 	will_return(rdma_reject, MOCK_ERRNO);
-	expect_value(rdma_ack_cm_event, event, &cstate->event);
-	will_return(rdma_ack_cm_event, MOCK_OK);
 	expect_function_call(rpma_private_data_discard);
 	if (cstate->get_cqe.shared)
 		will_return(ibv_destroy_comp_channel, MOCK_OK);
@@ -235,41 +225,6 @@ delete_via_reject__reject_ERRNO_ack_ERRNO2(void **cstate_ptr)
 	will_return(rpma_cq_delete, MOCK_OK);
 	expect_value(rdma_reject, id, &cstate->id);
 	will_return(rdma_reject, MOCK_ERRNO); /* first error */
-	expect_value(rdma_ack_cm_event, event, &cstate->event);
-	will_return(rdma_ack_cm_event, MOCK_ERRNO2); /* second error */
-	expect_function_call(rpma_private_data_discard);
-	if (cstate->get_cqe.shared)
-		will_return(ibv_destroy_comp_channel, MOCK_OK);
-
-	/* run test */
-	int ret = rpma_conn_req_delete(&cstate->req);
-
-	/* verify the results */
-	assert_int_equal(ret, RPMA_E_PROVIDER);
-	assert_null(cstate->req);
-}
-
-/*
- * delete_via_reject__ack_ERRNO - rdma_ack_cm_event() fails with MOCK_ERRNO
- */
-static void
-delete_via_reject__ack_ERRNO(void **cstate_ptr)
-{
-	/* WA for cmocka/issues#47 */
-	struct conn_req_test_state *cstate = *cstate_ptr;
-	assert_int_equal(setup__conn_req_from_cm_event((void **)&cstate), 0);
-	assert_non_null(cstate);
-
-	/* configure mocks */
-	expect_value(rdma_destroy_qp, id, &cstate->id);
-	expect_value(rpma_cq_delete, *cq_ptr, MOCK_GET_RCQ(cstate));
-	will_return(rpma_cq_delete, MOCK_OK);
-	expect_value(rpma_cq_delete, *cq_ptr, MOCK_RPMA_CQ);
-	will_return(rpma_cq_delete, MOCK_OK);
-	expect_value(rdma_reject, id, &cstate->id);
-	will_return(rdma_reject, MOCK_OK);
-	expect_value(rdma_ack_cm_event, event, &cstate->event);
-	will_return(rdma_ack_cm_event, MOCK_ERRNO);
 	expect_function_call(rpma_private_data_discard);
 	if (cstate->get_cqe.shared)
 		will_return(ibv_destroy_comp_channel, MOCK_OK);
@@ -302,8 +257,6 @@ delete_via_reject__ibv_destroy_comp_channel_ERRNO(void **cstate_ptr)
 	will_return(rpma_cq_delete, MOCK_OK);
 	expect_value(rdma_reject, id, &cstate->id);
 	will_return(rdma_reject, MOCK_OK);
-	expect_value(rdma_ack_cm_event, event, &cstate->event);
-	will_return(rdma_ack_cm_event, MOCK_OK);
 	expect_function_call(rpma_private_data_discard);
 	will_return(ibv_destroy_comp_channel, MOCK_ERRNO);
 
@@ -335,8 +288,6 @@ delete_via_reject__ack_ERRNO_ibv_ERRNO2(void **cstate_ptr)
 	will_return(rpma_cq_delete, MOCK_OK);
 	expect_value(rdma_reject, id, &cstate->id);
 	will_return(rdma_reject, MOCK_OK);
-	expect_value(rdma_ack_cm_event, event, &cstate->event);
-	will_return(rdma_ack_cm_event, MOCK_ERRNO); /* first error */
 	expect_function_call(rpma_private_data_discard);
 	will_return(ibv_destroy_comp_channel, MOCK_ERRNO2); /* second error */
 
@@ -591,7 +542,6 @@ static const struct CMUnitTest test_delete[] = {
 	CONN_REQ_TEST_WITH_AND_WITHOUT_RCQ(delete_via_reject__reject_ERRNO),
 	CONN_REQ_TEST_WITH_AND_WITHOUT_RCQ(
 		delete_via_reject__reject_ERRNO_ack_ERRNO2),
-	CONN_REQ_TEST_WITH_AND_WITHOUT_RCQ(delete_via_reject__ack_ERRNO),
 	cmocka_unit_test_prestate(
 		delete_via_reject__ibv_destroy_comp_channel_ERRNO,
 		&Conn_req_conn_cfg_custom),

--- a/tests/unit/conn_req/conn_req-private_data.c
+++ b/tests/unit/conn_req/conn_req-private_data.c
@@ -30,8 +30,6 @@ get_private_data__success(void **cstate_ptr)
 	will_return(rpma_cq_delete, MOCK_OK);
 	expect_value(rdma_reject, id, &cstate->id);
 	will_return(rdma_reject, MOCK_OK);
-	expect_value(rdma_ack_cm_event, event, &cstate->event);
-	will_return(rdma_ack_cm_event, MOCK_OK);
 	if (cstate->get_cqe.shared)
 		will_return(ibv_destroy_comp_channel, MOCK_OK);
 	expect_function_call(rpma_private_data_discard);
@@ -82,8 +80,6 @@ get_private_data__pdata_NULL(void **cstate_ptr)
 	will_return(rpma_cq_delete, MOCK_OK);
 	expect_value(rdma_reject, id, &cstate->id);
 	will_return(rdma_reject, MOCK_OK);
-	expect_value(rdma_ack_cm_event, event, &cstate->event);
-	will_return(rdma_ack_cm_event, MOCK_OK);
 	if (cstate->get_cqe.shared)
 		will_return(ibv_destroy_comp_channel, MOCK_OK);
 	expect_function_call(rpma_private_data_discard);

--- a/tests/unit/ep/ep-common.c
+++ b/tests/unit/ep/ep-common.c
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: BSD-3-Clause
-/* Copyright 2020, Intel Corporation */
+/* Copyright 2020-2022, Intel Corporation */
 
 /*
  * ep-common.c -- common part of the endpoint unit tests
@@ -256,11 +256,11 @@ rdma_get_cm_event(struct rdma_event_channel *channel,
  */
 int
 rpma_conn_req_from_cm_event(struct rpma_peer *peer,
-		struct rdma_cm_event *edata, const struct rpma_conn_cfg *cfg,
+		struct rdma_cm_event *event, const struct rpma_conn_cfg *cfg,
 		struct rpma_conn_req **req_ptr)
 {
 	check_expected_ptr(peer);
-	check_expected_ptr(edata);
+	check_expected_ptr(event);
 	check_expected_ptr(cfg);
 	assert_non_null(req_ptr);
 
@@ -269,6 +269,19 @@ rpma_conn_req_from_cm_event(struct rpma_peer *peer,
 		return mock_type(int);
 
 	*req_ptr = req;
+	return 0;
+}
+
+/*
+ * rpma_conn_req_delete -- rpma_conn_req_delete() mock
+ */
+int
+rpma_conn_req_delete(struct rpma_conn_req **req_ptr)
+{
+	assert_non_null(req_ptr);
+	check_expected_ptr(*req_ptr);
+	*req_ptr = NULL;
+
 	return 0;
 }
 

--- a/tests/unit/ep/ep-next_conn_req.c
+++ b/tests/unit/ep/ep-next_conn_req.c
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: BSD-3-Clause
-/* Copyright 2020, Intel Corporation */
+/* Copyright 2020-2022, Intel Corporation */
 /* Copyright 2021, Fujitsu */
 
 /*
@@ -170,7 +170,7 @@ next_conn_req__from_cm_event_E_NOMEM(void **estate_ptr)
 	will_return(rdma_get_cm_event, &event);
 
 	expect_value(rpma_conn_req_from_cm_event, peer, MOCK_PEER);
-	expect_value(rpma_conn_req_from_cm_event, edata, &event);
+	expect_value(rpma_conn_req_from_cm_event, event, &event);
 	expect_value(rpma_conn_req_from_cm_event, cfg, MOCK_CONN_CFG_DEFAULT);
 	will_return(rpma_conn_req_from_cm_event, NULL);
 	will_return(rpma_conn_req_from_cm_event, RPMA_E_NOMEM);
@@ -203,7 +203,7 @@ next_conn_req__from_cm_event_E_NOMEM_ack_ERRNO(void **estate_ptr)
 	will_return(rdma_get_cm_event, &event);
 
 	expect_value(rpma_conn_req_from_cm_event, peer, MOCK_PEER);
-	expect_value(rpma_conn_req_from_cm_event, edata, &event);
+	expect_value(rpma_conn_req_from_cm_event, event, &event);
 	expect_value(rpma_conn_req_from_cm_event, cfg, MOCK_CONN_CFG_DEFAULT);
 	will_return(rpma_conn_req_from_cm_event, NULL);
 	will_return(rpma_conn_req_from_cm_event, RPMA_E_NOMEM);
@@ -221,6 +221,37 @@ next_conn_req__from_cm_event_E_NOMEM_ack_ERRNO(void **estate_ptr)
 }
 
 /*
+ * next_conn_req__rdma_ack_cm_event_ERRNO - rdma_ack_cm_event() fails with MOCK_ERRNO
+ */
+static void
+next_conn_req__rdma_ack_cm_event_ERRNO(void **estate_ptr)
+{
+	struct ep_test_state *estate = *estate_ptr;
+
+	expect_value(rdma_get_cm_event, channel, &estate->evch);
+	struct rdma_cm_event event;
+	event.event = RDMA_CM_EVENT_CONNECT_REQUEST;
+	will_return(rdma_get_cm_event, &event);
+
+	expect_value(rpma_conn_req_from_cm_event, peer, MOCK_PEER);
+	expect_value(rpma_conn_req_from_cm_event, event, &event);
+	expect_value(rpma_conn_req_from_cm_event, cfg,
+			(estate->cfg == NULL ? MOCK_CONN_CFG_DEFAULT : estate->cfg));
+	will_return(rpma_conn_req_from_cm_event, MOCK_CONN_REQ);
+	expect_value(rdma_ack_cm_event, event, &event);
+	will_return(rdma_ack_cm_event, MOCK_ERRNO);
+	expect_value(rpma_conn_req_delete, *req_ptr, MOCK_CONN_REQ);
+
+	/* run test */
+	struct rpma_conn_req *req = NULL;
+	int ret = rpma_ep_next_conn_req(estate->ep, estate->cfg, &req);
+
+	/* verify the results */
+	assert_int_equal(ret, RPMA_E_PROVIDER);
+	assert_null(req);
+}
+
+/*
  * next_conn_req__success - happy day scenario
  */
 static void
@@ -234,11 +265,12 @@ next_conn_req__success(void **estate_ptr)
 	will_return(rdma_get_cm_event, &event);
 
 	expect_value(rpma_conn_req_from_cm_event, peer, MOCK_PEER);
-	expect_value(rpma_conn_req_from_cm_event, edata, &event);
+	expect_value(rpma_conn_req_from_cm_event, event, &event);
 	expect_value(rpma_conn_req_from_cm_event, cfg,
-			(estate->cfg == NULL ?
-					MOCK_CONN_CFG_DEFAULT : estate->cfg));
+			(estate->cfg == NULL ? MOCK_CONN_CFG_DEFAULT : estate->cfg));
 	will_return(rpma_conn_req_from_cm_event, MOCK_CONN_REQ);
+	expect_value(rdma_ack_cm_event, event, &event);
+	will_return(rdma_ack_cm_event, MOCK_OK);
 
 	/* run test */
 	struct rpma_conn_req *req = NULL;
@@ -288,6 +320,10 @@ main(int argc, char *argv[])
 			&prestate_conn_cfg_default),
 		cmocka_unit_test_prestate_setup_teardown(
 			next_conn_req__from_cm_event_E_NOMEM_ack_ERRNO,
+			setup__ep_listen, teardown__ep_shutdown,
+			&prestate_conn_cfg_default),
+		cmocka_unit_test_prestate_setup_teardown(
+			next_conn_req__rdma_ack_cm_event_ERRNO,
 			setup__ep_listen, teardown__ep_shutdown,
 			&prestate_conn_cfg_default),
 		{"next_conn_req__success_conn_cfg_default",


### PR DESCRIPTION
ACK the connection request event and free it
in `rpma_ep_next_conn_req()` and do not pass it
to the connection request. Use `is_passive` instead of `edata`
to distinguish between active and passive side.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/pmem/rpma/1703)
<!-- Reviewable:end -->
