### PR TITLE
examples: handle failure of rpma_mr_remote_get_flush_type()

### DIFF
--- a/examples/07-atomic-write/client.c
+++ b/examples/07-atomic-write/client.c
@@ -145,11 +145,12 @@ main(int argc, char *argv[])
 
 	enum rpma_flush_type flush_type;
 	int remote_flush_type;
-	/*
-	 * rpma_mr_remote_get_flush_type() cannot fail here because:
-	 * remote_mr != NULL && remote_flush_type != NULL
-	 */
-	(void) rpma_mr_remote_get_flush_type(remote_mr, &remote_flush_type);
+	ret = rpma_mr_remote_get_flush_type(remote_mr, &remote_flush_type);
+	if (ret) {
+		fprintf(stderr, "rpma_mr_remote_get_flush_type() failed\n");
+		goto err_mr_remote_delete;
+	}
+
 	if (remote_flush_type & RPMA_MR_USAGE_FLUSH_TYPE_PERSISTENT)
 		flush_type = RPMA_FLUSH_TYPE_PERSISTENT;
 	else


### PR DESCRIPTION
It fixes the following valgrind error:
```
==39385== Command: /home/circleci/project/build/examples/07-atomic-write\
==39385==          /client 172.28.63.213 7204 1st_word 2nd_word 3rd_word
==39385== Parent PID: 31175
==39385==
==39385== Conditional jump or move depends on uninitialised value(s)
==39385==    at 0x10AB11: main (client.c:153)
==39385==
```

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/pmem/rpma/1732)
<!-- Reviewable:end -->
