### PR TITLE
test: fix error handling path of rpma_mr_remote_from_descriptor MT test

### DIFF
--- a/tests/multithreaded/mr/rpma_mr_remote_from_descriptor.c
+++ b/tests/multithreaded/mr/rpma_mr_remote_from_descriptor.c
@@ -2,8 +2,7 @@
 /* Copyright 2022, Intel Corporation */
 
 /*
- * rpma_mr_remote_from_descriptor.c -- rpma_mr_remote_from_descriptor
- * multithreaded test
+ * rpma_mr_remote_from_descriptor.c -- rpma_mr_remote_from_descriptor multithreaded test
  */
 
 #include <stdlib.h>
@@ -54,10 +53,14 @@ prestate_init(void *prestate, struct mtt_result *tr)
 	ret = rpma_mr_remote_get_size(pr->mr_ptr, &pr->mr_size);
 	if (ret) {
 		MTT_RPMA_ERR(tr, "rpma_mr_remote_get_size", ret);
-		goto err_conn_disconnect;
+		goto err_mr_remote_delete;
 	};
 
 	return;
+
+err_mr_remote_delete:
+	/* delete the remote memory region's structure */
+	(void) rpma_mr_remote_delete(&pr->mr_ptr);
 
 err_conn_disconnect:
 	mtt_client_err_disconnect(&pr->conn, &pr->peer);

--- a/tests/multithreaded/mr/server_rpma_mr_remote_from_descriptor.c
+++ b/tests/multithreaded/mr/server_rpma_mr_remote_from_descriptor.c
@@ -2,8 +2,7 @@
 /* Copyright 2022, Intel Corporation */
 
 /*
- * server.c -- a server of the rpma_mr_remote_from_descriptor
- * MT test
+ * server_rpma_mr_remote_from_descriptor.c -- a server of the rpma_mr_remote_from_descriptor MT test
  */
 
 #include <stdlib.h>


### PR DESCRIPTION
Add rpma_mr_remote_delete() in the error handling path.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/pmem/rpma/1707)
<!-- Reviewable:end -->
