### PR TITLE
rpma: remove redundant _Atomic declaration in the rpma_conn_cfg struct

### DIFF
--- a/src/conn_cfg.c
+++ b/src/conn_cfg.c
@@ -42,9 +42,6 @@
 
 struct rpma_conn_cfg {
 	int timeout_ms;	/* connection establishment timeout */
-#ifdef ATOMIC_STORE_SUPPORTED
-	_Atomic
-#endif /* ATOMIC_STORE_SUPPORTED */
 	uint32_t cq_size;	/* main CQ size */
 	uint32_t rcq_size;	/* receive CQ size */
 	uint32_t sq_size;	/* SQ size */


### PR DESCRIPTION


<!-- Reviewable:start -->
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/pmem/rpma/1936)
<!-- Reviewable:end -->
