### PR TITLE
rpma: rpma_ep_shutdown is MT-safe

### DIFF
--- a/THREAD_SAFETY.md
+++ b/THREAD_SAFETY.md
@@ -31,6 +31,7 @@ The following API calls of the librpma library are thread-safe:
 - rpma_peer_cfg_from_descriptor
 - rpma_peer_cfg_get_descriptor_size
 - rpma_ep_get_fd
+- rpma_ep_shutdown
 - rpma_conn_cfg_new
 - rpma_conn_cfg_delete
 - rpma_mr_get_descriptor
@@ -110,7 +111,6 @@ The following API calls of the librpma library are NOT thread-safe:
 - rpma_conn_req_delete
 - rpma_ep_listen
 - rpma_ep_next_conn_req
-- rpma_ep_shutdown
 - rpma_mr_reg
 - rpma_mr_dereg
 - rpma_utils_get_ibv_context

--- a/tests/drd.supp
+++ b/tests/drd.supp
@@ -195,7 +195,6 @@
 #
 # Occurs in traces of:
 # - rpma_utils_get_ibv_context
-# - rpma_ep_shutdown
 #
 {
    Conflicting load of size 8

--- a/tests/helgrind.supp
+++ b/tests/helgrind.supp
@@ -144,6 +144,7 @@
 # Occurs in traces of:
 # - rpma_utils_get_ibv_context
 # - rpma_ep_listen
+#
 {
    Possible data race during read of size 8
    Helgrind:Race
@@ -163,8 +164,8 @@
 #
 # Occurs in traces of:
 # - rpma_utils_get_ibv_context
-# - rpma_ep_shutdown
 # - rpma_conn_req_delete
+#
 {
    Possible data race during read of size 8
    Helgrind:Race


### PR DESCRIPTION
The MT-test for rpma_ep_shutdown() does not fail
without suppressions.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/pmem/rpma/1899)
<!-- Reviewable:end -->
