### PR TITLE
test: increase timeout for pthread_cond_timedwait() to 60 seconds

### DIFF
--- a/tests/multithreaded/common/mtt.c
+++ b/tests/multithreaded/common/mtt.c
@@ -18,7 +18,7 @@
 
 #include "mtt.h"
 
-#define TIMEOUT_SECONDS 15
+#define TIMEOUT_SECONDS 60
 
 static struct {
 	/* mutex and conditional used to start all threads synchronously */


### PR DESCRIPTION
Increase timeout for pthread_cond_timedwait() to 60 seconds, because the error:
```
mtt.c:80 mtt_thread_main() -> pthread_cond_timedwait() failed: Connection timed out
```
still occurs:

https://app.circleci.com/pipelines/github/haichangsi/rpma/61/workflows/a241ab1b-5230-4a75-b4f1-3a3ae2b91005/jobs/61

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/pmem/rpma/1830)
<!-- Reviewable:end -->
