### PR TITLE
rpma: initialize flush_type to prevent a fault-injection error

### DIFF
--- a/src/conn.c
+++ b/src/conn.c
@@ -541,7 +541,12 @@ rpma_flush(struct rpma_conn *conn,
 		return RPMA_E_NOSUPP;
 	}
 
-	int flush_type;
+	/*
+	 * Initialize 'flush_type' to prevent
+	 * the "Conditional jump or move depends on uninitialised value(s)" error
+	 * in case of fault-injection in rpma_mr_remote_get_flush_type().
+	 */
+	int flush_type = 0;
 	/* it cannot fail because: mr != NULL && flush_type != NULL */
 	(void) rpma_mr_remote_get_flush_type(dst, &flush_type);
 


### PR DESCRIPTION
It fixes the following fault-injection error:
```
==378809== Conditional jump or move depends on uninitialised value(s)
==378809==    at 0x4E46584: rpma_flush (conn.c:555)
==378809==    by 0x4021E8: main (client.c:182)
```

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/pmem/rpma/1852)
<!-- Reviewable:end -->
