### PR TITLE
rpma: replace localtime_r with gmtime_r [DRAFT]

### DIFF
--- a/src/log_default.c
+++ b/src/log_default.c
@@ -56,7 +56,7 @@ rpma_get_timestamp_prefix(char *buf, size_t buf_size)
 	if (clock_gettime(CLOCK_REALTIME, &ts))
 		goto err_message;
 
-	if (NULL == localtime_r(&ts.tv_sec, &info))
+	if (NULL == gmtime_r(&ts.tv_sec, &info))
 		goto err_message;
 
 	usec = ts.tv_nsec / 1000;
@@ -64,7 +64,7 @@ rpma_get_timestamp_prefix(char *buf, size_t buf_size)
 		goto err_message;
 
 	/* it cannot fail - please see the note above */
-	(void) snprintf(buf, buf_size, "%s.%06ld ", date, usec);
+	(void) snprintf(buf, buf_size, "%s.%06ld(UTC) ", date, usec);
 	if (strnlen(buf, buf_size) == buf_size)
 		goto err_message;
 
@@ -127,7 +127,7 @@ rpma_log_default_function(enum rpma_log_level level, const char *file_name,
 
 	if (level <= Rpma_log_threshold[RPMA_LOG_THRESHOLD_AUX] ||
 	    level == RPMA_LOG_LEVEL_ALWAYS) {
-		char times_tamp[45] = "";
+		char times_tamp[50] = "";
 		rpma_get_timestamp_prefix(times_tamp, sizeof(times_tamp));
 		(void) fprintf(stderr, "%s[%d] %s%s%s", times_tamp, getpid(),
 			rpma_log_level_names[(level == RPMA_LOG_LEVEL_ALWAYS) ?

--- a/tests/drd.supp
+++ b/tests/drd.supp
@@ -79,40 +79,6 @@
 }
 
 #
-# Assessment: these 2 suppressions indicate a lack of MT safety.
-#
-# rpma_log_default_function() calls rpma_get_timestamp_prefix()
-# which calls localtime_r(3).
-# localtime_r(3) has the "MT-Safe env locale" attributes(7)
-# and therefore it is considered as not MT-safe by valgrind.
-# This issue can cause that logs of rpma_log_default_function() can be corrupted,
-# but it does not affect the MT-safety of the librpma library.
-#
-# OS: ubuntu-2204:2022.04.1 of CircleCI
-# libibverbs: 1.14.39.0
-# librdmacm: 1.3.39.0
-#
-# They can occur in traces of all functions of librpma API.
-#
-{
-   Race while reading the name of time zone ("GMT").
-   drd:ConflictingAccess
-   ...
-   fun:__tz_convert
-   fun:rpma_get_timestamp_prefix
-   fun:rpma_log_default_function
-   ...
-}
-{
-   Race while reading the name of time zone ("GMT") - non-existing code path (unknown Valgrind issue on CircleCI)
-   drd:ConflictingAccess
-   ...
-   fun:__tz_convert
-   fun:rpma_log_default_function
-   ...
-}
-
-#
 # Assessment: this suppression does not indicate a lack of MT safety.
 #
 # cma_dev_cnt was a global counter of elements populating the global array of

--- a/tests/helgrind.supp
+++ b/tests/helgrind.supp
@@ -79,40 +79,6 @@
 }
 
 #
-# Assessment: these 2 suppressions indicate a lack of MT safety.
-#
-# rpma_log_default_function() calls rpma_get_timestamp_prefix()
-# which calls localtime_r(3).
-# localtime_r(3) has the "MT-Safe env locale" attributes(7)
-# and therefore it is considered as not MT-safe by valgrind.
-# This issue can cause that logs of rpma_log_default_function() can be corrupted,
-# but it does not affect the MT-safety of the librpma library.
-#
-# OS: ubuntu-2204:2022.04.1 of CircleCI
-# libibverbs: 1.14.39.0
-# librdmacm: 1.3.39.0
-#
-# They can occur in traces of all functions of librpma API.
-#
-{
-   Race while reading the name of time zone ("GMT").
-   Helgrind:Race
-   ...
-   fun:__tz_convert
-   fun:rpma_get_timestamp_prefix
-   fun:rpma_log_default_function
-   ...
-}
-{
-   Race while reading the name of time zone ("GMT") - non-existing code path (unknown Valgrind issue on CircleCI)
-   Helgrind:Race
-   ...
-   fun:__tz_convert
-   fun:rpma_log_default_function
-   ...
-}
-
-#
 # Assessment: this suppression does not indicate a lack of MT safety.
 #
 # For details please see drd.supp.

--- a/tests/unit/common/mocks-time.c
+++ b/tests/unit/common/mocks-time.c
@@ -28,10 +28,10 @@ __wrap_clock_gettime(clockid_t __clock_id, struct timespec *__tp)
 }
 
 /*
- * __wrap_localtime_r -- localtime_r() mock
+ * __wrap_gmtime_r -- gmtime_r() mock
  */
 struct tm *
-__wrap_localtime_r(const time_t *restrict __timer, struct tm *restrict __result)
+__wrap_gmtime_r(const time_t *restrict __timer, struct tm *restrict __result)
 {
 	assert_non_null(__timer);
 	assert_non_null(__result);

--- a/tests/unit/log_default/CMakeLists.txt
+++ b/tests/unit/log_default/CMakeLists.txt
@@ -24,7 +24,7 @@ function(build_log_default name)
 
 		set_target_properties(log_default-${name} PROPERTIES
 			LINK_FLAGS
-			"-Wl,--wrap=vsnprintf,--wrap=snprintf,--wrap=fprintf,--wrap=clock_gettime,--wrap=localtime_r,--wrap=strftime,--wrap=getpid")
+			"-Wl,--wrap=vsnprintf,--wrap=snprintf,--wrap=fprintf,--wrap=clock_gettime,--wrap=gmtime_r,--wrap=strftime,--wrap=getpid")
 
 	add_test_generic(NAME log_default-${name} TRACERS none)
 endfunction()

--- a/tests/unit/log_default/function.c
+++ b/tests/unit/log_default/function.c
@@ -17,7 +17,7 @@
  * Where 'writing to stderr' is:
  * 1. in the following order:
  *     1. clock_gettime
- *     2. localtime_r
+ *     2. gmtime_r
  *     3. strftime
  *     4. snprintf
  * 2. fprintf (no matter if the time-related sequence will succeed)
@@ -71,7 +71,7 @@ static const int rpma_log_level_syslog_severity[] = {
 
 typedef struct {
 	int clock_gettime_error;
-	int localtime_r_error;
+	int gmtime_r_error;
 	int strftime_error;
 	int snprintf_no_eol;
 
@@ -198,7 +198,7 @@ function__syslog(void **config_ptr)
 
 #define MOCK_TIME_OF_DAY {00, 00, 00, 1, 0, 70, 0, 365, 0}
 #define MOCK_TIME_OF_DAY_STR "Jan 01 00:00:00"
-#define MOCK_TIME_STR MOCK_TIME_OF_DAY_STR ".000000 "
+#define MOCK_TIME_STR MOCK_TIME_OF_DAY_STR ".000000(UTC) "
 #define MOCK_TIME_ERROR_STR "[time error] "
 #define MOCK_PID 123456
 #define MOCK_PID_AS_STR "["STR(MOCK_PID)"] "
@@ -212,31 +212,31 @@ static struct tm Tm = MOCK_TIME_OF_DAY;
 #define MOCK_GET_TIMESTAMP_CONFIGURE(x) \
 	if ((x)->clock_gettime_error) { \
 		will_return(__wrap_clock_gettime, NULL); \
-	} else if ((x)->localtime_r_error) { \
+	} else if ((x)->gmtime_r_error) { \
 		will_return(__wrap_clock_gettime, &Timespec); \
-		will_return(__wrap_localtime_r, &Timespec); \
-		will_return(__wrap_localtime_r, NULL); \
+		will_return(__wrap_gmtime_r, &Timespec); \
+		will_return(__wrap_gmtime_r, NULL); \
 	} else if ((x)->strftime_error) { \
 		will_return(__wrap_clock_gettime, &Timespec); \
-		will_return(__wrap_localtime_r, &Timespec); \
-		will_return(__wrap_localtime_r, &Tm); \
+		will_return(__wrap_gmtime_r, &Timespec); \
+		will_return(__wrap_gmtime_r, &Tm); \
 		will_return(__wrap_strftime, MOCK_STRFTIME_ERROR); \
 	} else if ((x)->snprintf_no_eol) { \
 		will_return(__wrap_clock_gettime, &Timespec); \
-		will_return(__wrap_localtime_r, &Timespec); \
-		will_return(__wrap_localtime_r, &Tm); \
+		will_return(__wrap_gmtime_r, &Timespec); \
+		will_return(__wrap_gmtime_r, &Tm); \
 		will_return(__wrap_strftime, MOCK_STRFTIME_SUCCESS); \
 		will_return(__wrap_snprintf, MOCK_SNPRINTF_NO_EOL); \
 	} else { \
 		will_return(__wrap_clock_gettime, &Timespec); \
-		will_return(__wrap_localtime_r, &Timespec); \
-		will_return(__wrap_localtime_r, &Tm); \
+		will_return(__wrap_gmtime_r, &Timespec); \
+		will_return(__wrap_gmtime_r, &Tm); \
 		will_return(__wrap_strftime, MOCK_STRFTIME_SUCCESS); \
 		will_return(__wrap_snprintf, MOCK_OK); \
 	}
 
 #define MOCK_TIME_STR_EXPECTED(x) \
-	(((x)->clock_gettime_error || (x)->localtime_r_error || \
+	(((x)->clock_gettime_error || (x)->gmtime_r_error || \
 			(x)->strftime_error || (x)->snprintf_no_eol) ? \
 			MOCK_TIME_ERROR_STR : MOCK_TIME_STR)
 
@@ -371,7 +371,7 @@ static mock_config config_gettime_error = {
 	1, 0, 0, 0, RPMA_LOG_LEVEL_DEBUG, MOCK_FILE_NAME
 };
 
-static mock_config config_localtime_r_error = {
+static mock_config config_gmtime_r_error = {
 	0, 1, 0, 0, RPMA_LOG_LEVEL_DEBUG, MOCK_FILE_NAME
 };
 
@@ -413,9 +413,9 @@ main(int argc, char *argv[])
 		{"function__stderr_path_gettime_error",
 			function__stderr_path,
 			setup_thresholds, NULL, &config_gettime_error},
-		{"function__stderr_path_localtime_r_error",
+		{"function__stderr_path_gmtime_r_error",
 			function__stderr_path,
-			setup_thresholds, NULL, &config_localtime_r_error},
+			setup_thresholds, NULL, &config_gmtime_r_error},
 		{"function__stderr_path_strftime_error",
 			function__stderr_path,
 			setup_thresholds, NULL, &config_strftime_error},


### PR DESCRIPTION
gmtime_r is documented as threadsafe
gmtime_r is recognized as threadsafe by Valgrind

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/pmem/rpma/1894)
<!-- Reviewable:end -->
