### PR TITLE
examples: fix quoting in the help message

### DIFF
--- a/examples/run-all-examples.sh
+++ b/examples/run-all-examples.sh
@@ -15,11 +15,11 @@
 # - RPMA_EXAMPLES_STOP_ON_FAILURE
 #
 # In order to run the examples on a PMem (a DAX device or a file on a file system DAX),
-# an absolute path (starting with `/`) to this PMem has to be provided
-# either via the `<pmem-path>` argument or via the `RPMA_EXAMPLES_PMEM_PATH` environment variable.
-# If both of them are set, the command line argument `<pmem-path>` will be used.
+# an absolute path (starting with '/') to this PMem has to be provided
+# either via the '<pmem-path>' argument or via the 'RPMA_EXAMPLES_PMEM_PATH' environment variable.
+# If both of them are set, the command line argument '<pmem-path>' will be used.
 #
-# If the `--stop-on-failure` argument is used or the `RPMA_EXAMPLES_STOP_ON_FAILURE`
+# If the '--stop-on-failure' argument is used or the 'RPMA_EXAMPLES_STOP_ON_FAILURE'
 # environment variable is set to ON, then the integration tests will stop on the first failure.
 #
 
@@ -37,11 +37,11 @@ $ run-all-examples.sh <binary-examples-directory> [--valgrind|--fault-injection]
 Important: the given order of command line arguments is mandatory!\n\
 \n\
 In order to run the examples on a PMem (a DAX device or a file on a file system DAX), \
-an absolute path (starting with `/`) to this PMem has to be provided \
-either via the `<pmem-path>` argument or via the `RPMA_EXAMPLES_PMEM_PATH` environment variable. \
-If both of them are set, the command line argument `<pmem-path>` will be used. \
+an absolute path (starting with '/') to this PMem has to be provided \
+either via the '<pmem-path>' argument or via the 'RPMA_EXAMPLES_PMEM_PATH' environment variable. \
+If both of them are set, the command line argument '<pmem-path>' will be used. \
 \n\
-If the `--stop-on-failure` argument is used or the `RPMA_EXAMPLES_STOP_ON_FAILURE` \
+If the '--stop-on-failure' argument is used or the 'RPMA_EXAMPLES_STOP_ON_FAILURE' \
 environment variable is set to ON, then the integration tests will stop on the first failure.\n"
 
 BIN_DIR=$1


### PR DESCRIPTION
Fix following errors:
```
$ ./run-all-examples.sh ../build/examples/
./run-all-examples.sh: line 45: /: Is a directory
./run-all-examples.sh: command substitution: line 45: syntax error near unexpected token `newline'
./run-all-examples.sh: command substitution: line 45: `<pmem-path>'
./run-all-examples.sh: line 45: RPMA_EXAMPLES_PMEM_PATH: command not found
./run-all-examples.sh: command substitution: line 45: syntax error near unexpected token `newline'
./run-all-examples.sh: command substitution: line 45: `<pmem-path>'
./run-all-examples.sh: line 45: --stop-on-failure: command not found
./run-all-examples.sh: line 45: RPMA_EXAMPLES_STOP_ON_FAILURE: command not found
Notice: PMem path (RPMA_EXAMPLES_PMEM_PATH) is not set, examples will be run on DRAM.
```
