### PR TITLE
test: "ut-" prefix for unit tests' names

### DIFF
--- a/tests/unit/conn/CMakeLists.txt
+++ b/tests/unit/conn/CMakeLists.txt
@@ -7,9 +7,10 @@
 include(../../cmake/ctest_helpers.cmake)
 
 function(add_test_conn name)
-	set(name conn-${name})
+	set(src_name conn-${name})
+	set(name ut-${src_name})
 	build_test_src(UNIT NAME ${name} SRCS
-		${name}.c
+		${src_name}.c
 		conn-common.c
 		${TEST_UNIT_COMMON_DIR}/mocks-ibverbs.c
 		${TEST_UNIT_COMMON_DIR}/mocks-rdma_cm.c

--- a/tests/unit/conn_cfg/CMakeLists.txt
+++ b/tests/unit/conn_cfg/CMakeLists.txt
@@ -7,9 +7,10 @@
 include(../../cmake/ctest_helpers.cmake)
 
 function(add_test_conn_cfg name)
-       set(name conn_cfg-${name})
+       set(src_name conn_cfg-${name})
+	set(name ut-${src_name})
        build_test_src(UNIT NAME ${name} SRCS
-              ${name}.c
+              ${src_name}.c
               conn_cfg-common.c
               ${TEST_UNIT_COMMON_DIR}/mocks-stdlib.c
               ${LIBRPMA_SOURCE_DIR}/conn_cfg.c)

--- a/tests/unit/conn_req/CMakeLists.txt
+++ b/tests/unit/conn_req/CMakeLists.txt
@@ -7,9 +7,10 @@
 include(../../cmake/ctest_helpers.cmake)
 
 function(add_test_conn_req name)
-       set(name conn_req-${name})
+       set(src_name conn_req-${name})
+       set(name ut-${name})
        build_test_src(UNIT NAME ${name} SRCS
-              ${name}.c
+              ${src_name}.c
               conn_req-common.c
               ${TEST_UNIT_COMMON_DIR}/mocks-ibverbs.c
               ${TEST_UNIT_COMMON_DIR}/mocks-rdma_cm.c

--- a/tests/unit/cq/CMakeLists.txt
+++ b/tests/unit/cq/CMakeLists.txt
@@ -7,9 +7,10 @@
 include(../../cmake/ctest_helpers.cmake)
 
 function (add_test_cq name)
-       set(name cq-${name})
+       set(src_name cq-${name})
+       set(name ut-${src_name})
        build_test_src(UNIT NAME ${name} SRCS
-              ${name}.c
+              ${src_name}.c
               cq-common.c
               ${TEST_UNIT_COMMON_DIR}/mocks-ibverbs.c
               ${TEST_UNIT_COMMON_DIR}/mocks-stdlib.c

--- a/tests/unit/ep/CMakeLists.txt
+++ b/tests/unit/ep/CMakeLists.txt
@@ -1,14 +1,15 @@
 #
 # SPDX-License-Identifier: BSD-3-Clause
-# Copyright 2020, Intel Corporation
+# Copyright 2020-2022, Intel Corporation
 #
 
 include(../../cmake/ctest_helpers.cmake)
 
 function(add_test_ep name)
-	set(name ep-${name})
+	set(src_name ep-${name})
+	set(name ut-${src_name})
 	build_test_src(UNIT NAME ${name} SRCS
-		${name}.c
+		${src_name}.c
 		ep-common.c
 		${TEST_UNIT_COMMON_DIR}/mocks-rpma-conn_cfg.c
 		${TEST_UNIT_COMMON_DIR}/mocks-rpma-log.c

--- a/tests/unit/error/CMakeLists.txt
+++ b/tests/unit/error/CMakeLists.txt
@@ -1,12 +1,12 @@
 #
 # SPDX-License-Identifier: BSD-3-Clause
-# Copyright 2020, Intel Corporation
+# Copyright 2020-2022, Intel Corporation
 #
 
 include(../../cmake/ctest_helpers.cmake)
 
-build_test_src(UNIT NAME error SRCS
+build_test_src(UNIT NAME ut-error SRCS
 	error.c
 	${LIBRPMA_SOURCE_DIR}/rpma_err.c)
 
-add_test_generic(NAME error TRACERS none)
+add_test_generic(NAME ut-error TRACERS none)

--- a/tests/unit/flush/CMakeLists.txt
+++ b/tests/unit/flush/CMakeLists.txt
@@ -1,14 +1,15 @@
 #
 # SPDX-License-Identifier: BSD-3-Clause
-# Copyright 2020-2021, Intel Corporation
+# Copyright 2020-2022, Intel Corporation
 #
 
 include(../../cmake/ctest_helpers.cmake)
 
 function(add_test_flush name)
-	set(name flush-${name})
+	set(src_name flush-${name})
+	set(name ut-${src_name})
 	build_test_src(UNIT NAME ${name} SRCS
-		${name}.c
+		${src_name}.c
 		flush-common.c
 		${LIBRPMA_SOURCE_DIR}/rpma_err.c
 		${LIBRPMA_SOURCE_DIR}/flush.c

--- a/tests/unit/info/CMakeLists.txt
+++ b/tests/unit/info/CMakeLists.txt
@@ -1,15 +1,16 @@
 #
 # SPDX-License-Identifier: BSD-3-Clause
-# Copyright 2020-2021, Intel Corporation
+# Copyright 2020-2022, Intel Corporation
 # Copyright 2021, Fujitsu
 #
 
 include(../../cmake/ctest_helpers.cmake)
 
 function(add_test_info name)
-	set(name info-${name})
+	set(src_name info-${name})
+	set(name ut-${src_name})
 	build_test_src(UNIT NAME ${name} SRCS
-		${name}.c
+		${src_name}.c
 		info-common.c
 		${TEST_UNIT_COMMON_DIR}/mocks-ibverbs.c
 		${TEST_UNIT_COMMON_DIR}/mocks-rdma_cm.c

--- a/tests/unit/librpma_constructor/CMakeLists.txt
+++ b/tests/unit/librpma_constructor/CMakeLists.txt
@@ -1,15 +1,15 @@
 #
 # SPDX-License-Identifier: BSD-3-Clause
-# Copyright 2020, Intel Corporation
+# Copyright 2020-2022, Intel Corporation
 #
 
 include(../../cmake/ctest_helpers.cmake)
 
-build_test_src(UNIT NAME librpma_constructor SRCS
+build_test_src(UNIT NAME ut-librpma_constructor SRCS
 	librpma_constructor.c
 	${TEST_UNIT_COMMON_DIR}/mocks-rpma-log.c
 	${LIBRPMA_SOURCE_DIR}/librpma.c)
 
-target_compile_definitions(librpma_constructor PRIVATE MOCK_CONSTRUCTOR)
+target_compile_definitions(ut-librpma_constructor PRIVATE MOCK_CONSTRUCTOR)
 
-add_test_generic(NAME librpma_constructor TRACERS none)
+add_test_generic(NAME ut-librpma_constructor TRACERS none)

--- a/tests/unit/log/CMakeLists.txt
+++ b/tests/unit/log/CMakeLists.txt
@@ -7,9 +7,9 @@ include(../../cmake/ctest_helpers.cmake)
 
 function(add_test_log name)
 	if ("${ARGV1}" STREQUAL "DEBUG")
-		set(test log-${name}-DEBUG)
+		set(test ut-log-${name}-DEBUG)
 	else()
-		set(test log-${name})
+		set(test ut-log-${name})
 	endif()
 
 	build_test_src(UNIT NAME ${test} SRCS

--- a/tests/unit/log_default/CMakeLists.txt
+++ b/tests/unit/log_default/CMakeLists.txt
@@ -13,7 +13,7 @@ include(../../cmake/ctest_helpers.cmake)
 add_flag("-U_FORTIFY_SOURCE" RELEASE)
 
 function(build_log_default name)
-	build_test_src(UNIT NAME log_default-${name} SRCS
+	build_test_src(UNIT NAME ut-log_default-${name} SRCS
 		${name}.c
 		${TEST_UNIT_COMMON_DIR}/mocks-rpma-log.c
 		${TEST_UNIT_COMMON_DIR}/mocks-stdio.c
@@ -22,11 +22,11 @@ function(build_log_default name)
 		${TEST_UNIT_COMMON_DIR}/mocks-getpid.c
 		${LIBRPMA_SOURCE_DIR}/log_default.c)
 
-		set_target_properties(log_default-${name} PROPERTIES
+		set_target_properties(ut-log_default-${name} PROPERTIES
 			LINK_FLAGS
 			"-Wl,--wrap=vsnprintf,--wrap=snprintf,--wrap=fprintf,--wrap=clock_gettime,--wrap=localtime_r,--wrap=strftime,--wrap=getpid")
 
-	add_test_generic(NAME log_default-${name} TRACERS none)
+	add_test_generic(NAME ut-log_default-${name} TRACERS none)
 endfunction()
 
 build_log_default(init-fini)

--- a/tests/unit/mr/CMakeLists.txt
+++ b/tests/unit/mr/CMakeLists.txt
@@ -6,9 +6,10 @@
 include(../../cmake/ctest_helpers.cmake)
 
 function(add_test_mr name)
-	set(name mr-${name})
+	set(src_name mr-${name})
+	set(name ut-${src_name})
 	build_test_src(UNIT NAME ${name} SRCS
-		${name}.c
+		${src_name}.c
 		mr-common.c
 		${TEST_UNIT_COMMON_DIR}/mocks-ibverbs.c
 		${TEST_UNIT_COMMON_DIR}/mocks-rpma-log.c

--- a/tests/unit/peer/CMakeLists.txt
+++ b/tests/unit/peer/CMakeLists.txt
@@ -1,15 +1,16 @@
 #
 # SPDX-License-Identifier: BSD-3-Clause
-# Copyright 2020, Intel Corporation
+# Copyright 2020-2022, Intel Corporation
 # Copyright 2021, Fujitsu
 #
 
 include(../../cmake/ctest_helpers.cmake)
 
 function(add_test_peer name)
-	set(name peer-${name})
+	set(src_name peer-${name})
+	set(name ut-${src_name})
 	build_test_src(UNIT NAME ${name} SRCS
-		${name}.c
+		${src_name}.c
 		peer-common.c
 		${TEST_UNIT_COMMON_DIR}/mocks-ibverbs.c
 		${TEST_UNIT_COMMON_DIR}/mocks-rdma_cm.c

--- a/tests/unit/peer_cfg/CMakeLists.txt
+++ b/tests/unit/peer_cfg/CMakeLists.txt
@@ -1,14 +1,15 @@
 #
 # SPDX-License-Identifier: BSD-3-Clause
-# Copyright 2020, Intel Corporation
+# Copyright 2020-2022, Intel Corporation
 #
 
 include(../../cmake/ctest_helpers.cmake)
 
 function(add_test_peer_cfg name)
-	set(name peer_cfg-${name})
+	set(src_name peer_cfg-${name})
+	set(name ut-${src_name})
 	build_test_src(UNIT NAME ${name} SRCS
-		${name}.c
+		${src_name}.c
 		peer_cfg-common.c
 		${TEST_UNIT_COMMON_DIR}/mocks-rpma-log.c
 		${TEST_UNIT_COMMON_DIR}/mocks-stdlib.c

--- a/tests/unit/private_data/CMakeLists.txt
+++ b/tests/unit/private_data/CMakeLists.txt
@@ -1,14 +1,15 @@
 #
 # SPDX-License-Identifier: BSD-3-Clause
-# Copyright 2020-2021, Intel Corporation
+# Copyright 2020-2022, Intel Corporation
 #
 
 include(../../cmake/ctest_helpers.cmake)
 
 function (add_test_private_data name)
-       set(name private_data-${name})
+       set(src_name private_data-${name})
+       set(name ut-${src_name})
        build_test_src(UNIT NAME ${name} SRCS
-              ${name}.c
+              ${src_name}.c
               private_data-common.c
               ${TEST_UNIT_COMMON_DIR}/mocks-stdlib.c
               ${LIBRPMA_SOURCE_DIR}/private_data.c)

--- a/tests/unit/template/CMakeLists.txt
+++ b/tests/unit/template/CMakeLists.txt
@@ -1,9 +1,9 @@
 #
 # SPDX-License-Identifier: BSD-3-Clause
-# Copyright 2020, Intel Corporation
+# Copyright 2020-2022, Intel Corporation
 #
 
 include(../../cmake/ctest_helpers.cmake)
 
 build_test_lib(template template.c)
-add_test_generic(NAME template TRACERS none)
+add_test_generic(NAME ut-template TRACERS none)

--- a/tests/unit/utils/CMakeLists.txt
+++ b/tests/unit/utils/CMakeLists.txt
@@ -1,11 +1,11 @@
 #
 # SPDX-License-Identifier: BSD-3-Clause
-# Copyright 2020, Intel Corporation
+# Copyright 2020-2022, Intel Corporation
 #
 
 include(../../cmake/ctest_helpers.cmake)
 
-build_test_src(UNIT NAME utils-conn_event_2str SRCS
+build_test_src(UNIT NAME ut-utils-conn_event_2str SRCS
 	utils-conn_event_2str.c
 	${TEST_UNIT_COMMON_DIR}/mocks-ibverbs.c
 	${TEST_UNIT_COMMON_DIR}/mocks-rdma_cm.c
@@ -14,7 +14,7 @@ build_test_src(UNIT NAME utils-conn_event_2str SRCS
 	${LIBRPMA_SOURCE_DIR}/rpma_err.c
 	${LIBRPMA_SOURCE_DIR}/utils.c)
 
-build_test_src(UNIT NAME utils-get_ibv_context SRCS
+build_test_src(UNIT NAME ut-utils-get_ibv_context SRCS
 	utils-get_ibv_context.c
 	utils-common.c
 	${TEST_UNIT_COMMON_DIR}/mocks-ibverbs.c
@@ -22,11 +22,11 @@ build_test_src(UNIT NAME utils-get_ibv_context SRCS
 	${LIBRPMA_SOURCE_DIR}/rpma_err.c
 	${LIBRPMA_SOURCE_DIR}/utils.c)
 
-add_test_generic(NAME utils-conn_event_2str TRACERS none)
-add_test_generic(NAME utils-get_ibv_context TRACERS none)
+add_test_generic(NAME ut-utils-conn_event_2str TRACERS none)
+add_test_generic(NAME ut-utils-get_ibv_context TRACERS none)
 
 if(ON_DEMAND_PAGING_SUPPORTED)
-	build_test_src(UNIT NAME utils-ibv_context_is_odp_capable SRCS
+	build_test_src(UNIT NAME ut-utils-ibv_context_is_odp_capable SRCS
 		utils-ibv_context_is_odp_capable.c
 		${TEST_UNIT_COMMON_DIR}/mocks-ibverbs.c
 		${TEST_UNIT_COMMON_DIR}/mocks-rdma_cm.c
@@ -35,5 +35,5 @@ if(ON_DEMAND_PAGING_SUPPORTED)
 		${LIBRPMA_SOURCE_DIR}/rpma_err.c
 		${LIBRPMA_SOURCE_DIR}/utils.c)
 
-	add_test_generic(NAME utils-ibv_context_is_odp_capable TRACERS none)
+	add_test_generic(NAME ut-utils-ibv_context_is_odp_capable TRACERS none)
 endif()


### PR DESCRIPTION
Add "ut-" prefix to all unit tests' names to be able to filter
them out while running ctest:

```
$ ctest
...
 74/169 Test  #74: ut-utils-ibv_context_is_odp_capable_0_none .............................   Passed    0.03 sec
        Start  75: ut-log_default-init-fini_0_none
 75/169 Test  #75: ut-log_default-init-fini_0_none ........................................   Passed    0.03 sec
        Start  76: ut-log_default-function_0_none
 76/169 Test  #76: ut-log_default-function_0_none .........................................   Passed    0.03 sec
        Start  77: multithreaded-conn_cfg-get_cq_size_0_none
 77/169 Test  #77: multithreaded-conn_cfg-get_cq_size_0_none ..............................   Passed    0.03 sec
...
```
```
$ ctest -E "ut-"
Test project /home/rpma/repos/rpma/build
      Start  1: multithreaded-conn_cfg-get_cq_size_0_none
 1/93 Test  #1: multithreaded-conn_cfg-get_cq_size_0_none ..............................   Passed    0.04 sec
...
```

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/pmem/rpma/1907)
<!-- Reviewable:end -->
