### PR TITLE
common: fix chown command on Arch Linux

### DIFF
--- a/utils/docker/images/install-archlinux-aur.sh
+++ b/utils/docker/images/install-archlinux-aur.sh
@@ -1,12 +1,12 @@
 #!/bin/bash -e
 #
 # SPDX-License-Identifier: BSD-3-Clause
-# Copyright 2020, Intel Corporation
+# Copyright 2020-2022, Intel Corporation
 #
 
 PKG=$1
 git clone https://aur.archlinux.org/$PKG.git
-chown -R user.user ./$PKG
+chown -R user:user ./$PKG
 cd $PKG
 sudo -u user makepkg -si --noconfirm --skippgpcheck
 cd ..

--- a/utils/docker/prepare-for-build.sh
+++ b/utils/docker/prepare-for-build.sh
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
 #
 # SPDX-License-Identifier: BSD-3-Clause
-# Copyright 2020, Intel Corporation
+# Copyright 2020-2022, Intel Corporation
 #
 
 #
@@ -16,5 +16,9 @@ function sudo_password() {
 
 # this should be run only on CIs
 if [ "$CI_RUN" == "YES" ]; then
+	set -x
+	echo WORKDIR=$WORKDIR
 	sudo_password chown -R $(id -u).$(id -g) $WORKDIR
+	git config --global --add safe.directory "$WORKDIR"
+	sudo_password git config --global --add safe.directory "$WORKDIR"
 fi


### PR DESCRIPTION
It fixes the following warning:
```sh
chown: warning: '.' should be ':': ‘user.user’
```

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/pmem/rpma/1753)
<!-- Reviewable:end -->
