### PR TITLE
common: always set WORKDIR as a safe directory

### DIFF
--- a/utils/docker/prepare-for-build.sh
+++ b/utils/docker/prepare-for-build.sh
@@ -18,7 +18,8 @@ function sudo_password() {
 if [ "$CI_RUN" == "YES" ]; then
 	echo WORKDIR=$WORKDIR
 	sudo_password chown -R $(id -u).$(id -g) $WORKDIR
-	# fix for: https://github.com/actions/checkout/issues/766 (git CVE-2022-24765)
-	git config --global --add safe.directory "$WORKDIR"
-	sudo_password git config --global --add safe.directory "$WORKDIR"
 fi
+
+# fix for: https://github.com/actions/checkout/issues/766 (git CVE-2022-24765)
+git config --global --add safe.directory "$WORKDIR"
+sudo_password git config --global --add safe.directory "$WORKDIR"


### PR DESCRIPTION
WORKDIR has to be set as a safe directory always (not only on CIs),
because this issue occurs everywhere.

Ref: 69ac575c
Ref: dec98f68

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/pmem/rpma/1819)
<!-- Reviewable:end -->
