### PR TITLE
common: disable testing performance tools on OpenSUSE Tumbleweed

### DIFF
--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -55,7 +55,9 @@ jobs:
                  "N=Debian_Experimental  OS=debian               OS_VER=experimental",
                  # Arch Linux build was temporarily moved to Nightly Experimental
                  "N=OpenSUSE_Leap        OS=opensuse-leap        OS_VER=latest",
-                 "N=OpenSUSE_Tumbleweed  OS=opensuse-tumbleweed  OS_VER=latest"]
+                 # Testing performance tools is temporarily disabled due to the following issue:
+                 # ImportError: Module 'sqlite3' is not installed.
+                 "N=OpenSUSE_Tumbleweed  OS=opensuse-tumbleweed  OS_VER=latest TESTS_PERF_TOOLS=OFF"]
     steps:
        - name: Clone the git repo
          uses: actions/checkout@v1
@@ -96,7 +98,9 @@ jobs:
                  "N=Debian_Experimental  OS=debian               OS_VER=experimental",
                  # Arch Linux build was temporarily moved to Nightly Experimental
                  "N=OpenSUSE_Leap        OS=opensuse-leap        OS_VER=latest",
-                 "N=OpenSUSE_Tumbleweed  OS=opensuse-tumbleweed  OS_VER=latest"]
+                 # Testing performance tools is temporarily disabled due to the following issue:
+                 # ImportError: Module 'sqlite3' is not installed.
+                 "N=OpenSUSE_Tumbleweed  OS=opensuse-tumbleweed  OS_VER=latest TESTS_PERF_TOOLS=OFF"]
     steps:
        - name: Clone the git repo
          uses: actions/checkout@v1


### PR DESCRIPTION
Temporarily disable testing performance tools on OpenSUSE Tumbleweed
due to the following issue:
https://github.com/ldorau/rpma/runs/7464261110?check_suite_focus=true#step:4:1390
```
Traceback (most recent call last):
  File "/home/user/.local/bin/coverage", line 5, in <module>
    from coverage.cmdline import main
  File "/home/user/.local/lib/python3.10/site-packages/coverage/__init__.py", line 15, in <module>
    from coverage.control import Coverage, process_startup
  File "/home/user/.local/lib/python3.10/site-packages/coverage/control.py", line 23, in <module>
    from coverage.data import CoverageData, combine_parallel_data
  File "/home/user/.local/lib/python3.10/site-packages/coverage/data.py", line 18, in <module>
    from coverage.sqldata import CoverageData
  File "/home/user/.local/lib/python3.10/site-packages/coverage/sqldata.py", line 15, in <module>
    import sqlite3
  File "/usr/lib64/python3.10/_import_failed/sqlite3.py", line 16, in <module>
    raise ImportError(f"""Module '{failed_name}' is not installed.
ImportError: Module 'sqlite3' is not installed.
```

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/pmem/rpma/1937)
<!-- Reviewable:end -->
