### PR TITLE
common: doc update should be run only on the master branch (fix)

### DIFF
--- a/utils/docker/build.sh
+++ b/utils/docker/build.sh
@@ -61,8 +61,8 @@ fi
 
 if [ -n "$DNS_SERVER" ]; then DNS_SETTING=" --dns=$DNS_SERVER "; fi
 
-# Only run doc update on $GITHUB_REPO master or stable branch
-if [[ -z "${CI_BRANCH}" || "$CI_EVENT_TYPE" == "pull_request" || "$CI_REPO_SLUG" != "${GITHUB_REPO}" ]]; then
+# Run doc update only on $GITHUB_REPO and only on the master branch
+if [[ "${CI_BRANCH}" != "master" || "$CI_EVENT_TYPE" == "pull_request" || "$CI_REPO_SLUG" != "${GITHUB_REPO}" ]]; then
 	AUTO_DOC_UPDATE=0
 fi
 


### PR DESCRIPTION
It was tested on the devel branch: https://github.com/pmem/rpma/pull/1778
The following build:
https://github.com/pmem/rpma/runs/6624424359
did not trigger the automatic documentation update, what proves that this fix is correct.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/pmem/rpma/1780)
<!-- Reviewable:end -->
