### PR TITLE
common: set WORKDIR as a safe directory

### DIFF
--- a/utils/docker/prepare-for-build.sh
+++ b/utils/docker/prepare-for-build.sh
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
 #
 # SPDX-License-Identifier: BSD-3-Clause
-# Copyright 2020, Intel Corporation
+# Copyright 2020-2022, Intel Corporation
 #
 
 #
@@ -16,5 +16,9 @@ function sudo_password() {
 
 # this should be run only on CIs
 if [ "$CI_RUN" == "YES" ]; then
+	set -x
+	echo WORKDIR=$WORKDIR
 	sudo_password chown -R $(id -u).$(id -g) $WORKDIR
+	git config --global --add safe.directory "$WORKDIR"
+	sudo_password git config --global --add safe.directory "$WORKDIR"
 fi


### PR DESCRIPTION
This is fix for: https://github.com/actions/checkout/issues/766 (git CVE-2022-24765)
```
fatal: unsafe repository ('/rpma' is owned by someone else)
```

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/pmem/rpma/1782)
<!-- Reviewable:end -->
