### PR TITLE
test: revert running 32 threads in MT tests

### DIFF
--- a/tests/multithreaded/run_group.cmake
+++ b/tests/multithreaded/run_group.cmake
@@ -7,9 +7,7 @@ include(${SRC_DIR}/../../cmake/helpers.cmake)
 
 setup()
 
-# XXX change ulimits to enable 32 threads
-# set(THREADS 32)
-set(THREADS 7)
+set(THREADS 32)
 
 if("$ENV{RPMA_SOFT_ROCE_IP}" STREQUAL "")
 	set(SOFT_ROCE_IP "127.0.0.1")


### PR DESCRIPTION
It works just "out-of-box" now:
- https://app.circleci.com/pipelines/github/ldorau/rpma/4055/workflows/3875a8cf-a028-4203-bca3-4bf3c3a8507b/jobs/4122
- https://app.circleci.com/pipelines/github/ldorau/rpma/4056/workflows/4498f3c9-ad1f-4128-b88b-5ffd1527659f/jobs/4123

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/pmem/rpma/1807)
<!-- Reviewable:end -->
