### PR TITLE
test: fix checking if valgrind -s option is supported

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -244,14 +244,14 @@ install(FILES ${CMAKE_CURRENT_BINARY_DIR}/librpma-config.cmake ${CMAKE_CURRENT_B
 pkg_check_modules(VALGRIND valgrind)
 
 if(VALGRIND_FOUND)
-	add_flag(-DVG_MEMCHECK_ENABLED=1)
-	add_flag(-DVG_DRD_ENABLED=1)
-	add_flag(-DVG_HELGRIND_ENABLED=1)
-
 	include_directories(${VALGRIND_INCLUDE_DIRS})
 
 	# sets VALGRIND_S_OPTION to "-s" if valgrind supports it or "" otherwise
 	valgrind_check_s_option()
+
+	add_flag(-DVG_MEMCHECK_ENABLED=1)
+	add_flag(-DVG_DRD_ENABLED=1)
+	add_flag(-DVG_HELGRIND_ENABLED=1)
 
 	if(TESTS_USE_VALGRIND_PMEMCHECK)
 		find_pmemcheck()

--- a/cmake/functions.cmake
+++ b/cmake/functions.cmake
@@ -184,13 +184,15 @@ endfunction()
 function(valgrind_check_s_option)
 	set(ENV{PATH} ${VALGRIND_PREFIX}/bin:$ENV{PATH})
 	execute_process(COMMAND valgrind -s date
-			RESULT_VARIABLE VALGRIND_S_OPTION_RET_VAL
-			OUTPUT_QUIET
-			ERROR_QUIET)
-	if(VALGRIND_S_OPTION_RET_VAL)
+			ERROR_VARIABLE VALGRIND_S_OPTION_STDERR
+			OUTPUT_QUIET)
+	string(REGEX MATCH "Unknown option: -s" VALGRIND_S_OPTION_MATCH "${VALGRIND_S_OPTION_STDERR}")
+	if(VALGRIND_S_OPTION_MATCH)
 		set(VALGRIND_S_OPTION "" CACHE INTERNAL "")
+		message(STATUS "valgrind -s option is not supported")
 	else()
 		set(VALGRIND_S_OPTION "-s" CACHE INTERNAL "")
+		message(STATUS "valgrind -s option is supported")
 	endif()
 endfunction()
 

--- a/tests/cmake/ctest_helpers.cmake
+++ b/tests/cmake/ctest_helpers.cmake
@@ -125,6 +125,7 @@ function(add_testcase name tracer testcase cmake_script)
 			-DTRACER=${tracer}
 			-DLONG_TESTS=${LONG_TESTS}
 			-DNPROC=${NPROC}
+			-DVALGRIND_S_OPTION=${VALGRIND_S_OPTION}
 			-P ${cmake_script})
 
 	set_tests_properties(${name}_${testcase}_${tracer} PROPERTIES


### PR DESCRIPTION
The 'valgrind -s date' command can fail also because of valgrind
issues in the 'date' command, not only because of unknown '-s' option.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/pmem/rpma/1866)
<!-- Reviewable:end -->
