### PR TITLE
Revert "examples: fix building examples with libpmem"

### DIFF
--- a/examples/CMakeLists.txt
+++ b/examples/CMakeLists.txt
@@ -88,13 +88,7 @@ function(add_example)
 		target_link_libraries(${target} ${LIBPMEM2_LIBRARIES})
 		target_compile_definitions(${target}
 			PRIVATE USE_LIBPMEM2)
-	endif()
-	#
-	# XXX revert it to:
-	# elseif(LIBPMEM_FOUND)
-	# when all examples have support for libpmem2.
-	#
-	if(LIBPMEM_FOUND)
+	elseif(LIBPMEM_FOUND)
 		target_include_directories(${target}
 			PRIVATE ${LIBPMEM_INCLUDE_DIRS})
 		target_link_libraries(${target} ${LIBPMEM_LIBRARIES})


### PR DESCRIPTION
This reverts commit f2a9efbfdbc0ed3a720d9364f01e640449253afc.

All examples have support for libpmem2 now.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/pmem/rpma/1960)
<!-- Reviewable:end -->
