### PR TITLE
test: rename multithreaded tests prefix to "mtt-"

### DIFF
--- a/tests/cmake/ctest_helpers.cmake
+++ b/tests/cmake/ctest_helpers.cmake
@@ -221,7 +221,7 @@ function(add_multithreaded)
 		"${multiValueArgs}"
 		${ARGN})
 
-	set(target multithreaded-${MULTITHREADED_NAME}-${MULTITHREADED_BIN})
+	set(target mtt-${MULTITHREADED_NAME}-${MULTITHREADED_BIN})
 
 	prepend(srcs ${CMAKE_CURRENT_SOURCE_DIR} ${srcs})
 	add_executable(${target} ${TEST_MT_COMMON_DIR}/mtt.c


### PR DESCRIPTION
Use shorter multithreaded tests prefix "mtt-", unified with unit tests prefix "ut-"

e.g.
$ ctest
...
 74/169 Test  #74: ut-utils-ibv_context_is_odp_capable_0_none .............................   Passed    0.03 sec
        Start  75: ut-log_default-init-fini_0_none
 75/169 Test  #75: ut-log_default-init-fini_0_none ........................................   Passed    0.03 sec
        Start  76: ut-log_default-function_0_none
 76/169 Test  #76: ut-log_default-function_0_none .........................................   Passed    0.03 sec
        Start  77: mtt-conn_cfg-get_cq_size_0_none
 77/169 Test  #77: mtt-conn_cfg-get_cq_size_0_none ..............................   Passed    0.03 sec
...

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/pmem/rpma/1908)
<!-- Reviewable:end -->
