### PR TITLE
examples: fix error handling in client_fetch_name() of example 06

### DIFF
--- a/examples/06-multiple-connections/server.c
+++ b/examples/06-multiple-connections/server.c
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: BSD-3-Clause
-/* Copyright 2020-2021, Intel Corporation */
+/* Copyright 2020-2022, Intel Corporation */
 /* Copyright 2021-2022, Fujitsu */
 
 /*
@@ -267,7 +267,11 @@ client_fetch_name(struct client_res *clnt, struct rpma_mr_local *dst)
 	/* get connection's private data */
 	struct rpma_conn_private_data pdata;
 	int ret = rpma_conn_get_private_data(clnt->conn, &pdata);
-	if (ret != 0 || pdata.len < sizeof(struct common_data)) {
+	if (ret) {
+		(void) fprintf(stderr, "rpma_conn_get_private_data() failed\n");
+		return -1;
+	}
+	if (pdata.len < sizeof(struct common_data)) {
 		(void) fprintf(stderr,
 				"[%d] received connection's private data is too small (%d < %zu)\n",
 				clnt->client_id,


### PR DESCRIPTION
It fixes the following valgrind error:
```
==37831== Conditional jump or move depends on uninitialised value(s)
==37831==    at 0x4907AD8: __vfprintf_internal (vfprintf-internal.c:1687)
==37831==    by 0x490A021: buffered_vfprintf (vfprintf-internal.c:2377)
==37831==    by 0x4906EA3: __vfprintf_internal (vfprintf-internal.c:1346)
==37831==    by 0x48F1DE9: fprintf (fprintf.c:32)
==37831==    by 0x10AC6D: client_fetch_name (server.c:271)
==37831==    by 0x10AD56: client_handle_is_ready (server.c:314)
==37831==    by 0x10ADE3: client_handle_connection_event (server.c:340)
==37831==    by 0x10B124: main (server.c:458)
==37831==
```
and:
```
==37831== Use of uninitialised value of size 8
==37831==    at 0x48EB81B: _itoa_word (_itoa.c:179)
==37831==    by 0x49076F4: __vfprintf_internal (vfprintf-internal.c:1687)
==37831==    by 0x490A021: buffered_vfprintf (vfprintf-internal.c:2377)
==37831==    by 0x4906EA3: __vfprintf_internal (vfprintf-internal.c:1346)
==37831==    by 0x48F1DE9: fprintf (fprintf.c:32)
==37831==    by 0x10AC6D: client_fetch_name (server.c:271)
==37831==    by 0x10AD56: client_handle_is_ready (server.c:314)
==37831==    by 0x10ADE3: client_handle_connection_event (server.c:340)
==37831==    by 0x10B124: main (server.c:458)
==37831==
```