### PR TITLE
common: add python3 to openSUSE Leap Docker image (fix)

### DIFF
--- a/utils/docker/images/Dockerfile.opensuse-leap-latest
+++ b/utils/docker/images/Dockerfile.opensuse-leap-latest
@@ -32,6 +32,7 @@ ENV TOOLS_DEPS "\
 	python3-Jinja2"
 
 ENV TESTS_DEPS "\
+	python3 \
 	python3-pip \
 	python3-pylint \
 	python3-pytest \


### PR DESCRIPTION
Fix the CI build of openSUSE Leap by adding the python3 package.
Failed build: https://github.com/pmem/rpma/runs/6853969337

There is no python36 package:
https://github.com/ldorau/rpma/runs/6858757885

The build with the fix:
https://github.com/ldorau/rpma/runs/6858837416

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/pmem/rpma/1829)
<!-- Reviewable:end -->
