### PR TITLE
Revert "common: temporarily do not error out if updating pmem.github.…

### DIFF
--- a/utils/docker/run-doc-update.sh
+++ b/utils/docker/run-doc-update.sh
@@ -120,21 +120,6 @@ mkdir ${DOCS_DIR}
 # copy new man pages
 cp -r ${WORKDIR}/md/*.md ${DOCS_DIR}
 
-#
-# XXX temporarily do not error out if the following fails
-# This is workaround for the following issue:
-#
-# To https://github.com/***/pmem.github.io
-#  ! [remote rejected]   rpma-automatic-update-of-man-pages -> rpma-automatic-update-of-man-pages
-#    (refusing to allow a Personal Access Token to create or update workflow
-#     `.github/workflows/gh-pages.yml` without `workflow` scope)
-# error: failed to push some refs to 'https://github.com/***/pmem.github.io'
-# Error: Process completed with exit code 1.
-#
-# See: https://github.com/pmem/rpma/runs/7128459223
-#
-set +e
-
 # add, commit and push changes to the pmem.github.io repo
 commit_and_push_changes ${ORIGIN_PMEM_IO} ${BRANCH_PR} ${TARGET_BRANCH} "rpma: automatic update of man pages"
 


### PR DESCRIPTION
…io fails"

This reverts commit 45a53f7b2d40b9ea01f900cf75485d104ba3583b.

The workaround is not needed anymore, since the issue is resolved.

The issue was just an outdated pmem-bot's repository. It contained
the old version of the workflow and now it's equal to upstream
repository and the issue is no longer appearing.

Fixes: #1902

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/pmem/rpma/1924)
<!-- Reviewable:end -->
