### PR TITLE
examples: fix memory leak in example 08

### DIFF
--- a/examples/08-messages-ping-pong/server.c
+++ b/examples/08-messages-ping-pong/server.c
@@ -89,8 +89,10 @@ main(int argc, char *argv[])
 	}
 
 	/* accept the connection request and obtain the connection object */
-	if ((ret = rpma_conn_req_connect(&req, NULL, &conn)))
+	if ((ret = rpma_conn_req_connect(&req, NULL, &conn))) {
+		(void) rpma_conn_req_delete(&req);
 		goto err_mr_dereg;
+	}
 
 	/* wait for the connection to be established */
 	if ((ret = rpma_conn_next_event(conn, &conn_event)))


### PR DESCRIPTION
It fixes the following valgrind error when `rpma_conn_req_connect()` fails:
```
==34021== 144 (64 direct, 80 indirect) bytes in 1 blocks are definitely lost in loss record 9 of 22
==34021==    at 0x483B7F3: malloc (in /usr/lib/x86_64-linux-gnu/valgrind/vgpreload_memcheck-amd64-linux.so)
==34021==    by 0x48516A8: rpma_conn_req_from_id (conn_req.c:123)
==34021==    by 0x485232F: rpma_conn_req_from_cm_event (conn_req.c:352)
==34021==    by 0x48548FA: rpma_ep_next_conn_req (ep.c:217)
==34021==    by 0x10A708: main (server.c:79)
==34021==
```

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/pmem/rpma/1738)
<!-- Reviewable:end -->
