### PR TITLE
common: user-friend CMAKE_BUILD_TYPE options order

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -60,12 +60,12 @@ set(CMAKE_NO_SYSTEM_FROM_IMPORTED 1)
 set(TEST_DIR ${CMAKE_CURRENT_BINARY_DIR}/test
 	CACHE STRING "working directory for tests")
 
-set(buildTypes None Debug Release RelWithDebInfo MinSizeRel)
+set(buildTypes Release Debug RelWithDebInfo MinSizeRel)
 
 if(NOT CMAKE_BUILD_TYPE)
 	message(STATUS "No build type selected (CMAKE_BUILD_TYPE), defaulting to Release")
 	set(CMAKE_BUILD_TYPE "Release" CACHE STRING
-		"Choose the type of build, options are: None Debug Release RelWithDebInfo MinSizeRel ..." FORCE)
+		"Choose the type of build, options are: Release Debug RelWithDebInfo MinSizeRel ..." FORCE)
 	set_property(CACHE CMAKE_BUILD_TYPE PROPERTY STRINGS ${buildTypes})
 else()
 	message(STATUS "CMAKE_BUILD_TYPE: ${CMAKE_BUILD_TYPE}")


### PR DESCRIPTION
It is important to move easily from the default Release build type
to Debug type used by library developers

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/pmem/rpma/1910)
<!-- Reviewable:end -->
