### PR TITLE
common: add --allow-unauthenticated to apt-get in CircleCI

### DIFF
--- a/.circleci/install-pkgs-ubuntu.sh
+++ b/.circleci/install-pkgs-ubuntu.sh
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
 #
 # SPDX-License-Identifier: BSD-3-Clause
-# Copyright 2021, Intel Corporation
+# Copyright 2021-2022, Intel Corporation
 #
 
 #
@@ -46,7 +46,7 @@ RPMA_DEPS="\
 	pandoc"
 
 # Update existing packages
-sudo apt-get update
+sudo apt-get update --allow-unauthenticated
 
 # Enable repositories with debug symbols packages (-dbgsym)
 sudo apt-get install --assume-yes --no-install-recommends lsb-release ubuntu-dbgsym-keyring
@@ -54,9 +54,9 @@ echo "deb http://ddebs.ubuntu.com $(lsb_release -cs) main restricted universe mu
 deb http://ddebs.ubuntu.com $(lsb_release -cs)-updates main restricted universe multiverse
 deb http://ddebs.ubuntu.com $(lsb_release -cs)-proposed main restricted universe multiverse" | \
 	sudo tee -a /etc/apt/sources.list.d/ddebs.list
-sudo apt-get update
+sudo apt-get update --allow-unauthenticated
 
-sudo apt-get install --assume-yes --no-install-recommends \
+sudo apt-get install --assume-yes --no-install-recommends --allow-unauthenticated \
 	$BASE_DEPS \
 	$EXAMPLES_DEPS \
 	$TOOLS_DEPS \


### PR DESCRIPTION
Add --allow-unauthenticated to apt-get in CircleCI.
It skips the GPG signature checks of apt on Ubuntu
and bypasses the errors while installing packages.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/pmem/rpma/1793)
<!-- Reviewable:end -->
