### PR TITLE
rpma: make conditions of logging in rpma_log_default_function more clear

### DIFF
--- a/src/log_default.c
+++ b/src/log_default.c
@@ -95,6 +95,9 @@ rpma_log_default_function(enum rpma_log_level level, const char *file_name,
 	char message[1024] = "";
 	const char file_info_error[] = "[file info error]: ";
 
+	if (RPMA_LOG_DISABLED == level)
+		return;
+
 	va_list arg;
 	va_start(arg, message_format);
 	if (vsnprintf(message, sizeof(message), message_format, arg) < 0) {
@@ -127,9 +130,11 @@ rpma_log_default_function(enum rpma_log_level level, const char *file_name,
 			rpma_log_level_names[(level == RPMA_LOG_LEVEL_ALWAYS) ?
 						RPMA_LOG_LEVEL_DEBUG : level],
 			file_info, message);
-		if (level == RPMA_LOG_LEVEL_ALWAYS)
-			return; /* do not log to syslog */
 	}
+
+	/* do not log to syslog in case of RPMA_LOG_LEVEL_ALWAYS */
+	if (RPMA_LOG_LEVEL_ALWAYS == level)
+		return;
 
 	/* assumed: level <= Rpma_log_threshold[RPMA_LOG_THRESHOLD] */
 	syslog(rpma_log_level_syslog_severity[level], "%s%s%s",

--- a/tests/unit/log_default/function.c
+++ b/tests/unit/log_default/function.c
@@ -98,6 +98,17 @@ setup_thresholds(void **config_ptr)
 }
 
 /*
+ * function__RPMA_LOG_DISABLED -- call rpma_log_default_function() with RPMA_LOG_DISABLED
+ */
+void
+function__RPMA_LOG_DISABLED(void **unused)
+{
+	/* run test */
+	rpma_log_default_function(RPMA_LOG_DISABLED, MOCK_FILE_NAME,
+			MOCK_LINE_NUMBER, MOCK_FUNCTION_NAME, MOCK_MESSAGE);
+}
+
+/*
  * function__vsnprintf_fail -- vsnprintf() fails
  */
 void
@@ -377,6 +388,9 @@ main(int argc, char *argv[])
 {
 	const struct CMUnitTest tests[] = {
 		/* syslog & stderr common tests */
+		cmocka_unit_test_prestate_setup_teardown(
+			function__RPMA_LOG_DISABLED,
+			setup_thresholds, NULL, &config_no_stderr),
 		cmocka_unit_test_prestate_setup_teardown(
 			function__vsnprintf_fail,
 			setup_thresholds, NULL, &config_no_stderr),


### PR DESCRIPTION
It fixes 3 Klocwork issues.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/pmem/rpma/1752)
<!-- Reviewable:end -->
