### PR TITLE
common: install PMDK from sources instead of AUR on Arch Linux

### DIFF
--- a/utils/docker/images/Dockerfile.archlinux-latest
+++ b/utils/docker/images/Dockerfile.archlinux-latest
@@ -54,7 +54,8 @@ ENV PYTHON_DEPS "\
 
 # PMDK deps
 ENV PMDK_DEPS "\
-	ndctl"
+	ndctl \
+	wget"
 
 # RPMA deps
 ENV RPMA_DEPS "\
@@ -88,6 +89,10 @@ RUN ./install-cmocka.sh
 COPY install-txt2man.sh install-txt2man.sh
 RUN ./install-txt2man.sh
 
+# Install PMDK
+COPY install-pmdk.sh install-pmdk.sh
+RUN ./install-pmdk.sh
+
 # Add user
 ENV USER user
 ENV USERPASS p1a2s3s4
@@ -107,7 +112,6 @@ RUN echo 'Defaults env_keep += "FTP_PROXY HTTP_PROXY HTTPS_PROXY NO_PROXY"' >> /
 
 # Install rdma-core and pmdk (requires user 'user')
 COPY install-archlinux-aur.sh install-archlinux-aur.sh
-RUN ./install-archlinux-aur.sh pmdk
 RUN ./install-archlinux-aur.sh rdma-core
 
 # Switch to user

--- a/utils/docker/images/install-pmdk.sh
+++ b/utils/docker/images/install-pmdk.sh
@@ -1,0 +1,25 @@
+#!/usr/bin/env bash
+#
+# SPDX-License-Identifier: BSD-3-Clause
+# Copyright 2020-2022, Intel Corporation
+#
+
+#
+# install-pmdk.sh - installs PMDK libraries
+#
+
+# PMDK version: 1.12.0
+PMDK_VERSION=1.12.0
+
+WORKDIR=$(pwd)
+
+#
+# Install PMDK libraries from a release package with already generated documentation.
+#
+wget https://github.com/pmem/pmdk/releases/download/${PMDK_VERSION}/pmdk-${PMDK_VERSION}.tar.gz
+tar -xzf pmdk-${PMDK_VERSION}.tar.gz
+cd pmdk-${PMDK_VERSION}
+make -j$(nproc) NDCTL_ENABLE=n
+sudo make -j$(nproc) install prefix=/usr NDCTL_ENABLE=n
+cd $WORKDIR
+rm -rf pmdk-${PMDK_VERSION}

--- a/utils/docker/prepare-for-build.sh
+++ b/utils/docker/prepare-for-build.sh
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
 #
 # SPDX-License-Identifier: BSD-3-Clause
-# Copyright 2020, Intel Corporation
+# Copyright 2020-2022, Intel Corporation
 #
 
 #
@@ -16,5 +16,9 @@ function sudo_password() {
 
 # this should be run only on CIs
 if [ "$CI_RUN" == "YES" ]; then
+	set -x
+	echo WORKDIR=$WORKDIR
 	sudo_password chown -R $(id -u).$(id -g) $WORKDIR
+	git config --global --add safe.directory "$WORKDIR"
+	sudo_password git config --global --add safe.directory "$WORKDIR"
 fi


### PR DESCRIPTION
It fixes the following error during compilation of PMDK:
```
../../src/../src/libpmem2/region_namespace_ndctl.c:9:10: \
  fatal error: ndctl/libdaxctl.h: No such file or directory
    9 | #include <ndctl/libdaxctl.h>
      |          ^~~~~~~~~~~~~~~~~~~
compilation terminated.
```

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/pmem/rpma/1754)
<!-- Reviewable:end -->
