### PR TITLE
common: fix build of openSUSE Tumbleweed

### DIFF
--- a/utils/docker/images/Dockerfile.opensuse-tumbleweed-latest
+++ b/utils/docker/images/Dockerfile.opensuse-tumbleweed-latest
@@ -53,13 +53,15 @@ ENV PYTHON_DEPS "\
 ENV RPMA_DEPS "\
 	cmake \
 	file \
-	gawk \
 	groff \
 	graphviz \
 	libunwind-devel \
 	pandoc \
 	rpm-build \
 	rdma-core-devel"
+
+# needed to install findutils-4.9.0-1.6.x86_64[repo-oss]
+RUN zypper remove -y busybox-findutils aaa_base-extras
 
 # Install all required packages
 RUN zypper install -y \


### PR DESCRIPTION
It fixes the following 2 issues:
```
Reading installed packages...
'gawk' is already installed.
No update candidate for 'gawk-5.1.1-3.9.x86_64'.
The highest available version is already installed.
Resolving package dependencies...

Problem: the to be installed rpm-build-4.17.0-7.4.x86_64 requires \
  'findutils', but this requirement cannot be provided
  not installable providers: findutils-4.9.0-1.6.i586[repo-oss]
                   findutils-4.9.0-1.6.x86_64[repo-oss]
 Solution 1: deinstallation of busybox-findutils-1.35.0-23.3.noarch
 Solution 2: do not install rpm-build-4.17.0-7.4.x86_64
 Solution 3: break rpm-build-4.17.0-7.4.x86_64 by ignoring some of \
             its dependencies

Choose from above solutions by number or cancel [1/2/3/c/d/?] (c): c
Error: Process completed with exit code 4.
```