### PR TITLE
common: replace dot with colon in chown

### DIFF
--- a/utils/docker/prepare-for-build.sh
+++ b/utils/docker/prepare-for-build.sh
@@ -17,7 +17,7 @@ function sudo_password() {
 # this should be run only on CIs
 if [ "$CI_RUN" == "YES" ]; then
 	echo WORKDIR=$WORKDIR
-	sudo_password chown -R $(id -u).$(id -g) $WORKDIR
+	sudo_password chown -R $(id -u):$(id -g) $WORKDIR
 fi
 
 # fix for: https://github.com/actions/checkout/issues/766 (git CVE-2022-24765)


### PR DESCRIPTION
Replace the old syntax:
```sh
$ chown [OWNER][.[GROUP]]
```
with the new one:
```sh
$ chown [OWNER][:[GROUP]]
```

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/pmem/rpma/1935)
<!-- Reviewable:end -->
