### PR TITLE
rpma: only one librpma API call is not thread-safe

### DIFF
--- a/THREAD_SAFETY.md
+++ b/THREAD_SAFETY.md
@@ -103,7 +103,7 @@ are thread-safe only if each thread operates on a **separate connection request*
 
 ## NOT thread-safe API calls
 
-The following API calls of the librpma library are NOT thread-safe:
+Only one API call of the librpma library is NOT thread-safe:
 - rpma_utils_get_ibv_context
 
 ## Relationship of libibverbs and librdmacm


### PR DESCRIPTION


<!-- Reviewable:start -->
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/pmem/rpma/1774)
<!-- Reviewable:end -->
