### PR TITLE
rpma: replace localtime() with localtime_r()

### DIFF
--- a/tests/drd.supp
+++ b/tests/drd.supp
@@ -79,11 +79,11 @@
 }
 
 #
-# Assessment: this suppression indicates a lack of MT safety.
+# Assessment: these 2 suppressions indicate a lack of MT safety.
 #
 # rpma_log_default_function() calls rpma_get_timestamp_prefix()
-# which calls localtime(3).
-# localtime(3) has the "MT-Unsafe race:tmbuf env locale" attributes(7)
+# which calls localtime_r(3).
+# localtime_r(3) has the "MT-Safe env locale" attributes(7)
 # and therefore it is considered as not MT-safe by valgrind.
 # This issue can cause that logs of rpma_log_default_function() can be corrupted,
 # but it does not affect the MT-safety of the librpma library.
@@ -92,14 +92,22 @@
 # libibverbs: 1.14.39.0
 # librdmacm: 1.3.39.0
 #
-# It can occur in traces of all functions of librpma API.
+# They can occur in traces of all functions of librpma API.
 #
 {
    Race while reading the name of time zone ("GMT").
    drd:ConflictingAccess
    ...
    fun:__tz_convert
+   fun:rpma_get_timestamp_prefix
+   fun:rpma_log_default_function
    ...
+}
+{
+   Race while reading the name of time zone ("GMT") - non-existing code path (unknown Valgrind issue on CircleCI)
+   drd:ConflictingAccess
+   ...
+   fun:__tz_convert
    fun:rpma_log_default_function
    ...
 }

--- a/tests/helgrind.supp
+++ b/tests/helgrind.supp
@@ -79,11 +79,11 @@
 }
 
 #
-# Assessment: this suppression indicates a lack of MT safety.
+# Assessment: these 2 suppressions indicate a lack of MT safety.
 #
 # rpma_log_default_function() calls rpma_get_timestamp_prefix()
-# which calls localtime(3).
-# localtime(3) has the "MT-Unsafe race:tmbuf env locale" attributes(7)
+# which calls localtime_r(3).
+# localtime_r(3) has the "MT-Safe env locale" attributes(7)
 # and therefore it is considered as not MT-safe by valgrind.
 # This issue can cause that logs of rpma_log_default_function() can be corrupted,
 # but it does not affect the MT-safety of the librpma library.
@@ -92,14 +92,22 @@
 # libibverbs: 1.14.39.0
 # librdmacm: 1.3.39.0
 #
-# It can occur in traces of all functions of librpma API.
+# They can occur in traces of all functions of librpma API.
 #
 {
    Race while reading the name of time zone ("GMT").
    Helgrind:Race
    ...
    fun:__tz_convert
+   fun:rpma_get_timestamp_prefix
+   fun:rpma_log_default_function
    ...
+}
+{
+   Race while reading the name of time zone ("GMT") - non-existing code path (unknown Valgrind issue on CircleCI)
+   Helgrind:Race
+   ...
+   fun:__tz_convert
    fun:rpma_log_default_function
    ...
 }

--- a/tests/unit/common/mocks-time.c
+++ b/tests/unit/common/mocks-time.c
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: BSD-3-Clause
-/* Copyright 2020, Intel Corporation */
+/* Copyright 2020-2022, Intel Corporation */
 
 /*
  * mocks-time.c -- time.h mocks
@@ -28,16 +28,19 @@ __wrap_clock_gettime(clockid_t __clock_id, struct timespec *__tp)
 }
 
 /*
- * __wrap_localtime -- localtime() mock
+ * __wrap_localtime_r -- localtime_r() mock
  */
 struct tm *
-__wrap_localtime(const time_t *__timer)
+__wrap_localtime_r(const time_t *restrict __timer, struct tm *restrict __result)
 {
 	assert_non_null(__timer);
+	assert_non_null(__result);
 	time_t *timer = mock_type(time_t *);
 	assert_memory_equal(__timer, timer, sizeof(time_t));
-
-	return mock_type(struct tm *);
+	struct tm *__tm = mock_type(struct tm *);
+	if (__tm)
+		memcpy(__result, __tm, sizeof(*__result));
+	return __tm;
 }
 
 size_t

--- a/tests/unit/log_default/CMakeLists.txt
+++ b/tests/unit/log_default/CMakeLists.txt
@@ -1,6 +1,6 @@
 #
 # SPDX-License-Identifier: BSD-3-Clause
-# Copyright 2020, Intel Corporation
+# Copyright 2020-2022, Intel Corporation
 #
 
 include(../../cmake/ctest_helpers.cmake)
@@ -24,7 +24,7 @@ function(build_log_default name)
 
 		set_target_properties(log_default-${name} PROPERTIES
 			LINK_FLAGS
-			"-Wl,--wrap=vsnprintf,--wrap=snprintf,--wrap=fprintf,--wrap=clock_gettime,--wrap=localtime,--wrap=strftime,--wrap=getpid")
+			"-Wl,--wrap=vsnprintf,--wrap=snprintf,--wrap=fprintf,--wrap=clock_gettime,--wrap=localtime_r,--wrap=strftime,--wrap=getpid")
 
 	add_test_generic(NAME log_default-${name} TRACERS none)
 endfunction()

--- a/tests/unit/log_default/function.c
+++ b/tests/unit/log_default/function.c
@@ -17,7 +17,7 @@
  * Where 'writing to stderr' is:
  * 1. in the following order:
  *     1. clock_gettime
- *     2. localtime
+ *     2. localtime_r
  *     3. strftime
  *     4. snprintf
  * 2. fprintf (no matter if the time-related sequence will succeed)
@@ -71,7 +71,7 @@ static const int rpma_log_level_syslog_severity[] = {
 
 typedef struct {
 	int clock_gettime_error;
-	int localtime_error;
+	int localtime_r_error;
 	int strftime_error;
 	int snprintf_no_eol;
 
@@ -212,31 +212,31 @@ static struct tm Tm = MOCK_TIME_OF_DAY;
 #define MOCK_GET_TIMESTAMP_CONFIGURE(x) \
 	if ((x)->clock_gettime_error) { \
 		will_return(__wrap_clock_gettime, NULL); \
-	} else if ((x)->localtime_error) { \
+	} else if ((x)->localtime_r_error) { \
 		will_return(__wrap_clock_gettime, &Timespec); \
-		will_return(__wrap_localtime, &Timespec); \
-		will_return(__wrap_localtime, NULL); \
+		will_return(__wrap_localtime_r, &Timespec); \
+		will_return(__wrap_localtime_r, NULL); \
 	} else if ((x)->strftime_error) { \
 		will_return(__wrap_clock_gettime, &Timespec); \
-		will_return(__wrap_localtime, &Timespec); \
-		will_return(__wrap_localtime, &Tm); \
+		will_return(__wrap_localtime_r, &Timespec); \
+		will_return(__wrap_localtime_r, &Tm); \
 		will_return(__wrap_strftime, MOCK_STRFTIME_ERROR); \
 	} else if ((x)->snprintf_no_eol) { \
 		will_return(__wrap_clock_gettime, &Timespec); \
-		will_return(__wrap_localtime, &Timespec); \
-		will_return(__wrap_localtime, &Tm); \
+		will_return(__wrap_localtime_r, &Timespec); \
+		will_return(__wrap_localtime_r, &Tm); \
 		will_return(__wrap_strftime, MOCK_STRFTIME_SUCCESS); \
 		will_return(__wrap_snprintf, MOCK_SNPRINTF_NO_EOL); \
 	} else { \
 		will_return(__wrap_clock_gettime, &Timespec); \
-		will_return(__wrap_localtime, &Timespec); \
-		will_return(__wrap_localtime, &Tm); \
+		will_return(__wrap_localtime_r, &Timespec); \
+		will_return(__wrap_localtime_r, &Tm); \
 		will_return(__wrap_strftime, MOCK_STRFTIME_SUCCESS); \
 		will_return(__wrap_snprintf, MOCK_OK); \
 	}
 
 #define MOCK_TIME_STR_EXPECTED(x) \
-	(((x)->clock_gettime_error || (x)->localtime_error || \
+	(((x)->clock_gettime_error || (x)->localtime_r_error || \
 			(x)->strftime_error || (x)->snprintf_no_eol) ? \
 			MOCK_TIME_ERROR_STR : MOCK_TIME_STR)
 
@@ -371,7 +371,7 @@ static mock_config config_gettime_error = {
 	1, 0, 0, 0, RPMA_LOG_LEVEL_DEBUG, MOCK_FILE_NAME
 };
 
-static mock_config config_localtime_error = {
+static mock_config config_localtime_r_error = {
 	0, 1, 0, 0, RPMA_LOG_LEVEL_DEBUG, MOCK_FILE_NAME
 };
 
@@ -413,9 +413,9 @@ main(int argc, char *argv[])
 		{"function__stderr_path_gettime_error",
 			function__stderr_path,
 			setup_thresholds, NULL, &config_gettime_error},
-		{"function__stderr_path_localtime_error",
+		{"function__stderr_path_localtime_r_error",
 			function__stderr_path,
-			setup_thresholds, NULL, &config_localtime_error},
+			setup_thresholds, NULL, &config_localtime_r_error},
 		{"function__stderr_path_strftime_error",
 			function__stderr_path,
 			setup_thresholds, NULL, &config_strftime_error},


### PR DESCRIPTION
Replace localtime() with localtime_r() in rpma_get_timestamp_prefix(),
because:
- localtime_r() has "MT-Safe env locale" attributes(7),
while
- localtime() has "MT-Unsafe race:tmbuf env locale" attributes(7).

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/pmem/rpma/1859)
<!-- Reviewable:end -->
