### PR TITLE
examples: fix wait_and_process_completions() in example 08

### DIFF
--- a/examples/08-messages-ping-pong/messages-ping-pong-common.c
+++ b/examples/08-messages-ping-pong/messages-ping-pong-common.c
@@ -56,13 +56,8 @@ wait_and_process_completions(struct rpma_cq *cq, uint64_t *recv,
 			return ret;
 
 		/* get two next completions at most (1 of send + 1 of recv) */
-		if ((ret = rpma_cq_get_wc(cq, MAX_N_WC, wc, &num_got))) {
-			/* lack of completions is not an error here */
-			if (ret == RPMA_E_NO_COMPLETION)
-				continue;
-			if (ret)
-				return ret;
-		}
+		if ((ret = rpma_cq_get_wc(cq, MAX_N_WC, wc, &num_got)))
+			return ret;
 
 		/* validate received completions */
 		for (int i = 0; i < num_got; i++) {


### PR DESCRIPTION
`rpma_cq_get_wc()` should not return `RPMA_E_NO_COMPLETION` when it is run in the current loop.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/pmem/rpma/1741)
<!-- Reviewable:end -->
