### PR TITLE
examples: fix error handling in example 08

### DIFF
--- a/examples/08-messages-ping-pong/messages-ping-pong-common.c
+++ b/examples/08-messages-ping-pong/messages-ping-pong-common.c
@@ -58,7 +58,9 @@ wait_and_process_completions(struct rpma_cq *cq, uint64_t *recv,
 		/* get two next completions at most (1 of send + 1 of recv) */
 		if ((ret = rpma_cq_get_wc(cq, MAX_N_WC, wc, &num_got))) {
 			/* lack of completions is not an error here */
-			if (ret && ret != RPMA_E_NO_COMPLETION)
+			if (ret == RPMA_E_NO_COMPLETION)
+				continue;
+			if (ret)
 				return ret;
 		}
 


### PR DESCRIPTION
It fixes the following valgrind error, when `rpma_cq_get_wc()` fails with `RPMA_E_NO_COMPLETION`:
```
==32483== Conditional jump or move depends on uninitialised value(s)
==32483==    at 0x10B053: wait_and_process_completions \
             (messages-ping-pong-common.c:66)
==32483==    by 0x10A89D: main (client.c:121)
==32483==
```

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/pmem/rpma/1739)
<!-- Reviewable:end -->
