### PR TITLE
rpma: make rpma_log_set_threshold() thread-safe

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   - rpma_conn_req_connect
   - rpma_ep_next_conn_req
   - rpma_log_set_function
+  - rpma_log_set_threshold
   - rpma_peer_cfg_set_direct_write_to_pmem
 
 ### Changed

--- a/src/log_internal.h
+++ b/src/log_internal.h
@@ -12,12 +12,19 @@
 #include <string.h>
 #include "librpma.h"
 #include "log_default.h"
+#ifdef ATOMIC_OPERATIONS_SUPPORTED
+#include <stdatomic.h>
+#endif /* ATOMIC_OPERATIONS_SUPPORTED */
 
 /* pointer to the logging function */
 extern rpma_log_function *Rpma_log_function;
 
 /* threshold levels */
-extern enum rpma_log_level Rpma_log_threshold[RPMA_LOG_THRESHOLD_MAX];
+extern
+#ifdef ATOMIC_OPERATIONS_SUPPORTED
+_Atomic
+#endif /* ATOMIC_OPERATIONS_SUPPORTED */
+enum rpma_log_level Rpma_log_threshold[RPMA_LOG_THRESHOLD_MAX];
 
 void rpma_log_init();
 

--- a/tests/multithreaded/log/CMakeLists.txt
+++ b/tests/multithreaded/log/CMakeLists.txt
@@ -7,3 +7,6 @@ include(../../cmake/ctest_helpers.cmake)
 
 add_multithreaded(NAME log BIN rpma_log_set_function
 	SRCS rpma_log_set_function.c)
+add_multithreaded(NAME log BIN rpma_log_set_threshold
+	SRCS rpma_log_set_threshold.c)
+

--- a/tests/multithreaded/log/rpma_log_set_threshold.c
+++ b/tests/multithreaded/log/rpma_log_set_threshold.c
@@ -1,0 +1,46 @@
+// SPDX-License-Identifier: BSD-3-Clause
+/* Copyright 2022, Intel Corporation */
+
+/*
+ * rpma_log_set_threshold.c -- rpma_log_set_threshold multithreaded test
+ */
+
+#include <librpma.h>
+
+#include "mtt.h"
+
+/*
+ * thread -- set the log level threshold
+ */
+void
+thread(unsigned id, void *prestate, void *state, struct mtt_result *tr)
+{
+	int ret;
+
+	if ((ret = rpma_log_set_threshold(RPMA_LOG_THRESHOLD, RPMA_LOG_LEVEL_INFO))) {
+		MTT_RPMA_ERR(tr, "rpma_log_set_threshold", ret);
+		return;
+	}
+}
+
+int
+main(int argc, char *argv[])
+{
+	struct mtt_args args = {0};
+
+	if (mtt_parse_args(argc, argv, &args))
+		return -1;
+
+	struct mtt_test test = {
+			NULL,
+			NULL,
+			NULL,
+			NULL,
+			thread,
+			NULL,
+			NULL,
+			NULL
+	};
+
+	return mtt_run(&test, args.threads_num);
+}

--- a/tests/unit/common/mocks-rpma-log.c
+++ b/tests/unit/common/mocks-rpma-log.c
@@ -8,6 +8,9 @@
 #include "cmocka_headers.h"
 #include "log_internal.h"
 
+#ifdef ATOMIC_OPERATIONS_SUPPORTED
+_Atomic
+#endif /* ATOMIC_OPERATIONS_SUPPORTED */
 enum rpma_log_level Rpma_log_threshold[] = {
 		/* all logs have to be triggered */
 		RPMA_LOG_LEVEL_DEBUG,	/* RPMA_LOG_THRESHOLD */


### PR DESCRIPTION
Add a mtt test for rpma_log_set_threshold.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/pmem/rpma/1951)
<!-- Reviewable:end -->
