### PR TITLE
rpma: change the names of the internal API functions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -33,7 +33,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   - 08srq-simple-messages-ping-pong-with-srq - a single-connection example for shared RQ with ping-pong messages
   - 13-messages-ping-pong-with-srq - a multi-connection example for shared RQ with ping-pong messages
 
-- logging of the source and the destination GID addresses in rpma_conn_req_from_id()
+- logging of the source and the destination GID addresses in rpma_conn_req_new_from_id()
 - error message for RPMA_E_AGAIN: "Temporary error, try again"
 - peer_cfg: get/set_direct_write_to_pmem and get_descriptor are now thread-safe
 - conn_cfg: all get and set functions for cq, rq, sq, rcq, timeout and compl_channel are now thread-safe

--- a/src/conn.c
+++ b/src/conn.c
@@ -217,7 +217,7 @@ rpma_conn_next_event(struct rpma_conn *conn, enum rpma_conn_event *event)
 	return 0;
 
 err_private_data_discard:
-	rpma_private_data_discard(&conn->data);
+	rpma_private_data_delete(&conn->data);
 
 	return ret;
 }
@@ -395,7 +395,7 @@ rpma_conn_delete(struct rpma_conn **conn_ptr)
 	}
 
 	rdma_destroy_event_channel(conn->evch);
-	rpma_private_data_discard(&conn->data);
+	rpma_private_data_delete(&conn->data);
 
 	free(conn);
 	*conn_ptr = NULL;
@@ -414,7 +414,7 @@ err_destroy_comp_channel:
 		(void) ibv_destroy_comp_channel(conn->channel);
 err_destroy_event_channel:
 	rdma_destroy_event_channel(conn->evch);
-	rpma_private_data_discard(&conn->data);
+	rpma_private_data_delete(&conn->data);
 
 	free(conn);
 	*conn_ptr = NULL;

--- a/src/conn_cfg.c
+++ b/src/conn_cfg.c
@@ -353,7 +353,7 @@ rpma_conn_cfg_get_sq_size(const struct rpma_conn_cfg *cfg, uint32_t *sq_size)
 #endif /* ATOMIC_OPERATIONS_SUPPORTED */
 
 	/*
-	 * This function is used as void in rpma_peer_create_qp()
+	 * This function is used as void in rpma_peer_setup_qp()
 	 * and therefore it has to return the correct value of size of SQ,
 	 * if it fails because of fault injection.
 	 */
@@ -401,7 +401,7 @@ rpma_conn_cfg_get_rq_size(const struct rpma_conn_cfg *cfg, uint32_t *rq_size)
 #endif /* ATOMIC_OPERATIONS_SUPPORTED */
 
 	/*
-	 * This function is used as void in rpma_peer_create_qp()
+	 * This function is used as void in rpma_peer_setup_qp()
 	 * and therefore it has to return the correct value of size of RQ,
 	 * if it fails because of fault injection.
 	 */

--- a/src/conn_req.h
+++ b/src/conn_req.h
@@ -1,5 +1,5 @@
 /* SPDX-License-Identifier: BSD-3-Clause */
-/* Copyright 2020, Intel Corporation */
+/* Copyright 2020-2022, Intel Corporation */
 
 /*
  * conn_req.h -- librpma connection-request-related internal definitions
@@ -14,14 +14,14 @@
 
 /*
  * ERRORS
- * rpma_conn_req_from_cm_event() can fail with the following errors:
+ * rpma_conn_req_new_from_cm_event() can fail with the following errors:
  *
  * - RPMA_E_INVAL - peer, event or req_ptr is NULL
  * - RPMA_E_INVAL - event is not RDMA_CM_EVENT_CONNECT_REQUEST
  * - RPMA_E_PROVIDER - ibv_create_cq(3) or rdma_create_qp(3) failed
  * - RPMA_E_NOMEM - out of memory
  */
-int rpma_conn_req_from_cm_event(struct rpma_peer *peer,
+int rpma_conn_req_new_from_cm_event(struct rpma_peer *peer,
 		struct rdma_cm_event *event, const struct rpma_conn_cfg *cfg,
 		struct rpma_conn_req **req_ptr);
 

--- a/src/ep.c
+++ b/src/ep.c
@@ -205,7 +205,7 @@ rpma_ep_next_conn_req(struct rpma_ep *ep, const struct rpma_conn_cfg *cfg,
 		goto err_ack;
 	}
 
-	ret = rpma_conn_req_from_cm_event(ep->peer, event, cfg, req_ptr);
+	ret = rpma_conn_req_new_from_cm_event(ep->peer, event, cfg, req_ptr);
 	if (ret)
 		goto err_ack;
 

--- a/src/flush.c
+++ b/src/flush.c
@@ -23,7 +23,7 @@
 static int rpma_flush_apm_new(struct rpma_peer *peer,
 		struct rpma_flush *flush);
 static int rpma_flush_apm_delete(struct rpma_flush *flush);
-static int rpma_flush_apm_do(struct ibv_qp *qp, struct rpma_flush *flush,
+static int rpma_flush_apm_execute(struct ibv_qp *qp, struct rpma_flush *flush,
 	struct rpma_mr_remote *dst, size_t dst_offset, size_t len,
 	enum rpma_flush_type type, int flags, const void *op_context);
 
@@ -96,7 +96,7 @@ rpma_flush_apm_new(struct rpma_peer *peer, struct rpma_flush *flush)
 
 	struct rpma_flush_internal *flush_internal =
 			(struct rpma_flush_internal *)flush;
-	flush_internal->flush_func = rpma_flush_apm_do;
+	flush_internal->flush_func = rpma_flush_apm_execute;
 	flush_internal->delete_func = rpma_flush_apm_delete;
 	flush_internal->context = flush_apm;
 
@@ -131,10 +131,10 @@ rpma_flush_apm_delete(struct rpma_flush *flush)
 }
 
 /*
- * rpma_flush_apm_do -- perform the APM-style flush
+ * rpma_flush_apm_execute -- perform the APM-style flush
  */
 static int
-rpma_flush_apm_do(struct ibv_qp *qp, struct rpma_flush *flush,
+rpma_flush_apm_execute(struct ibv_qp *qp, struct rpma_flush *flush,
 	struct rpma_mr_remote *dst, size_t dst_offset, size_t len,
 	enum rpma_flush_type type, int flags, const void *op_context)
 {

--- a/src/mr.c
+++ b/src/mr.c
@@ -414,7 +414,7 @@ rpma_mr_reg(struct rpma_peer *peer, void *ptr, size_t size, int usage,
 		return RPMA_E_NOMEM;
 
 	struct ibv_mr *ibv_mr;
-	if ((ret = rpma_peer_mr_reg(peer, &ibv_mr, ptr, size, usage))) {
+	if ((ret = rpma_peer_setup_mr_reg(peer, &ibv_mr, ptr, size, usage))) {
 		free(mr);
 		return ret;
 	}

--- a/src/peer.c
+++ b/src/peer.c
@@ -36,12 +36,12 @@ struct rpma_peer {
 /* internal librpma API */
 
 /*
- * rpma_peer_usage_to_access -- convert usage to access
+ * rpma_peer_usage2access -- convert usage to access
  *
  * Note: APM type of flush requires the same access as RPMA_MR_USAGE_READ_SRC
  */
 static int
-rpma_peer_usage_to_access(struct rpma_peer *peer, int usage)
+rpma_peer_usage2access(struct rpma_peer *peer, int usage)
 {
 	RPMA_DEBUG_TRACE;
 
@@ -138,13 +138,13 @@ err_srq_delete:
 }
 
 /*
- * rpma_peer_create_qp -- allocate a QP associated with the CM ID
+ * rpma_peer_setup_qp -- allocate a QP associated with the CM ID
  *
  * ASSUMPTIONS
  * - cfg != NULL
  */
 int
-rpma_peer_create_qp(struct rpma_peer *peer, struct rdma_cm_id *id,
+rpma_peer_setup_qp(struct rpma_peer *peer, struct rdma_cm_id *id,
 		struct rpma_cq *cq, struct rpma_cq *rcq,
 		const struct rpma_conn_cfg *cfg)
 {
@@ -221,16 +221,16 @@ rpma_peer_create_qp(struct rpma_peer *peer, struct rdma_cm_id *id,
 #endif
 
 /*
- * rpma_peer_mr_reg -- register a memory region using ibv_reg_mr()
+ * rpma_peer_setup_mr_reg -- register a memory region using ibv_reg_mr()
  */
 int
-rpma_peer_mr_reg(struct rpma_peer *peer, struct ibv_mr **ibv_mr_ptr,
+rpma_peer_setup_mr_reg(struct rpma_peer *peer, struct ibv_mr **ibv_mr_ptr,
 		void *addr, size_t length, int usage)
 {
 	RPMA_DEBUG_TRACE;
 	RPMA_FAULT_INJECTION(RPMA_E_PROVIDER, {});
 
-	int access = rpma_peer_usage_to_access(peer, usage);
+	int access = rpma_peer_usage2access(peer, usage);
 
 	*ibv_mr_ptr = ibv_reg_mr(peer->pd, addr, length,
 					RPMA_IBV_ACCESS(access));

--- a/src/peer.h
+++ b/src/peer.h
@@ -1,5 +1,5 @@
 /* SPDX-License-Identifier: BSD-3-Clause */
-/* Copyright 2020-2021, Intel Corporation */
+/* Copyright 2020-2022, Intel Corporation */
 /* Copyright 2021-2022, Fujitsu */
 
 /*
@@ -29,12 +29,12 @@ int rpma_peer_create_srq(struct rpma_peer *peer, struct rpma_srq_cfg *cfg,
 
 /*
  * ERRORS
- * rpma_peer_create_qp() can fail with the following errors:
+ * rpma_peer_setup_qp() can fail with the following errors:
  *
  * - RPMA_E_INVAL - peer, id or cq is NULL
  * - RPMA_E_PROVIDER - allocating a QP failed
  */
-int rpma_peer_create_qp(struct rpma_peer *peer, struct rdma_cm_id *id,
+int rpma_peer_setup_qp(struct rpma_peer *peer, struct rdma_cm_id *id,
 		struct rpma_cq *cq, struct rpma_cq *rcq,
 		const struct rpma_conn_cfg *cfg);
 
@@ -44,11 +44,11 @@ int rpma_peer_create_qp(struct rpma_peer *peer, struct rdma_cm_id *id,
  *   && peer->pd != NULL
  *
  * ERRORS
- * rpma_peer_mr_reg() can fail with the following error:
+ * rpma_peer_setup_mr_reg() can fail with the following error:
  *
  * - RPMA_E_PROVIDER - registering the memory region failed
  */
-int rpma_peer_mr_reg(struct rpma_peer *peer, struct ibv_mr **ibv_mr_ptr,
+int rpma_peer_setup_mr_reg(struct rpma_peer *peer, struct ibv_mr **ibv_mr_ptr,
 		void *addr, size_t length, int usage);
 
 #endif /* LIBRPMA_PEER_H */

--- a/src/private_data.c
+++ b/src/private_data.c
@@ -47,10 +47,10 @@ rpma_private_data_store(struct rdma_cm_event *edata,
 }
 
 /*
- * rpma_private_data_discard -- free the private data
+ * rpma_private_data_delete -- free the private data
  */
 void
-rpma_private_data_discard(struct rpma_conn_private_data *pdata)
+rpma_private_data_delete(struct rpma_conn_private_data *pdata)
 {
 	RPMA_DEBUG_TRACE;
 

--- a/src/private_data.h
+++ b/src/private_data.h
@@ -1,5 +1,5 @@
 /* SPDX-License-Identifier: BSD-3-Clause */
-/* Copyright 2020-2021, Intel Corporation */
+/* Copyright 2020-2022, Intel Corporation */
 
 /*
  * private_data.h -- a store for connections' private data (definitions)
@@ -34,6 +34,6 @@ int rpma_private_data_store(struct rdma_cm_event *edata,
  *
  * The function cannot fail.
  */
-void rpma_private_data_discard(struct rpma_conn_private_data *pdata);
+void rpma_private_data_delete(struct rpma_conn_private_data *pdata);
 
 #endif /* LIBRPMA_PRIVATE_DATA_H */

--- a/tests/drd.supp
+++ b/tests/drd.supp
@@ -445,6 +445,6 @@
    obj:*librxe-rdmav34.so*
    ...
    fun:rdma_create_qp
-   fun:rpma_peer_create_qp
+   fun:rpma_peer_setup_qp
    ...
 }

--- a/tests/memcheck-libibverbs-librdmacm.supp
+++ b/tests/memcheck-libibverbs-librdmacm.supp
@@ -96,8 +96,8 @@
    ...
    fun:rdma_create_qp_ex
    fun:rdma_create_qp
-   fun:rpma_peer_create_qp
-   fun:rpma_conn_req_from_id
+   fun:rpma_peer_setup_qp
+   fun:rpma_conn_req_new_from_id
    fun:rpma_conn_req_new
    ...
 }
@@ -189,9 +189,9 @@
    ...
    fun:rdma_create_qp_ex
    fun:rdma_create_qp
-   fun:rpma_peer_create_qp
-   fun:rpma_conn_req_from_id
-   fun:rpma_conn_req_from_cm_event
+   fun:rpma_peer_setup_qp
+   fun:rpma_conn_req_new_from_id
+   fun:rpma_conn_req_new_from_cm_event
    fun:rpma_ep_next_conn_req
    ...
 }

--- a/tests/unit/common/mocks-ibverbs.c
+++ b/tests/unit/common/mocks-ibverbs.c
@@ -230,14 +230,14 @@ int
 ibv_dereg_mr(struct ibv_mr *mr)
 {
 	/*
-	 * rpma_peer_mr_reg() and malloc() may be called in any order.
+	 * rpma_peer_setup_mr_reg() and malloc() may be called in any order.
 	 * If the first one fails, then the second one won't be called.
 	 * ibv_dereg_mr() will be called in rpma_mr_reg() only if:
-	 * 1) rpma_peer_mr_reg() succeeded and
+	 * 1) rpma_peer_setup_mr_reg() succeeded and
 	 * 2) malloc() failed.
 	 * In the opposite case, when:
 	 * 1) malloc() succeeded and
-	 * 2) rpma_peer_mr_reg() failed,
+	 * 2) rpma_peer_setup_mr_reg() failed,
 	 * ibv_dereg_mr() will not be called,
 	 * so we cannot add cmocka's expects here.
 	 * Otherwise, unconsumed expects would cause a test failure.

--- a/tests/unit/common/mocks-rpma-flush.c
+++ b/tests/unit/common/mocks-rpma-flush.c
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: BSD-3-Clause
-/* Copyright 2020, Intel Corporation */
+/* Copyright 2020-2022, Intel Corporation */
 
 /*
  * mocks-rpma-flush.c -- librpma flush.c module mocks
@@ -16,10 +16,10 @@
 struct rpma_flush Rpma_flush;
 
 /*
- * rpma_flush_mock_do -- rpma_flush_apm_do() mock
+ * rpma_flush_mock_execute -- rpma_flush_apm_execute() mock
  */
 int
-rpma_flush_mock_do(struct ibv_qp *qp, struct rpma_flush *flush,
+rpma_flush_mock_execute(struct ibv_qp *qp, struct rpma_flush *flush,
 	struct rpma_mr_remote *dst, size_t dst_offset, size_t len,
 	enum rpma_flush_type type, int flags, const void *op_context)
 {
@@ -47,7 +47,7 @@ rpma_flush_new(struct rpma_peer *peer, struct rpma_flush **flush_ptr)
 {
 	assert_int_equal(peer, MOCK_PEER);
 	assert_non_null(flush_ptr);
-	Rpma_flush.func = rpma_flush_mock_do;
+	Rpma_flush.func = rpma_flush_mock_execute;
 
 	int ret = mock_type(int);
 	if (ret == MOCK_OK)

--- a/tests/unit/common/mocks-rpma-peer.c
+++ b/tests/unit/common/mocks-rpma-peer.c
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: BSD-3-Clause
-/* Copyright 2020-2021, Intel Corporation */
+/* Copyright 2020-2022, Intel Corporation */
 /* Copyright 2022, Fujitsu */
 
 /*
@@ -41,10 +41,10 @@ rpma_peer_create_srq(struct rpma_peer *peer, struct rpma_srq_cfg *cfg,
 }
 
 /*
- * rpma_peer_create_qp -- rpma_peer_create_qp() mock
+ * rpma_peer_setup_qp -- rpma_peer_setup_qp() mock
  */
 int
-rpma_peer_create_qp(struct rpma_peer *peer, struct rdma_cm_id *id,
+rpma_peer_setup_qp(struct rpma_peer *peer, struct rdma_cm_id *id,
 		struct rpma_cq *cq, struct rpma_cq *rcq,
 		const struct rpma_conn_cfg *cfg)
 {
@@ -63,20 +63,20 @@ rpma_peer_create_qp(struct rpma_peer *peer, struct rdma_cm_id *id,
 }
 
 /*
- * rpma_peer_mr_reg -- a mock of rpma_peer_mr_reg()
+ * rpma_peer_setup_mr_reg -- a mock of rpma_peer_setup_mr_reg()
  */
 int
-rpma_peer_mr_reg(struct rpma_peer *peer, struct ibv_mr **ibv_mr_ptr,
+rpma_peer_setup_mr_reg(struct rpma_peer *peer, struct ibv_mr **ibv_mr_ptr,
 		void *addr, size_t length, int usage)
 {
 	/*
-	 * rpma_peer_mr_reg() and malloc() may be called in any order.
+	 * rpma_peer_setup_mr_reg() and malloc() may be called in any order.
 	 * If the first one fails, then the second one won't be called,
 	 * so we cannot add cmocka's expects here.
 	 * Otherwise, unconsumed expects would cause a test failure.
 	 */
-	struct rpma_peer_mr_reg_args *args =
-				mock_type(struct rpma_peer_mr_reg_args *);
+	struct rpma_peer_setup_mr_reg_args *args =
+				mock_type(struct rpma_peer_setup_mr_reg_args *);
 	assert_ptr_equal(peer, MOCK_PEER);
 	assert_ptr_equal(addr, MOCK_PTR);
 	assert_int_equal(length, MOCK_SIZE);

--- a/tests/unit/common/mocks-rpma-peer.h
+++ b/tests/unit/common/mocks-rpma-peer.h
@@ -1,5 +1,5 @@
 /* SPDX-License-Identifier: BSD-3-Clause */
-/* Copyright 2020, Intel Corporation */
+/* Copyright 2020-2022, Intel Corporation */
 
 /*
  * mocks-rpma-peer.h -- a rpma_peer mocks header
@@ -12,8 +12,8 @@
 #define MOCK_SIZE	(size_t)0x08090a0b0c0d0e0f
 #define MOCK_RKEY	(uint32_t)0x10111213
 
-/* structure of arguments used in rpma_peer_mr_reg() */
-struct rpma_peer_mr_reg_args {
+/* structure of arguments used in rpma_peer_setup_mr_reg() */
+struct rpma_peer_setup_mr_reg_args {
 	int usage;
 	int access;
 	struct ibv_mr *mr;

--- a/tests/unit/common/mocks-rpma-private_data.c
+++ b/tests/unit/common/mocks-rpma-private_data.c
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: BSD-3-Clause
-/* Copyright 2020, Intel Corporation */
+/* Copyright 2020-2022, Intel Corporation */
 
 /*
  * mocks-rpma-private_data.c -- librpma private_data.c module mocks
@@ -38,10 +38,10 @@ rpma_private_data_store(struct rdma_cm_event *edata,
 }
 
 /*
- * rpma_private_data_discard -- rpma_private_data_discard() mock
+ * rpma_private_data_delete -- rpma_private_data_delete() mock
  */
 void
-rpma_private_data_discard(struct rpma_conn_private_data *pdata)
+rpma_private_data_delete(struct rpma_conn_private_data *pdata)
 {
 	assert_non_null(pdata);
 	function_called();

--- a/tests/unit/conn/conn-common.c
+++ b/tests/unit/conn/conn-common.c
@@ -63,10 +63,10 @@ rpma_private_data_store(struct rdma_cm_event *edata,
 }
 
 /*
- * rpma_private_data_discard -- rpma_private_data_discard() mock
+ * rpma_private_data_delete -- rpma_private_data_delete() mock
  */
 void
-rpma_private_data_discard(struct rpma_conn_private_data *pdata)
+rpma_private_data_delete(struct rpma_conn_private_data *pdata)
 {
 	assert_non_null(pdata);
 	check_expected(pdata->ptr);
@@ -128,9 +128,9 @@ teardown__conn_delete(void **cstate_ptr)
 	will_return(rdma_destroy_id, MOCK_OK);
 	if (cstate->channel)
 		will_return(ibv_destroy_comp_channel, MOCK_OK);
-	expect_value(rpma_private_data_discard, pdata->ptr,
+	expect_value(rpma_private_data_delete, pdata->ptr,
 				cstate->data.ptr);
-	expect_value(rpma_private_data_discard, pdata->len,
+	expect_value(rpma_private_data_delete, pdata->len,
 				cstate->data.len);
 
 	/* delete the object */

--- a/tests/unit/conn/conn-flush.c
+++ b/tests/unit/conn/conn-flush.c
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: BSD-3-Clause
-/* Copyright 2020, Intel Corporation */
+/* Copyright 2020-2022, Intel Corporation */
 
 /*
  * conn-flush.c -- the rpma_flush() unit tests
@@ -221,13 +221,13 @@ flush__success_FLUSH_TYPE_VISIBILITY(void **cstate_ptr)
 	struct conn_test_state *cstate = *cstate_ptr;
 
 	/* configure mocks */
-	expect_value(rpma_flush_mock_do, qp, MOCK_QP);
-	expect_value(rpma_flush_mock_do, flush, MOCK_FLUSH);
-	expect_value(rpma_flush_mock_do, dst, MOCK_RPMA_MR_REMOTE);
-	expect_value(rpma_flush_mock_do, dst_offset, MOCK_REMOTE_OFFSET);
-	expect_value(rpma_flush_mock_do, len, MOCK_LEN);
-	expect_value(rpma_flush_mock_do, flags, MOCK_FLAGS);
-	expect_value(rpma_flush_mock_do, op_context, MOCK_OP_CONTEXT);
+	expect_value(rpma_flush_mock_execute, qp, MOCK_QP);
+	expect_value(rpma_flush_mock_execute, flush, MOCK_FLUSH);
+	expect_value(rpma_flush_mock_execute, dst, MOCK_RPMA_MR_REMOTE);
+	expect_value(rpma_flush_mock_execute, dst_offset, MOCK_REMOTE_OFFSET);
+	expect_value(rpma_flush_mock_execute, len, MOCK_LEN);
+	expect_value(rpma_flush_mock_execute, flags, MOCK_FLAGS);
+	expect_value(rpma_flush_mock_execute, op_context, MOCK_OP_CONTEXT);
 
 	expect_value(rpma_mr_remote_get_flush_type, mr, MOCK_RPMA_MR_REMOTE);
 	will_return(rpma_mr_remote_get_flush_type,
@@ -258,13 +258,13 @@ flush__success_FLUSH_TYPE_PERSISTENT(void **cstate_ptr)
 	assert_int_equal(ret, MOCK_OK);
 
 	/* configure mocks for rpma_flush() */
-	expect_value(rpma_flush_mock_do, qp, MOCK_QP);
-	expect_value(rpma_flush_mock_do, flush, MOCK_FLUSH);
-	expect_value(rpma_flush_mock_do, dst, MOCK_RPMA_MR_REMOTE);
-	expect_value(rpma_flush_mock_do, dst_offset, MOCK_REMOTE_OFFSET);
-	expect_value(rpma_flush_mock_do, len, MOCK_LEN);
-	expect_value(rpma_flush_mock_do, flags, MOCK_FLAGS);
-	expect_value(rpma_flush_mock_do, op_context, MOCK_OP_CONTEXT);
+	expect_value(rpma_flush_mock_execute, qp, MOCK_QP);
+	expect_value(rpma_flush_mock_execute, flush, MOCK_FLUSH);
+	expect_value(rpma_flush_mock_execute, dst, MOCK_RPMA_MR_REMOTE);
+	expect_value(rpma_flush_mock_execute, dst_offset, MOCK_REMOTE_OFFSET);
+	expect_value(rpma_flush_mock_execute, len, MOCK_LEN);
+	expect_value(rpma_flush_mock_execute, flags, MOCK_FLAGS);
+	expect_value(rpma_flush_mock_execute, op_context, MOCK_OP_CONTEXT);
 
 	expect_value(rpma_mr_remote_get_flush_type, mr, MOCK_RPMA_MR_REMOTE);
 	will_return(rpma_mr_remote_get_flush_type,

--- a/tests/unit/conn/conn-new.c
+++ b/tests/unit/conn/conn-new.c
@@ -259,8 +259,8 @@ delete__flush_delete_ERRNO(void **cstate_ptr)
 	will_return_maybe(rdma_destroy_id, MOCK_OK);
 	if (cstate->channel)
 		will_return(ibv_destroy_comp_channel, MOCK_OK);
-	expect_value(rpma_private_data_discard, pdata->ptr, NULL);
-	expect_value(rpma_private_data_discard, pdata->len, 0);
+	expect_value(rpma_private_data_delete, pdata->ptr, NULL);
+	expect_value(rpma_private_data_delete, pdata->len, 0);
 
 	/* run test */
 	ret = rpma_conn_delete(&cstate->conn);
@@ -299,8 +299,8 @@ delete__flush_delete_E_INVAL(void **cstate_ptr)
 	will_return_maybe(rdma_destroy_id, MOCK_OK);
 	if (cstate->channel)
 		will_return(ibv_destroy_comp_channel, MOCK_OK);
-	expect_value(rpma_private_data_discard, pdata->ptr, NULL);
-	expect_value(rpma_private_data_discard, pdata->len, 0);
+	expect_value(rpma_private_data_delete, pdata->ptr, NULL);
+	expect_value(rpma_private_data_delete, pdata->len, 0);
 
 	/* run test */
 	ret = rpma_conn_delete(&cstate->conn);
@@ -337,8 +337,8 @@ delete__rcq_delete_ERRNO(void **cstate_ptr)
 	will_return(rpma_cq_delete, MOCK_OK);
 	expect_value(rdma_destroy_id, id, MOCK_CM_ID);
 	will_return(rdma_destroy_id, MOCK_OK);
-	expect_value(rpma_private_data_discard, pdata->ptr, NULL);
-	expect_value(rpma_private_data_discard, pdata->len, 0);
+	expect_value(rpma_private_data_delete, pdata->ptr, NULL);
+	expect_value(rpma_private_data_delete, pdata->len, 0);
 
 	/* run test */
 	ret = rpma_conn_delete(&cstate->conn);
@@ -378,8 +378,8 @@ delete__rcq_delete_ERRNO_subsequent_ERRNO2(void **cstate_ptr)
 	will_return(rpma_cq_delete, MOCK_ERRNO2); /* second error */
 	expect_value(rdma_destroy_id, id, MOCK_CM_ID);
 	will_return(rdma_destroy_id, MOCK_ERRNO2); /* third error */
-	expect_value(rpma_private_data_discard, pdata->ptr, NULL);
-	expect_value(rpma_private_data_discard, pdata->len, 0);
+	expect_value(rpma_private_data_delete, pdata->ptr, NULL);
+	expect_value(rpma_private_data_delete, pdata->len, 0);
 
 	/* run test */
 	ret = rpma_conn_delete(&cstate->conn);
@@ -418,8 +418,8 @@ delete__cq_delete_ERRNO(void **cstate_ptr)
 	will_return(rdma_destroy_id, MOCK_OK);
 	if (cstate->channel)
 		will_return(ibv_destroy_comp_channel, MOCK_OK);
-	expect_value(rpma_private_data_discard, pdata->ptr, NULL);
-	expect_value(rpma_private_data_discard, pdata->len, 0);
+	expect_value(rpma_private_data_delete, pdata->ptr, NULL);
+	expect_value(rpma_private_data_delete, pdata->len, 0);
 
 	/* run test */
 	ret = rpma_conn_delete(&cstate->conn);
@@ -459,8 +459,8 @@ delete__cq_delete_ERRNO_subsequent_ERRNO2(void **cstate_ptr)
 	will_return(rdma_destroy_id, MOCK_ERRNO2); /* second error */
 	if (cstate->channel)
 		will_return(ibv_destroy_comp_channel, MOCK_OK);
-	expect_value(rpma_private_data_discard, pdata->ptr, NULL);
-	expect_value(rpma_private_data_discard, pdata->len, 0);
+	expect_value(rpma_private_data_delete, pdata->ptr, NULL);
+	expect_value(rpma_private_data_delete, pdata->len, 0);
 
 	/* run test */
 	ret = rpma_conn_delete(&cstate->conn);
@@ -498,8 +498,8 @@ delete__destroy_id_ERRNO(void **cstate_ptr)
 	will_return(rdma_destroy_id, MOCK_ERRNO);
 	if (cstate->channel)
 		will_return(ibv_destroy_comp_channel, MOCK_OK);
-	expect_value(rpma_private_data_discard, pdata->ptr, NULL);
-	expect_value(rpma_private_data_discard, pdata->len, 0);
+	expect_value(rpma_private_data_delete, pdata->ptr, NULL);
+	expect_value(rpma_private_data_delete, pdata->len, 0);
 
 	/* run test */
 	ret = rpma_conn_delete(&cstate->conn);
@@ -540,8 +540,8 @@ delete__ibv_destroy_comp_channel_E_PROVIDER(void **cstate_ptr)
 	will_return(rpma_cq_delete, MOCK_OK);
 	expect_value(rdma_destroy_id, id, MOCK_CM_ID);
 	will_return(rdma_destroy_id, MOCK_OK);
-	expect_value(rpma_private_data_discard, pdata->ptr, NULL);
-	expect_value(rpma_private_data_discard, pdata->len, 0);
+	expect_value(rpma_private_data_delete, pdata->ptr, NULL);
+	expect_value(rpma_private_data_delete, pdata->len, 0);
 	will_return(ibv_destroy_comp_channel, MOCK_ERRNO);
 
 	/* run test */

--- a/tests/unit/conn/conn-next_event.c
+++ b/tests/unit/conn/conn-next_event.c
@@ -143,8 +143,8 @@ next_event__event_UNREACHABLE_ack_ERRNO(void **cstate_ptr)
 	expect_value(rdma_ack_cm_event, event, &event);
 	will_return(rdma_ack_cm_event, MOCK_ERRNO);
 
-	expect_value(rpma_private_data_discard, pdata->ptr, NULL);
-	expect_value(rpma_private_data_discard, pdata->len, 0);
+	expect_value(rpma_private_data_delete, pdata->ptr, NULL);
+	expect_value(rpma_private_data_delete, pdata->len, 0);
 
 	/* run test */
 	enum rpma_conn_event c_event = RPMA_CONN_UNDEFINED;

--- a/tests/unit/conn_req/CMakeLists.txt
+++ b/tests/unit/conn_req/CMakeLists.txt
@@ -39,7 +39,7 @@ endfunction()
 
 add_test_conn_req(connect)
 add_test_conn_req(delete)
-add_test_conn_req(from_cm_event)
+add_test_conn_req(new_from_cm_event)
 add_test_conn_req(new)
 add_test_conn_req(private_data)
 add_test_conn_req(recv)

--- a/tests/unit/conn_req/conn_req-common.c
+++ b/tests/unit/conn_req/conn_req-common.c
@@ -126,11 +126,11 @@ configure_conn_req(void **cstate_ptr)
 }
 
 /*
- * setup__conn_req_from_cm_event -- prepare a valid rpma_conn_req object from CM
+ * setup__conn_req_new_from_cm_event -- prepare a valid rpma_conn_req object from CM
  * event
  */
 int
-setup__conn_req_from_cm_event(void **cstate_ptr)
+setup__conn_req_new_from_cm_event(void **cstate_ptr)
 {
 	struct conn_req_test_state *cstate = *cstate_ptr;
 	configure_conn_req((void **)&cstate);
@@ -155,16 +155,16 @@ setup__conn_req_from_cm_event(void **cstate_ptr)
 				MOCK_GET_CHANNEL(cstate));
 		will_return(rpma_cq_new, MOCK_RPMA_RCQ);
 	}
-	expect_value(rpma_peer_create_qp, id, &cstate->id);
-	expect_value(rpma_peer_create_qp, cfg, cstate->get_args.cfg);
-	expect_value(rpma_peer_create_qp, rcq, MOCK_GET_RCQ(cstate));
-	will_return(rpma_peer_create_qp, MOCK_OK);
+	expect_value(rpma_peer_setup_qp, id, &cstate->id);
+	expect_value(rpma_peer_setup_qp, cfg, cstate->get_args.cfg);
+	expect_value(rpma_peer_setup_qp, rcq, MOCK_GET_RCQ(cstate));
+	will_return(rpma_peer_setup_qp, MOCK_OK);
 	will_return(__wrap__test_malloc, MOCK_OK);
 	will_return_maybe(__wrap_snprintf, MOCK_OK);
 	will_return(rpma_private_data_store, MOCK_PRIVATE_DATA);
 
 	/* run test */
-	int ret = rpma_conn_req_from_cm_event(MOCK_PEER, &cstate->event,
+	int ret = rpma_conn_req_new_from_cm_event(MOCK_PEER, &cstate->event,
 			cstate->get_args.cfg, &cstate->req);
 
 	/* verify the results */
@@ -177,11 +177,11 @@ setup__conn_req_from_cm_event(void **cstate_ptr)
 }
 
 /*
- * teardown__conn_req_from_cm_event -- delete the rpma_conn_req object created
+ * teardown__conn_req_new_from_cm_event -- delete the rpma_conn_req object created
  * from a CM event
  */
 int
-teardown__conn_req_from_cm_event(void **cstate_ptr)
+teardown__conn_req_new_from_cm_event(void **cstate_ptr)
 {
 	struct conn_req_test_state *cstate = *cstate_ptr;
 
@@ -195,7 +195,7 @@ teardown__conn_req_from_cm_event(void **cstate_ptr)
 	will_return(rdma_reject, MOCK_OK);
 	if (!cstate->get_args.srq_rcq && cstate->get_args.shared)
 		will_return(ibv_destroy_comp_channel, MOCK_OK);
-	expect_function_call(rpma_private_data_discard);
+	expect_function_call(rpma_private_data_delete);
 
 	/* run test */
 	int ret = rpma_conn_req_delete(&cstate->req);
@@ -248,10 +248,10 @@ setup__conn_req_new(void **cstate_ptr)
 				MOCK_GET_CHANNEL(cstate));
 		will_return(rpma_cq_new, MOCK_RPMA_RCQ);
 	}
-	expect_value(rpma_peer_create_qp, id, &cstate->id);
-	expect_value(rpma_peer_create_qp, cfg, cstate->get_args.cfg);
-	expect_value(rpma_peer_create_qp, rcq, MOCK_GET_RCQ(cstate));
-	will_return(rpma_peer_create_qp, MOCK_OK);
+	expect_value(rpma_peer_setup_qp, id, &cstate->id);
+	expect_value(rpma_peer_setup_qp, cfg, cstate->get_args.cfg);
+	expect_value(rpma_peer_setup_qp, rcq, MOCK_GET_RCQ(cstate));
+	will_return(rpma_peer_setup_qp, MOCK_OK);
 	will_return(__wrap__test_malloc, MOCK_OK);
 	will_return_maybe(__wrap_snprintf, MOCK_STDIO_ERROR);
 
@@ -289,7 +289,7 @@ teardown__conn_req_new(void **cstate_ptr)
 	will_return(rdma_destroy_id, 0);
 	if (!cstate->get_args.srq_rcq && cstate->get_args.shared)
 		will_return(ibv_destroy_comp_channel, MOCK_OK);
-	expect_function_call(rpma_private_data_discard);
+	expect_function_call(rpma_private_data_delete);
 
 	/* run test */
 	int ret = rpma_conn_req_delete(&cstate->req);

--- a/tests/unit/conn_req/conn_req-common.h
+++ b/tests/unit/conn_req/conn_req-common.h
@@ -72,8 +72,8 @@
 	CONN_REQ_TEST_SETUP_TEARDOWN_WITH_AND_WITHOUT_SRQ_RCQ(test_func, NULL, NULL)
 
 /*
- * All the resources used between setup__conn_req_from_cm_event and
- * teardown__conn_req_from_cm_event
+ * All the resources used between setup__conn_req_new_from_cm_event and
+ * teardown__conn_req_new_from_cm_event
  */
 struct conn_req_test_state {
 	struct conn_cfg_get_mock_args get_args;
@@ -88,8 +88,8 @@ extern struct conn_req_test_state Conn_req_conn_cfg_custom;
 extern struct conn_req_test_state Conn_req_conn_cfg_custom_without_srq_rcq;
 extern struct conn_req_test_state Conn_req_conn_cfg_default_with_srq_rcq;
 
-int setup__conn_req_from_cm_event(void **cstate_ptr);
-int teardown__conn_req_from_cm_event(void **cstate_ptr);
+int setup__conn_req_new_from_cm_event(void **cstate_ptr);
+int teardown__conn_req_new_from_cm_event(void **cstate_ptr);
 
 /*
  * All the resources used between setup__conn_req_new and teardown__conn_req_new

--- a/tests/unit/conn_req/conn_req-connect.c
+++ b/tests/unit/conn_req/conn_req-connect.c
@@ -60,7 +60,7 @@ configure_mocks_conn_req_delete(struct conn_req_test_state *cstate)
 	will_return(rdma_reject, MOCK_OK);
 	if (cstate->get_args.shared)
 		will_return(ibv_destroy_comp_channel, MOCK_OK);
-	expect_function_call(rpma_private_data_discard);
+	expect_function_call(rpma_private_data_delete);
 }
 
 /*
@@ -71,7 +71,7 @@ connect__conn_ptr_NULL(void **cstate_ptr)
 {
 	/* WA for cmocka/issues#47 */
 	struct conn_req_test_state *cstate = *cstate_ptr;
-	assert_int_equal(setup__conn_req_from_cm_event((void **)&cstate), 0);
+	assert_int_equal(setup__conn_req_new_from_cm_event((void **)&cstate), 0);
 	assert_non_null(cstate);
 
 	/* configure mocks for rpma_conn_req_delete() */
@@ -93,7 +93,7 @@ connect__pdata_NULL_pdata_ptr_NULL(void **cstate_ptr)
 {
 	/* WA for cmocka/issues#47 */
 	struct conn_req_test_state *cstate = *cstate_ptr;
-	assert_int_equal(setup__conn_req_from_cm_event((void **)&cstate), 0);
+	assert_int_equal(setup__conn_req_new_from_cm_event((void **)&cstate), 0);
 	assert_non_null(cstate);
 
 	/* configure mocks for rpma_conn_req_delete() */
@@ -118,7 +118,7 @@ connect__pdata_NULL_pdata_len_0(void **cstate_ptr)
 {
 	/* WA for cmocka/issues#47 */
 	struct conn_req_test_state *cstate = *cstate_ptr;
-	assert_int_equal(setup__conn_req_from_cm_event((void **)&cstate), 0);
+	assert_int_equal(setup__conn_req_new_from_cm_event((void **)&cstate), 0);
 	assert_non_null(cstate);
 
 	/* configure mocks for rpma_conn_req_delete() */
@@ -145,7 +145,7 @@ connect__pdata_NULL_pdata_ptr_NULL_len_0(void **cstate_ptr)
 {
 	/* WA for cmocka/issues#47 */
 	struct conn_req_test_state *cstate = *cstate_ptr;
-	assert_int_equal(setup__conn_req_from_cm_event((void **)&cstate), 0);
+	assert_int_equal(setup__conn_req_new_from_cm_event((void **)&cstate), 0);
 	assert_non_null(cstate);
 
 	/* configure mocks for rpma_conn_req_delete() */
@@ -170,7 +170,7 @@ connect_via_accept__accept_ERRNO(void **cstate_ptr)
 {
 	/* WA for cmocka/issues#47 */
 	struct conn_req_test_state *cstate = *cstate_ptr;
-	assert_int_equal(setup__conn_req_from_cm_event((void **)&cstate), 0);
+	assert_int_equal(setup__conn_req_new_from_cm_event((void **)&cstate), 0);
 	assert_non_null(cstate);
 
 	/* configure mocks */
@@ -183,7 +183,7 @@ connect_via_accept__accept_ERRNO(void **cstate_ptr)
 	will_return(rpma_cq_delete, MOCK_OK);
 	if (cstate->get_args.shared)
 		will_return(ibv_destroy_comp_channel, MOCK_OK);
-	expect_function_call(rpma_private_data_discard);
+	expect_function_call(rpma_private_data_delete);
 
 	/* run test */
 	struct rpma_conn *conn = NULL;
@@ -205,7 +205,7 @@ connect_via_accept__accept_ERRNO_subsequent_ERRNO2(void **cstate_ptr)
 {
 	/* WA for cmocka/issues#47 */
 	struct conn_req_test_state *cstate = *cstate_ptr;
-	assert_int_equal(setup__conn_req_from_cm_event((void **)&cstate), 0);
+	assert_int_equal(setup__conn_req_new_from_cm_event((void **)&cstate), 0);
 	assert_non_null(cstate);
 
 	/* configure mocks */
@@ -225,7 +225,7 @@ connect_via_accept__accept_ERRNO_subsequent_ERRNO2(void **cstate_ptr)
 	will_return(rpma_cq_delete, MOCK_ERRNO2); /* third or fourth error */
 	if (cstate->get_args.shared)
 		will_return(ibv_destroy_comp_channel, MOCK_OK);
-	expect_function_call(rpma_private_data_discard);
+	expect_function_call(rpma_private_data_delete);
 
 	/* run test */
 	struct rpma_conn *conn = NULL;
@@ -246,7 +246,7 @@ connect_via_accept__conn_new_ERRNO(void **cstate_ptr)
 {
 	/* WA for cmocka/issues#47 */
 	struct conn_req_test_state *cstate = *cstate_ptr;
-	assert_int_equal(setup__conn_req_from_cm_event((void **)&cstate), 0);
+	assert_int_equal(setup__conn_req_new_from_cm_event((void **)&cstate), 0);
 	assert_non_null(cstate);
 
 	/* configure mocks */
@@ -267,7 +267,7 @@ connect_via_accept__conn_new_ERRNO(void **cstate_ptr)
 	will_return(rpma_cq_delete, MOCK_OK);
 	if (cstate->get_args.shared)
 		will_return(ibv_destroy_comp_channel, MOCK_OK);
-	expect_function_call(rpma_private_data_discard);
+	expect_function_call(rpma_private_data_delete);
 
 	/* run test */
 	struct rpma_conn *conn = NULL;
@@ -289,7 +289,7 @@ connect_via_accept__conn_new_ERRNO_subsequent_ERRNO2(void **cstate_ptr)
 {
 	/* WA for cmocka/issues#47 */
 	struct conn_req_test_state *cstate = *cstate_ptr;
-	assert_int_equal(setup__conn_req_from_cm_event((void **)&cstate), 0);
+	assert_int_equal(setup__conn_req_new_from_cm_event((void **)&cstate), 0);
 	assert_non_null(cstate);
 
 	/* configure mocks */
@@ -317,7 +317,7 @@ connect_via_accept__conn_new_ERRNO_subsequent_ERRNO2(void **cstate_ptr)
 	will_return(rpma_cq_delete, MOCK_ERRNO2); /* third or fourth error */
 	if (cstate->get_args.shared)
 		will_return(ibv_destroy_comp_channel, MOCK_OK);
-	expect_function_call(rpma_private_data_discard);
+	expect_function_call(rpma_private_data_delete);
 
 	/* run test */
 	struct rpma_conn *conn = NULL;
@@ -338,7 +338,7 @@ connect_via_accept__success_incoming(void **cstate_ptr)
 {
 	/* WA for cmocka/issues#47 */
 	struct conn_req_test_state *cstate = *cstate_ptr;
-	assert_int_equal(setup__conn_req_from_cm_event((void **)&cstate), 0);
+	assert_int_equal(setup__conn_req_new_from_cm_event((void **)&cstate), 0);
 	assert_non_null(cstate);
 
 	/* configure mocks */

--- a/tests/unit/conn_req/conn_req-delete.c
+++ b/tests/unit/conn_req/conn_req-delete.c
@@ -47,7 +47,7 @@ delete_via_reject__rcq_delete_ERRNO(void **unused)
 {
 	/* WA for cmocka/issues#47 */
 	struct conn_req_test_state *cstate = &Conn_req_conn_cfg_custom;
-	assert_int_equal(setup__conn_req_from_cm_event((void **)&cstate), 0);
+	assert_int_equal(setup__conn_req_new_from_cm_event((void **)&cstate), 0);
 	assert_non_null(cstate);
 
 	/* configure mocks */
@@ -59,7 +59,7 @@ delete_via_reject__rcq_delete_ERRNO(void **unused)
 	will_return(rpma_cq_delete, MOCK_OK);
 	expect_value(rdma_reject, id, &cstate->id);
 	will_return(rdma_reject, MOCK_OK);
-	expect_function_call(rpma_private_data_discard);
+	expect_function_call(rpma_private_data_delete);
 	if (cstate->get_args.shared)
 		will_return(ibv_destroy_comp_channel, MOCK_OK);
 
@@ -82,7 +82,7 @@ delete_via_reject__rcq_delete_ERRNO_subsequent_ERRNO2(void **unused)
 {
 	/* WA for cmocka/issues#47 */
 	struct conn_req_test_state *cstate = &Conn_req_conn_cfg_custom;
-	assert_int_equal(setup__conn_req_from_cm_event((void **)&cstate), 0);
+	assert_int_equal(setup__conn_req_new_from_cm_event((void **)&cstate), 0);
 	assert_non_null(cstate);
 
 	/* configure mocks */
@@ -95,7 +95,7 @@ delete_via_reject__rcq_delete_ERRNO_subsequent_ERRNO2(void **unused)
 	will_return(rpma_cq_delete, MOCK_ERRNO2); /* second error */
 	expect_value(rdma_reject, id, &cstate->id);
 	will_return(rdma_reject, MOCK_ERRNO2); /* third error */
-	expect_function_call(rpma_private_data_discard);
+	expect_function_call(rpma_private_data_delete);
 	if (cstate->get_args.shared)
 		will_return(ibv_destroy_comp_channel, MOCK_OK);
 
@@ -116,7 +116,7 @@ delete_via_reject__cq_delete_ERRNO(void **cstate_ptr)
 {
 	/* WA for cmocka/issues#47 */
 	struct conn_req_test_state *cstate = *cstate_ptr;
-	assert_int_equal(setup__conn_req_from_cm_event((void **)&cstate), 0);
+	assert_int_equal(setup__conn_req_new_from_cm_event((void **)&cstate), 0);
 	assert_non_null(cstate);
 
 	/* configure mocks */
@@ -128,7 +128,7 @@ delete_via_reject__cq_delete_ERRNO(void **cstate_ptr)
 	will_return(rpma_cq_delete, MOCK_ERRNO);
 	expect_value(rdma_reject, id, &cstate->id);
 	will_return(rdma_reject, MOCK_OK);
-	expect_function_call(rpma_private_data_discard);
+	expect_function_call(rpma_private_data_delete);
 	if (cstate->get_args.shared)
 		will_return(ibv_destroy_comp_channel, MOCK_OK);
 
@@ -150,7 +150,7 @@ delete_via_reject__cq_delete_ERRNO_subsequent_ERRNO2(void **cstate_ptr)
 {
 	/* WA for cmocka/issues#47 */
 	struct conn_req_test_state *cstate = *cstate_ptr;
-	assert_int_equal(setup__conn_req_from_cm_event((void **)&cstate), 0);
+	assert_int_equal(setup__conn_req_new_from_cm_event((void **)&cstate), 0);
 	assert_non_null(cstate);
 
 	/* configure mocks */
@@ -162,7 +162,7 @@ delete_via_reject__cq_delete_ERRNO_subsequent_ERRNO2(void **cstate_ptr)
 	will_return(rpma_cq_delete, MOCK_ERRNO); /* first error */
 	expect_value(rdma_reject, id, &cstate->id);
 	will_return(rdma_reject, MOCK_ERRNO2); /* second error */
-	expect_function_call(rpma_private_data_discard);
+	expect_function_call(rpma_private_data_delete);
 	if (cstate->get_args.shared)
 		will_return(ibv_destroy_comp_channel, MOCK_OK);
 
@@ -182,7 +182,7 @@ delete_via_reject__reject_ERRNO(void **cstate_ptr)
 {
 	/* WA for cmocka/issues#47 */
 	struct conn_req_test_state *cstate = *cstate_ptr;
-	assert_int_equal(setup__conn_req_from_cm_event((void **)&cstate), 0);
+	assert_int_equal(setup__conn_req_new_from_cm_event((void **)&cstate), 0);
 	assert_non_null(cstate);
 
 	/* configure mocks */
@@ -193,7 +193,7 @@ delete_via_reject__reject_ERRNO(void **cstate_ptr)
 	will_return(rpma_cq_delete, MOCK_OK);
 	expect_value(rdma_reject, id, &cstate->id);
 	will_return(rdma_reject, MOCK_ERRNO);
-	expect_function_call(rpma_private_data_discard);
+	expect_function_call(rpma_private_data_delete);
 	if (cstate->get_args.shared)
 		will_return(ibv_destroy_comp_channel, MOCK_OK);
 
@@ -214,7 +214,7 @@ delete_via_reject__reject_ERRNO_ack_ERRNO2(void **cstate_ptr)
 {
 	/* WA for cmocka/issues#47 */
 	struct conn_req_test_state *cstate = *cstate_ptr;
-	assert_int_equal(setup__conn_req_from_cm_event((void **)&cstate), 0);
+	assert_int_equal(setup__conn_req_new_from_cm_event((void **)&cstate), 0);
 	assert_non_null(cstate);
 
 	/* configure mocks */
@@ -225,7 +225,7 @@ delete_via_reject__reject_ERRNO_ack_ERRNO2(void **cstate_ptr)
 	will_return(rpma_cq_delete, MOCK_OK);
 	expect_value(rdma_reject, id, &cstate->id);
 	will_return(rdma_reject, MOCK_ERRNO); /* first error */
-	expect_function_call(rpma_private_data_discard);
+	expect_function_call(rpma_private_data_delete);
 	if (cstate->get_args.shared)
 		will_return(ibv_destroy_comp_channel, MOCK_OK);
 
@@ -246,7 +246,7 @@ delete_via_reject__ibv_destroy_comp_channel_ERRNO(void **cstate_ptr)
 {
 	/* WA for cmocka/issues#47 */
 	struct conn_req_test_state *cstate = *cstate_ptr;
-	assert_int_equal(setup__conn_req_from_cm_event((void **)&cstate), 0);
+	assert_int_equal(setup__conn_req_new_from_cm_event((void **)&cstate), 0);
 	assert_non_null(cstate);
 
 	/* configure mocks */
@@ -257,7 +257,7 @@ delete_via_reject__ibv_destroy_comp_channel_ERRNO(void **cstate_ptr)
 	will_return(rpma_cq_delete, MOCK_OK);
 	expect_value(rdma_reject, id, &cstate->id);
 	will_return(rdma_reject, MOCK_OK);
-	expect_function_call(rpma_private_data_discard);
+	expect_function_call(rpma_private_data_delete);
 	will_return(ibv_destroy_comp_channel, MOCK_ERRNO);
 
 	/* run test */
@@ -277,7 +277,7 @@ delete_via_reject__ack_ERRNO_ibv_ERRNO2(void **cstate_ptr)
 {
 	/* WA for cmocka/issues#47 */
 	struct conn_req_test_state *cstate = *cstate_ptr;
-	assert_int_equal(setup__conn_req_from_cm_event((void **)&cstate), 0);
+	assert_int_equal(setup__conn_req_new_from_cm_event((void **)&cstate), 0);
 	assert_non_null(cstate);
 
 	/* configure mocks */
@@ -288,7 +288,7 @@ delete_via_reject__ack_ERRNO_ibv_ERRNO2(void **cstate_ptr)
 	will_return(rpma_cq_delete, MOCK_OK);
 	expect_value(rdma_reject, id, &cstate->id);
 	will_return(rdma_reject, MOCK_OK);
-	expect_function_call(rpma_private_data_discard);
+	expect_function_call(rpma_private_data_delete);
 	will_return(ibv_destroy_comp_channel, MOCK_ERRNO2); /* second error */
 
 	/* run test */
@@ -320,7 +320,7 @@ delete_via_destroy__rcq_delete_ERRNO(void **unused)
 	will_return(rpma_cq_delete, MOCK_OK);
 	expect_value(rdma_destroy_id, id, &cstate->id);
 	will_return(rdma_destroy_id, MOCK_OK);
-	expect_function_call(rpma_private_data_discard);
+	expect_function_call(rpma_private_data_delete);
 	if (cstate->get_args.shared)
 		will_return(ibv_destroy_comp_channel, MOCK_OK);
 
@@ -355,7 +355,7 @@ delete_via_destroy__rcq_delete_ERRNO_subsequent_ERRNO2(void **unused)
 	will_return(rpma_cq_delete, MOCK_ERRNO2); /* second error */
 	expect_value(rdma_destroy_id, id, &cstate->id);
 	will_return(rdma_destroy_id, MOCK_ERRNO2); /* third error */
-	expect_function_call(rpma_private_data_discard);
+	expect_function_call(rpma_private_data_delete);
 	if (cstate->get_args.shared)
 		will_return(ibv_destroy_comp_channel, MOCK_OK);
 
@@ -388,7 +388,7 @@ delete_via_destroy__cq_delete_ERRNO(void **cstate_ptr)
 	will_return(rpma_cq_delete, MOCK_ERRNO);
 	expect_value(rdma_destroy_id, id, &cstate->id);
 	will_return(rdma_destroy_id, MOCK_OK);
-	expect_function_call(rpma_private_data_discard);
+	expect_function_call(rpma_private_data_delete);
 	if (cstate->get_args.shared)
 		will_return(ibv_destroy_comp_channel, MOCK_OK);
 
@@ -422,7 +422,7 @@ delete_via_destroy__cq_delete_ERRNO_subsequent_ERRNO2(void **cstate_ptr)
 	will_return(rpma_cq_delete, MOCK_ERRNO); /* first error */
 	expect_value(rdma_destroy_id, id, &cstate->id);
 	will_return(rdma_destroy_id, MOCK_ERRNO2); /* second error */
-	expect_function_call(rpma_private_data_discard);
+	expect_function_call(rpma_private_data_delete);
 	if (cstate->get_args.shared)
 		will_return(ibv_destroy_comp_channel, MOCK_OK);
 
@@ -454,7 +454,7 @@ delete_via_destroy__destroy_id_ERRNO(void **cstate_ptr)
 	will_return(rpma_cq_delete, MOCK_OK);
 	expect_value(rdma_destroy_id, id, &cstate->id);
 	will_return(rdma_destroy_id, MOCK_ERRNO);
-	expect_function_call(rpma_private_data_discard);
+	expect_function_call(rpma_private_data_delete);
 	if (cstate->get_args.shared)
 		will_return(ibv_destroy_comp_channel, MOCK_OK);
 
@@ -485,7 +485,7 @@ delete_via_destroy__ibv_destroy_comp_channel_ERRNO(void **cstate_ptr)
 	will_return(rpma_cq_delete, MOCK_OK);
 	expect_value(rdma_destroy_id, id, &cstate->id);
 	will_return(rdma_destroy_id, MOCK_OK);
-	expect_function_call(rpma_private_data_discard);
+	expect_function_call(rpma_private_data_delete);
 	will_return(ibv_destroy_comp_channel, MOCK_ERRNO);
 
 	/* run test */
@@ -516,7 +516,7 @@ delete_via_destroy__rdma_ERRNO_ibv_ERRNO2(void **cstate_ptr)
 	will_return(rpma_cq_delete, MOCK_OK);
 	expect_value(rdma_destroy_id, id, &cstate->id);
 	will_return(rdma_destroy_id, MOCK_ERRNO); /* first error */
-	expect_function_call(rpma_private_data_discard);
+	expect_function_call(rpma_private_data_delete);
 	will_return(ibv_destroy_comp_channel, MOCK_ERRNO2); /* second error */
 
 	/* run test */

--- a/tests/unit/conn_req/conn_req-new.c
+++ b/tests/unit/conn_req/conn_req-new.c
@@ -529,7 +529,7 @@ new__rcq_new_ERRNO_subsequent_ERRNO2(void **unused)
 }
 
 /*
- * new__peer_create_qp_ERRNO -- rpma_peer_create_qp() fails
+ * new__peer_create_qp_ERRNO -- rpma_peer_setup_qp() fails
  * with MOCK_ERRNO
  */
 static void
@@ -571,11 +571,11 @@ new__peer_create_qp_ERRNO(void **cstate_ptr)
 				MOCK_GET_CHANNEL(cstate));
 		will_return(rpma_cq_new, MOCK_RPMA_RCQ);
 	}
-	expect_value(rpma_peer_create_qp, id, &cstate->id);
-	expect_value(rpma_peer_create_qp, cfg, cstate->get_args.cfg);
-	expect_value(rpma_peer_create_qp, rcq, MOCK_GET_RCQ(cstate));
-	will_return(rpma_peer_create_qp, RPMA_E_PROVIDER);
-	will_return(rpma_peer_create_qp, MOCK_ERRNO);
+	expect_value(rpma_peer_setup_qp, id, &cstate->id);
+	expect_value(rpma_peer_setup_qp, cfg, cstate->get_args.cfg);
+	expect_value(rpma_peer_setup_qp, rcq, MOCK_GET_RCQ(cstate));
+	will_return(rpma_peer_setup_qp, RPMA_E_PROVIDER);
+	will_return(rpma_peer_setup_qp, MOCK_ERRNO);
 	expect_value(rpma_cq_delete, *cq_ptr, MOCK_GET_RCQ_DEL(cstate));
 	will_return(rpma_cq_delete, MOCK_OK);
 	expect_value(rpma_cq_delete, *cq_ptr, MOCK_RPMA_CQ);
@@ -595,7 +595,7 @@ new__peer_create_qp_ERRNO(void **cstate_ptr)
 }
 
 /*
- * new__peer_create_qp_ERRNO_subsequent_ERRNO2 -- rpma_peer_create_qp()
+ * new__peer_create_qp_ERRNO_subsequent_ERRNO2 -- rpma_peer_setup_qp()
  * fails with MOCK_ERRNO whereas subsequent (rpma_cq_delete(&rcq),
  * rpma_cq_delete(&cq), rdma_destroy_id()) fail with MOCK_ERRNO2
  */
@@ -638,11 +638,11 @@ new__peer_create_qp_ERRNO_subsequent_ERRNO2(void **cstate_ptr)
 				MOCK_GET_CHANNEL(cstate));
 		will_return(rpma_cq_new, MOCK_RPMA_RCQ);
 	}
-	expect_value(rpma_peer_create_qp, id, &cstate->id);
-	expect_value(rpma_peer_create_qp, cfg, cstate->get_args.cfg);
-	expect_value(rpma_peer_create_qp, rcq, MOCK_GET_RCQ(cstate));
-	will_return(rpma_peer_create_qp, RPMA_E_PROVIDER);
-	will_return(rpma_peer_create_qp, MOCK_ERRNO); /* first error */
+	expect_value(rpma_peer_setup_qp, id, &cstate->id);
+	expect_value(rpma_peer_setup_qp, cfg, cstate->get_args.cfg);
+	expect_value(rpma_peer_setup_qp, rcq, MOCK_GET_RCQ(cstate));
+	will_return(rpma_peer_setup_qp, RPMA_E_PROVIDER);
+	will_return(rpma_peer_setup_qp, MOCK_ERRNO); /* first error */
 	expect_value(rpma_cq_delete, *cq_ptr, MOCK_GET_RCQ_DEL(cstate));
 	if (!cstate->get_args.srq_rcq && cstate->get_args.rcq_size) {
 		will_return(rpma_cq_delete, RPMA_E_PROVIDER);
@@ -710,10 +710,10 @@ new__malloc_ERRNO(void **cstate_ptr)
 			MOCK_GET_CHANNEL(cstate));
 		will_return(rpma_cq_new, MOCK_RPMA_RCQ);
 	}
-	expect_value(rpma_peer_create_qp, id, &cstate->id);
-	expect_value(rpma_peer_create_qp, rcq, MOCK_GET_RCQ(cstate));
-	expect_value(rpma_peer_create_qp, cfg, cstate->get_args.cfg);
-	will_return(rpma_peer_create_qp, MOCK_OK);
+	expect_value(rpma_peer_setup_qp, id, &cstate->id);
+	expect_value(rpma_peer_setup_qp, rcq, MOCK_GET_RCQ(cstate));
+	expect_value(rpma_peer_setup_qp, cfg, cstate->get_args.cfg);
+	will_return(rpma_peer_setup_qp, MOCK_OK);
 	will_return(__wrap__test_malloc, MOCK_ERRNO);
 	expect_value(rdma_destroy_qp, id, &cstate->id);
 	expect_value(rpma_cq_delete, *cq_ptr, MOCK_GET_RCQ_DEL(cstate));
@@ -778,10 +778,10 @@ new__malloc_ERRNO_subsequent_ERRNO2(void **cstate_ptr)
 				MOCK_GET_CHANNEL(cstate));
 		will_return(rpma_cq_new, MOCK_RPMA_RCQ);
 	}
-	expect_value(rpma_peer_create_qp, id, &cstate->id);
-	expect_value(rpma_peer_create_qp, rcq, MOCK_GET_RCQ(cstate));
-	expect_value(rpma_peer_create_qp, cfg, cstate->get_args.cfg);
-	will_return(rpma_peer_create_qp, MOCK_OK);
+	expect_value(rpma_peer_setup_qp, id, &cstate->id);
+	expect_value(rpma_peer_setup_qp, rcq, MOCK_GET_RCQ(cstate));
+	expect_value(rpma_peer_setup_qp, cfg, cstate->get_args.cfg);
+	will_return(rpma_peer_setup_qp, MOCK_OK);
 	will_return(__wrap__test_malloc, MOCK_ERRNO); /* first error */
 	expect_value(rdma_destroy_qp, id, &cstate->id);
 	expect_value(rpma_cq_delete, *cq_ptr, MOCK_GET_RCQ_DEL(cstate));

--- a/tests/unit/conn_req/conn_req-new_from_cm_event.c
+++ b/tests/unit/conn_req/conn_req-new_from_cm_event.c
@@ -3,10 +3,10 @@
 /* Copyright 2021-2022, Fujitsu */
 
 /*
- * conn_req-from_cm_event.c -- the rpma_conn_req_from_cm_event() unit tests
+ * conn_req-new_from_cm_event.c -- the rpma_conn_req_new_from_cm_event() unit tests
  *
  * API covered:
- * - rpma_conn_req_from_cm_event()
+ * - rpma_conn_req_new_from_cm_event()
  */
 
 #include "conn_req-common.h"
@@ -23,7 +23,7 @@ from_cm_event__peer_NULL(void **unused)
 	/* run test */
 	struct rdma_cm_event event = CM_EVENT_CONNECTION_REQUEST_INIT;
 	struct rpma_conn_req *req = NULL;
-	int ret = rpma_conn_req_from_cm_event(NULL, &event,
+	int ret = rpma_conn_req_new_from_cm_event(NULL, &event,
 			MOCK_CONN_CFG_DEFAULT, &req);
 
 	/* verify the results */
@@ -39,7 +39,7 @@ from_cm_event__edata_NULL(void **unused)
 {
 	/* run test */
 	struct rpma_conn_req *req = NULL;
-	int ret = rpma_conn_req_from_cm_event(MOCK_PEER, NULL,
+	int ret = rpma_conn_req_new_from_cm_event(MOCK_PEER, NULL,
 			MOCK_CONN_CFG_DEFAULT, &req);
 
 	/* verify the results */
@@ -55,7 +55,7 @@ from_cm_event__req_ptr_NULL(void **unused)
 {
 	/* run test */
 	struct rdma_cm_event event = CM_EVENT_CONNECTION_REQUEST_INIT;
-	int ret = rpma_conn_req_from_cm_event(MOCK_PEER, &event,
+	int ret = rpma_conn_req_new_from_cm_event(MOCK_PEER, &event,
 			MOCK_CONN_CFG_DEFAULT, NULL);
 
 	/* verify the results */
@@ -70,7 +70,7 @@ static void
 from_cm_event__peer_NULL_edata_NULL_req_ptr_NULL(void **unused)
 {
 	/* run test */
-	int ret = rpma_conn_req_from_cm_event(NULL, NULL,
+	int ret = rpma_conn_req_new_from_cm_event(NULL, NULL,
 			MOCK_CONN_CFG_DEFAULT, NULL);
 
 	/* verify the results */
@@ -87,7 +87,7 @@ from_cm_event__RDMA_CM_EVENT_CONNECT_ERROR(void **unused)
 	/* run test */
 	struct rdma_cm_event event = CM_EVENT_CONNECT_ERROR_INIT;
 	struct rpma_conn_req *req = NULL;
-	int ret = rpma_conn_req_from_cm_event(MOCK_PEER, &event,
+	int ret = rpma_conn_req_new_from_cm_event(MOCK_PEER, &event,
 			MOCK_CONN_CFG_DEFAULT, &req);
 
 	/* verify the results */
@@ -117,7 +117,7 @@ from_cm_event__shared_true_srq_rcq_not_NULL(void **unused)
 
 	/* run test */
 	struct rpma_conn_req *req = NULL;
-	int ret = rpma_conn_req_from_cm_event(MOCK_PEER, &cstate->event,
+	int ret = rpma_conn_req_new_from_cm_event(MOCK_PEER, &cstate->event,
 			cstate->get_args.cfg, &req);
 
 	/* verify the results */
@@ -145,7 +145,7 @@ from_cm_event__ibv_create_comp_channel_ERRNO(void **cstate_ptr)
 
 	/* run test */
 	struct rpma_conn_req *req = NULL;
-	int ret = rpma_conn_req_from_cm_event(MOCK_PEER, &cstate->event,
+	int ret = rpma_conn_req_new_from_cm_event(MOCK_PEER, &cstate->event,
 			cstate->get_args.cfg, &req);
 
 	/* verify the results */
@@ -173,7 +173,7 @@ from_cm_event__ibv_create_comp_channel_ERRNO_rdma_ack_cm_event_ERRNO2(void **cst
 
 	/* run test */
 	struct rpma_conn_req *req = NULL;
-	int ret = rpma_conn_req_from_cm_event(MOCK_PEER, &cstate->event,
+	int ret = rpma_conn_req_new_from_cm_event(MOCK_PEER, &cstate->event,
 			cstate->get_args.cfg, &req);
 
 	/* verify the results */
@@ -211,7 +211,7 @@ from_cm_event__cq_new_ERRNO(void **cstate_ptr)
 
 	/* run test */
 	struct rpma_conn_req *req = NULL;
-	int ret = rpma_conn_req_from_cm_event(MOCK_PEER, &cstate->event,
+	int ret = rpma_conn_req_new_from_cm_event(MOCK_PEER, &cstate->event,
 			cstate->get_args.cfg, &req);
 
 	/* verify the results */
@@ -251,7 +251,7 @@ from_cm_event__rcq_new_ERRNO(void **unused)
 
 	/* run test */
 	struct rpma_conn_req *req = NULL;
-	int ret = rpma_conn_req_from_cm_event(MOCK_PEER, &cstate->event,
+	int ret = rpma_conn_req_new_from_cm_event(MOCK_PEER, &cstate->event,
 			cstate->get_args.cfg, &req);
 
 	/* verify the results */
@@ -260,7 +260,7 @@ from_cm_event__rcq_new_ERRNO(void **unused)
 }
 
 /*
- * from_cm_event__peer_create_qp_ERRNO -- rpma_peer_create_qp()
+ * from_cm_event__peer_create_qp_ERRNO -- rpma_peer_setup_qp()
  * fails with MOCK_ERRNO
  */
 static void
@@ -289,11 +289,11 @@ from_cm_event__peer_create_qp_ERRNO(void **cstate_ptr)
 			MOCK_GET_CHANNEL(cstate));
 		will_return(rpma_cq_new, MOCK_RPMA_RCQ);
 	}
-	expect_value(rpma_peer_create_qp, id, &cstate->id);
-	expect_value(rpma_peer_create_qp, rcq, MOCK_GET_RCQ(cstate));
-	expect_value(rpma_peer_create_qp, cfg, cstate->get_args.cfg);
-	will_return(rpma_peer_create_qp, RPMA_E_PROVIDER);
-	will_return(rpma_peer_create_qp, MOCK_ERRNO);
+	expect_value(rpma_peer_setup_qp, id, &cstate->id);
+	expect_value(rpma_peer_setup_qp, rcq, MOCK_GET_RCQ(cstate));
+	expect_value(rpma_peer_setup_qp, cfg, cstate->get_args.cfg);
+	will_return(rpma_peer_setup_qp, RPMA_E_PROVIDER);
+	will_return(rpma_peer_setup_qp, MOCK_ERRNO);
 	expect_value(rpma_cq_delete, *cq_ptr, MOCK_GET_RCQ_DEL(cstate));
 	will_return(rpma_cq_delete, MOCK_OK);
 	expect_value(rpma_cq_delete, *cq_ptr, MOCK_RPMA_CQ);
@@ -303,7 +303,7 @@ from_cm_event__peer_create_qp_ERRNO(void **cstate_ptr)
 
 	/* run test */
 	struct rpma_conn_req *req = NULL;
-	int ret = rpma_conn_req_from_cm_event(MOCK_PEER, &cstate->event,
+	int ret = rpma_conn_req_new_from_cm_event(MOCK_PEER, &cstate->event,
 			cstate->get_args.cfg, &req);
 
 	/* verify the results */
@@ -312,7 +312,7 @@ from_cm_event__peer_create_qp_ERRNO(void **cstate_ptr)
 }
 
 /*
- * from_cm_event__create_qp_ERRNO_subsequent_ERRNO2 -- rpma_peer_create_qp()
+ * from_cm_event__create_qp_ERRNO_subsequent_ERRNO2 -- rpma_peer_setup_qp()
  * fails with MOCK_ERRNO whereas subsequent (rpma_cq_delete(&rcq),
  * rpma_cq_delete(&cq)) fail with MOCK_ERRNO2
  */
@@ -342,11 +342,11 @@ from_cm_event__create_qp_ERRNO_subsequent_ERRNO2(void **cstate_ptr)
 				MOCK_GET_CHANNEL(cstate));
 		will_return(rpma_cq_new, MOCK_RPMA_RCQ);
 	}
-	expect_value(rpma_peer_create_qp, id, &cstate->id);
-	expect_value(rpma_peer_create_qp, rcq, MOCK_GET_RCQ(cstate));
-	expect_value(rpma_peer_create_qp, cfg, cstate->get_args.cfg);
-	will_return(rpma_peer_create_qp, RPMA_E_PROVIDER);
-	will_return(rpma_peer_create_qp, MOCK_ERRNO); /* first error */
+	expect_value(rpma_peer_setup_qp, id, &cstate->id);
+	expect_value(rpma_peer_setup_qp, rcq, MOCK_GET_RCQ(cstate));
+	expect_value(rpma_peer_setup_qp, cfg, cstate->get_args.cfg);
+	will_return(rpma_peer_setup_qp, RPMA_E_PROVIDER);
+	will_return(rpma_peer_setup_qp, MOCK_ERRNO); /* first error */
 	expect_value(rpma_cq_delete, *cq_ptr, MOCK_GET_RCQ_DEL(cstate));
 	if (!cstate->get_args.srq_rcq && cstate->get_args.rcq_size) {
 		will_return(rpma_cq_delete, RPMA_E_PROVIDER);
@@ -363,7 +363,7 @@ from_cm_event__create_qp_ERRNO_subsequent_ERRNO2(void **cstate_ptr)
 
 	/* run test */
 	struct rpma_conn_req *req = NULL;
-	int ret = rpma_conn_req_from_cm_event(MOCK_PEER, &cstate->event,
+	int ret = rpma_conn_req_new_from_cm_event(MOCK_PEER, &cstate->event,
 			cstate->get_args.cfg, &req);
 
 	/* verify the results */
@@ -400,10 +400,10 @@ from_cm_event__malloc_ERRNO(void **cstate_ptr)
 				MOCK_GET_CHANNEL(cstate));
 		will_return(rpma_cq_new, MOCK_RPMA_RCQ);
 	}
-	expect_value(rpma_peer_create_qp, id, &cstate->id);
-	expect_value(rpma_peer_create_qp, rcq, MOCK_GET_RCQ(cstate));
-	expect_value(rpma_peer_create_qp, cfg, cstate->get_args.cfg);
-	will_return(rpma_peer_create_qp, MOCK_OK);
+	expect_value(rpma_peer_setup_qp, id, &cstate->id);
+	expect_value(rpma_peer_setup_qp, rcq, MOCK_GET_RCQ(cstate));
+	expect_value(rpma_peer_setup_qp, cfg, cstate->get_args.cfg);
+	will_return(rpma_peer_setup_qp, MOCK_OK);
 	will_return(__wrap__test_malloc, MOCK_ERRNO);
 	expect_value(rdma_destroy_qp, id, &cstate->id);
 	expect_value(rpma_cq_delete, *cq_ptr, MOCK_GET_RCQ_DEL(cstate));
@@ -415,7 +415,7 @@ from_cm_event__malloc_ERRNO(void **cstate_ptr)
 
 	/* run test */
 	struct rpma_conn_req *req = NULL;
-	int ret = rpma_conn_req_from_cm_event(MOCK_PEER, &cstate->event,
+	int ret = rpma_conn_req_new_from_cm_event(MOCK_PEER, &cstate->event,
 			cstate->get_args.cfg, &req);
 
 	/* verify the results */
@@ -454,10 +454,10 @@ from_cm_event__malloc_ERRNO_subsequent_ERRNO2(void **cstate_ptr)
 				MOCK_GET_CHANNEL(cstate));
 		will_return(rpma_cq_new, MOCK_RPMA_RCQ);
 	}
-	expect_value(rpma_peer_create_qp, id, &cstate->id);
-	expect_value(rpma_peer_create_qp, rcq, MOCK_GET_RCQ(cstate));
-	expect_value(rpma_peer_create_qp, cfg, cstate->get_args.cfg);
-	will_return(rpma_peer_create_qp, MOCK_OK);
+	expect_value(rpma_peer_setup_qp, id, &cstate->id);
+	expect_value(rpma_peer_setup_qp, rcq, MOCK_GET_RCQ(cstate));
+	expect_value(rpma_peer_setup_qp, cfg, cstate->get_args.cfg);
+	will_return(rpma_peer_setup_qp, MOCK_OK);
 	will_return(__wrap__test_malloc, MOCK_ERRNO); /* first error */
 	expect_value(rdma_destroy_qp, id, &cstate->id);
 	expect_value(rpma_cq_delete, *cq_ptr, MOCK_GET_RCQ_DEL(cstate));
@@ -476,7 +476,7 @@ from_cm_event__malloc_ERRNO_subsequent_ERRNO2(void **cstate_ptr)
 
 	/* run test */
 	struct rpma_conn_req *req = NULL;
-	int ret = rpma_conn_req_from_cm_event(MOCK_PEER, &cstate->event,
+	int ret = rpma_conn_req_new_from_cm_event(MOCK_PEER, &cstate->event,
 			cstate->get_args.cfg, &req);
 
 	/* verify the results */
@@ -514,10 +514,10 @@ from_cm_event__private_data_store_E_NOMEM(void **cstate_ptr)
 				MOCK_GET_CHANNEL(cstate));
 		will_return(rpma_cq_new, MOCK_RPMA_RCQ);
 	}
-	expect_value(rpma_peer_create_qp, id, &cstate->id);
-	expect_value(rpma_peer_create_qp, rcq, MOCK_GET_RCQ(cstate));
-	expect_value(rpma_peer_create_qp, cfg, cstate->get_args.cfg);
-	will_return(rpma_peer_create_qp, MOCK_OK);
+	expect_value(rpma_peer_setup_qp, id, &cstate->id);
+	expect_value(rpma_peer_setup_qp, rcq, MOCK_GET_RCQ(cstate));
+	expect_value(rpma_peer_setup_qp, cfg, cstate->get_args.cfg);
+	will_return(rpma_peer_setup_qp, MOCK_OK);
 	will_return(__wrap__test_malloc, MOCK_OK);
 	will_return_maybe(__wrap_snprintf, MOCK_OK);
 	will_return(rpma_private_data_store, NULL); /* RPMA_E_NOMEM */
@@ -528,13 +528,13 @@ from_cm_event__private_data_store_E_NOMEM(void **cstate_ptr)
 	will_return(rpma_cq_delete, MOCK_OK);
 	expect_value(rdma_destroy_id, id, &cstate->id);
 	will_return(rdma_destroy_id, MOCK_OK);
-	expect_function_call(rpma_private_data_discard);
+	expect_function_call(rpma_private_data_delete);
 	if (!cstate->get_args.srq_rcq && cstate->get_args.shared)
 		will_return(ibv_destroy_comp_channel, MOCK_OK);
 
 	/* run test */
 	struct rpma_conn_req *req = NULL;
-	int ret = rpma_conn_req_from_cm_event(MOCK_PEER, &cstate->event,
+	int ret = rpma_conn_req_new_from_cm_event(MOCK_PEER, &cstate->event,
 			cstate->get_args.cfg, &req);
 
 	/* verify the results */
@@ -574,10 +574,10 @@ from_cm_event__private_data_store_E_NOMEM_subsequent_ERRNO2(void **cstate_ptr)
 				MOCK_GET_CHANNEL(cstate));
 		will_return(rpma_cq_new, MOCK_RPMA_RCQ);
 	}
-	expect_value(rpma_peer_create_qp, id, &cstate->id);
-	expect_value(rpma_peer_create_qp, rcq, MOCK_GET_RCQ(cstate));
-	expect_value(rpma_peer_create_qp, cfg, cstate->get_args.cfg);
-	will_return(rpma_peer_create_qp, MOCK_OK);
+	expect_value(rpma_peer_setup_qp, id, &cstate->id);
+	expect_value(rpma_peer_setup_qp, rcq, MOCK_GET_RCQ(cstate));
+	expect_value(rpma_peer_setup_qp, cfg, cstate->get_args.cfg);
+	will_return(rpma_peer_setup_qp, MOCK_OK);
 	will_return(__wrap__test_malloc, MOCK_OK);
 	will_return_maybe(__wrap_snprintf, MOCK_STDIO_ERROR);
 	will_return(rpma_private_data_store, NULL); /* first RPMA_E_NOMEM */
@@ -595,13 +595,13 @@ from_cm_event__private_data_store_E_NOMEM_subsequent_ERRNO2(void **cstate_ptr)
 	will_return(rpma_cq_delete, MOCK_ERRNO2); /* second or third error */
 	expect_value(rdma_destroy_id, id, &cstate->id);
 	will_return(rdma_destroy_id, MOCK_ERRNO2); /* third or fourth error */
-	expect_function_call(rpma_private_data_discard);
+	expect_function_call(rpma_private_data_delete);
 	if (!cstate->get_args.srq_rcq && cstate->get_args.shared)
 		will_return(ibv_destroy_comp_channel, MOCK_OK);
 
 	/* run test */
 	struct rpma_conn_req *req = NULL;
-	int ret = rpma_conn_req_from_cm_event(MOCK_PEER, &cstate->event,
+	int ret = rpma_conn_req_new_from_cm_event(MOCK_PEER, &cstate->event,
 			cstate->get_args.cfg, &req);
 
 	/* verify the results */
@@ -610,19 +610,19 @@ from_cm_event__private_data_store_E_NOMEM_subsequent_ERRNO2(void **cstate_ptr)
 }
 
 /*
- * conn_req_from_cm__lifecycle - happy day scenario
+ * conn_req_new_from_cm__lifecycle - happy day scenario
  */
 static void
-conn_req_from_cm__lifecycle(void **unused)
+conn_req_new_from_cm__lifecycle(void **unused)
 {
 	/*
-	 * The thing is done by setup__conn_req_from_cm_event() and
-	 * teardown__conn_req_from_cm_event().
+	 * The thing is done by setup__conn_req_new_from_cm_event() and
+	 * teardown__conn_req_new_from_cm_event().
 	 */
 }
 
 static const struct CMUnitTest test_from_cm_event[] = {
-	/* rpma_conn_req_from_cm_event() unit tests */
+	/* rpma_conn_req_new_from_cm_event() unit tests */
 	cmocka_unit_test(from_cm_event__peer_NULL),
 	cmocka_unit_test(from_cm_event__edata_NULL),
 	cmocka_unit_test(from_cm_event__req_ptr_NULL),
@@ -662,13 +662,13 @@ static const struct CMUnitTest test_from_cm_event[] = {
 		from_cm_event__private_data_store_E_NOMEM_subsequent_ERRNO2),
 	CONN_REQ_TEST_WITH_AND_WITHOUT_SRQ_RCQ(
 		from_cm_event__private_data_store_E_NOMEM_subsequent_ERRNO2),
-	/* rpma_conn_req_from_cm_event()/_delete() lifecycle */
+	/* rpma_conn_req_new_from_cm_event()/_delete() lifecycle */
 	CONN_REQ_TEST_SETUP_TEARDOWN_WITH_AND_WITHOUT_RCQ(
-		conn_req_from_cm__lifecycle, setup__conn_req_from_cm_event,
-		teardown__conn_req_from_cm_event),
+		conn_req_new_from_cm__lifecycle, setup__conn_req_new_from_cm_event,
+		teardown__conn_req_new_from_cm_event),
 	CONN_REQ_TEST_SETUP_TEARDOWN_WITH_AND_WITHOUT_SRQ_RCQ(
-		conn_req_from_cm__lifecycle, setup__conn_req_from_cm_event,
-		teardown__conn_req_from_cm_event),
+		conn_req_new_from_cm__lifecycle, setup__conn_req_new_from_cm_event,
+		teardown__conn_req_new_from_cm_event),
 };
 
 int

--- a/tests/unit/conn_req/conn_req-private_data.c
+++ b/tests/unit/conn_req/conn_req-private_data.c
@@ -19,7 +19,7 @@ get_private_data__success(void **cstate_ptr)
 {
 	/* WA for cmocka/issues#47 */
 	struct conn_req_test_state *cstate = *cstate_ptr;
-	assert_int_equal(setup__conn_req_from_cm_event((void **)&cstate), 0);
+	assert_int_equal(setup__conn_req_new_from_cm_event((void **)&cstate), 0);
 	assert_non_null(cstate);
 
 	/* configure mocks */
@@ -32,7 +32,7 @@ get_private_data__success(void **cstate_ptr)
 	will_return(rdma_reject, MOCK_OK);
 	if (cstate->get_args.shared)
 		will_return(ibv_destroy_comp_channel, MOCK_OK);
-	expect_function_call(rpma_private_data_discard);
+	expect_function_call(rpma_private_data_delete);
 
 	/* run test */
 	struct rpma_conn_private_data data;
@@ -69,7 +69,7 @@ get_private_data__pdata_NULL(void **cstate_ptr)
 {
 	/* WA for cmocka/issues#47 */
 	struct conn_req_test_state *cstate = *cstate_ptr;
-	assert_int_equal(setup__conn_req_from_cm_event((void **)&cstate), 0);
+	assert_int_equal(setup__conn_req_new_from_cm_event((void **)&cstate), 0);
 	assert_non_null(cstate);
 
 	/* configure mocks */
@@ -82,7 +82,7 @@ get_private_data__pdata_NULL(void **cstate_ptr)
 	will_return(rdma_reject, MOCK_OK);
 	if (cstate->get_args.shared)
 		will_return(ibv_destroy_comp_channel, MOCK_OK);
-	expect_function_call(rpma_private_data_discard);
+	expect_function_call(rpma_private_data_delete);
 
 	/* run test */
 	int ret = rpma_conn_req_get_private_data(cstate->req, NULL);

--- a/tests/unit/ep/ep-common.c
+++ b/tests/unit/ep/ep-common.c
@@ -252,10 +252,10 @@ rdma_get_cm_event(struct rdma_event_channel *channel,
 }
 
 /*
- * rpma_conn_req_from_cm_event -- rpma_conn_req_from_cm_event() mock
+ * rpma_conn_req_new_from_cm_event -- rpma_conn_req_new_from_cm_event() mock
  */
 int
-rpma_conn_req_from_cm_event(struct rpma_peer *peer,
+rpma_conn_req_new_from_cm_event(struct rpma_peer *peer,
 		struct rdma_cm_event *event, const struct rpma_conn_cfg *cfg,
 		struct rpma_conn_req **req_ptr)
 {

--- a/tests/unit/ep/ep-next_conn_req.c
+++ b/tests/unit/ep/ep-next_conn_req.c
@@ -157,7 +157,7 @@ next_conn_req__event_REJECTED_ack_ERRNO(void **estate_ptr)
 
 /*
  * next_conn_req__from_cm_event_E_NOMEM -
- * rpma_conn_req_from_cm_event() returns RPMA_E_NOMEM
+ * rpma_conn_req_new_from_cm_event() returns RPMA_E_NOMEM
  */
 static void
 next_conn_req__from_cm_event_E_NOMEM(void **estate_ptr)
@@ -169,11 +169,11 @@ next_conn_req__from_cm_event_E_NOMEM(void **estate_ptr)
 	event.event = RDMA_CM_EVENT_CONNECT_REQUEST;
 	will_return(rdma_get_cm_event, &event);
 
-	expect_value(rpma_conn_req_from_cm_event, peer, MOCK_PEER);
-	expect_value(rpma_conn_req_from_cm_event, event, &event);
-	expect_value(rpma_conn_req_from_cm_event, cfg, MOCK_CONN_CFG_DEFAULT);
-	will_return(rpma_conn_req_from_cm_event, NULL);
-	will_return(rpma_conn_req_from_cm_event, RPMA_E_NOMEM);
+	expect_value(rpma_conn_req_new_from_cm_event, peer, MOCK_PEER);
+	expect_value(rpma_conn_req_new_from_cm_event, event, &event);
+	expect_value(rpma_conn_req_new_from_cm_event, cfg, MOCK_CONN_CFG_DEFAULT);
+	will_return(rpma_conn_req_new_from_cm_event, NULL);
+	will_return(rpma_conn_req_new_from_cm_event, RPMA_E_NOMEM);
 
 	expect_value(rdma_ack_cm_event, event, &event);
 	will_return(rdma_ack_cm_event, MOCK_OK);
@@ -189,7 +189,7 @@ next_conn_req__from_cm_event_E_NOMEM(void **estate_ptr)
 
 /*
  * next_conn_req__from_cm_event_E_NOMEM_ack_ERRNO -
- * rpma_conn_req_from_cm_event() returns RPMA_E_NOMEM
+ * rpma_conn_req_new_from_cm_event() returns RPMA_E_NOMEM
  * and rdma_ack_cm_event() fails with MOCK_ERRNO
  */
 static void
@@ -202,11 +202,11 @@ next_conn_req__from_cm_event_E_NOMEM_ack_ERRNO(void **estate_ptr)
 	event.event = RDMA_CM_EVENT_CONNECT_REQUEST;
 	will_return(rdma_get_cm_event, &event);
 
-	expect_value(rpma_conn_req_from_cm_event, peer, MOCK_PEER);
-	expect_value(rpma_conn_req_from_cm_event, event, &event);
-	expect_value(rpma_conn_req_from_cm_event, cfg, MOCK_CONN_CFG_DEFAULT);
-	will_return(rpma_conn_req_from_cm_event, NULL);
-	will_return(rpma_conn_req_from_cm_event, RPMA_E_NOMEM);
+	expect_value(rpma_conn_req_new_from_cm_event, peer, MOCK_PEER);
+	expect_value(rpma_conn_req_new_from_cm_event, event, &event);
+	expect_value(rpma_conn_req_new_from_cm_event, cfg, MOCK_CONN_CFG_DEFAULT);
+	will_return(rpma_conn_req_new_from_cm_event, NULL);
+	will_return(rpma_conn_req_new_from_cm_event, RPMA_E_NOMEM);
 
 	expect_value(rdma_ack_cm_event, event, &event);
 	will_return(rdma_ack_cm_event, MOCK_ERRNO);
@@ -233,11 +233,11 @@ next_conn_req__rdma_ack_cm_event_ERRNO(void **estate_ptr)
 	event.event = RDMA_CM_EVENT_CONNECT_REQUEST;
 	will_return(rdma_get_cm_event, &event);
 
-	expect_value(rpma_conn_req_from_cm_event, peer, MOCK_PEER);
-	expect_value(rpma_conn_req_from_cm_event, event, &event);
-	expect_value(rpma_conn_req_from_cm_event, cfg,
+	expect_value(rpma_conn_req_new_from_cm_event, peer, MOCK_PEER);
+	expect_value(rpma_conn_req_new_from_cm_event, event, &event);
+	expect_value(rpma_conn_req_new_from_cm_event, cfg,
 			(estate->cfg == NULL ? MOCK_CONN_CFG_DEFAULT : estate->cfg));
-	will_return(rpma_conn_req_from_cm_event, MOCK_CONN_REQ);
+	will_return(rpma_conn_req_new_from_cm_event, MOCK_CONN_REQ);
 	expect_value(rdma_ack_cm_event, event, &event);
 	will_return(rdma_ack_cm_event, MOCK_ERRNO);
 	expect_value(rpma_conn_req_delete, *req_ptr, MOCK_CONN_REQ);
@@ -264,11 +264,11 @@ next_conn_req__success(void **estate_ptr)
 	event.event = RDMA_CM_EVENT_CONNECT_REQUEST;
 	will_return(rdma_get_cm_event, &event);
 
-	expect_value(rpma_conn_req_from_cm_event, peer, MOCK_PEER);
-	expect_value(rpma_conn_req_from_cm_event, event, &event);
-	expect_value(rpma_conn_req_from_cm_event, cfg,
+	expect_value(rpma_conn_req_new_from_cm_event, peer, MOCK_PEER);
+	expect_value(rpma_conn_req_new_from_cm_event, event, &event);
+	expect_value(rpma_conn_req_new_from_cm_event, cfg,
 			(estate->cfg == NULL ? MOCK_CONN_CFG_DEFAULT : estate->cfg));
-	will_return(rpma_conn_req_from_cm_event, MOCK_CONN_REQ);
+	will_return(rpma_conn_req_new_from_cm_event, MOCK_CONN_REQ);
 	expect_value(rdma_ack_cm_event, event, &event);
 	will_return(rdma_ack_cm_event, MOCK_OK);
 

--- a/tests/unit/flush/CMakeLists.txt
+++ b/tests/unit/flush/CMakeLists.txt
@@ -28,5 +28,5 @@ function(add_test_flush name)
 	add_test_generic(NAME ${name} TRACERS none)
 endfunction()
 
-add_test_flush(apm_do)
+add_test_flush(apm_execute)
 add_test_flush(new)

--- a/tests/unit/flush/flush-apm_execute.c
+++ b/tests/unit/flush/flush-apm_execute.c
@@ -1,11 +1,11 @@
 // SPDX-License-Identifier: BSD-3-Clause
-/* Copyright 2020-2021, Intel Corporation */
+/* Copyright 2020-2022, Intel Corporation */
 
 /*
- * flush-apm_do.c -- unit tests of the flush module
+ * flush-apm_execute.c -- unit tests of the flush module
  *
  * API covered:
- * - rpma_flush_apm_do
+ * - rpma_flush_apm_execute
  */
 
 #include "cmocka_headers.h"
@@ -16,10 +16,10 @@
 #include "flush-common.h"
 
 /*
- * apm_do__success -- rpma_flush_apm_do() success
+ * apm_execute__success -- rpma_flush_apm_execute() success
  */
 static void
-apm_do__success(void **fstate_ptr)
+apm_execute__success(void **fstate_ptr)
 {
 	/* configure mocks */
 	expect_value(rpma_mr_read, qp, MOCK_QP);
@@ -48,8 +48,8 @@ main(int argc, char *argv[])
 	enable_unistd_mocks();
 
 	const struct CMUnitTest tests[] = {
-		/* rpma_flush_apm_do() unit tests */
-		cmocka_unit_test_setup_teardown(apm_do__success,
+		/* rpma_flush_apm_execute() unit tests */
+		cmocka_unit_test_setup_teardown(apm_execute__success,
 			setup__flush_new, teardown__flush_delete),
 	};
 

--- a/tests/unit/mr/mr-common.c
+++ b/tests/unit/mr/mr-common.c
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: BSD-3-Clause
-/* Copyright 2020, Intel Corporation */
+/* Copyright 2020-2022, Intel Corporation */
 
 /*
  * mr-common.c -- the memory region unit tests's common functions
@@ -85,11 +85,11 @@ setup__reg_success(void **pprestate)
 	struct prestate *prestate = *pprestate;
 
 	/* configure mocks */
-	struct rpma_peer_mr_reg_args mr_reg_args;
+	struct rpma_peer_setup_mr_reg_args mr_reg_args;
 	mr_reg_args.usage = prestate->usage;
 	mr_reg_args.access = prestate->access;
 	mr_reg_args.mr = MOCK_MR;
-	will_return(rpma_peer_mr_reg, &mr_reg_args);
+	will_return(rpma_peer_setup_mr_reg, &mr_reg_args);
 	will_return(__wrap__test_malloc, MOCK_OK);
 
 	/* run test */

--- a/tests/unit/mr/mr-reg.c
+++ b/tests/unit/mr/mr-reg.c
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: BSD-3-Clause
-/* Copyright 2020-2021, Intel Corporation */
+/* Copyright 2020-2022, Intel Corporation */
 
 /*
  * mr-reg.c -- the memory region registration/deregistration unit tests
@@ -136,12 +136,12 @@ static void
 reg__malloc_ERRNO(void **unused)
 {
 	/* configure mocks */
-	struct rpma_peer_mr_reg_args mr_reg_args;
+	struct rpma_peer_setup_mr_reg_args mr_reg_args;
 	mr_reg_args.usage = RPMA_MR_USAGE_READ_SRC;
 	mr_reg_args.access = IBV_ACCESS_REMOTE_READ;
 	mr_reg_args.mr = MOCK_MR;
 	will_return(__wrap__test_malloc, MOCK_ERRNO);
-	will_return_maybe(rpma_peer_mr_reg, &mr_reg_args);
+	will_return_maybe(rpma_peer_setup_mr_reg, &mr_reg_args);
 	will_return_maybe(ibv_dereg_mr, MOCK_OK);
 
 	/* run test */
@@ -155,18 +155,18 @@ reg__malloc_ERRNO(void **unused)
 }
 
 /*
- * reg__peer_mr_reg_ERRNO -- rpma_peer_mr_reg() fails with MOCK_ERRNO
+ * reg__peer_mr_reg_ERRNO -- rpma_peer_setup_mr_reg() fails with MOCK_ERRNO
  */
 static void
 reg__peer_mr_reg_ERRNO(void **unused)
 {
 	/* configure mocks */
-	struct rpma_peer_mr_reg_args mr_reg_args;
+	struct rpma_peer_setup_mr_reg_args mr_reg_args;
 	mr_reg_args.usage = RPMA_MR_USAGE_READ_DST;
 	mr_reg_args.access = IBV_ACCESS_LOCAL_WRITE;
 	mr_reg_args.mr = NULL;
 	mr_reg_args.verrno = MOCK_ERRNO;
-	will_return(rpma_peer_mr_reg, &mr_reg_args);
+	will_return(rpma_peer_setup_mr_reg, &mr_reg_args);
 	will_return_maybe(__wrap__test_malloc, MOCK_OK);
 
 	/* run test */

--- a/tests/unit/peer/peer-create_qp.c
+++ b/tests/unit/peer/peer-create_qp.c
@@ -6,7 +6,7 @@
  * peer-create_qp.c -- a peer unit test
  *
  * API covered:
- * - rpma_peer_create_qp()
+ * - rpma_peer_setup_qp()
  */
 
 #include <infiniband/verbs.h>
@@ -83,7 +83,7 @@ static void
 create_qp__peer_NULL(void **unused)
 {
 	/* run test */
-	int ret = rpma_peer_create_qp(NULL, MOCK_CM_ID, MOCK_RPMA_CQ,
+	int ret = rpma_peer_setup_qp(NULL, MOCK_CM_ID, MOCK_RPMA_CQ,
 			NULL, MOCK_CONN_CFG_DEFAULT);
 
 	/* verify the results */
@@ -99,7 +99,7 @@ create_qp__id_NULL(void **pprestate)
 	struct prestate *prestate = *pprestate;
 
 	/* run test */
-	int ret = rpma_peer_create_qp(prestate->peer, NULL, MOCK_RPMA_CQ, NULL,
+	int ret = rpma_peer_setup_qp(prestate->peer, NULL, MOCK_RPMA_CQ, NULL,
 			MOCK_CONN_CFG_DEFAULT);
 
 	/* verify the results */
@@ -115,7 +115,7 @@ create_qp__cq_NULL(void **pprestate)
 	struct prestate *prestate = *pprestate;
 
 	/* run test */
-	int ret = rpma_peer_create_qp(prestate->peer, MOCK_CM_ID, NULL,
+	int ret = rpma_peer_setup_qp(prestate->peer, MOCK_CM_ID, NULL,
 			NULL, MOCK_CONN_CFG_DEFAULT);
 
 	/* verify the results */
@@ -137,7 +137,7 @@ create_qp__rdma_create_qp_ERRNO(void **pprestate)
 		will_return(rdma_create_qp, MOCK_ERRNO);
 
 		/* run test */
-		int ret = rpma_peer_create_qp(prestate->peer, MOCK_CM_ID, MOCK_RPMA_CQ,
+		int ret = rpma_peer_setup_qp(prestate->peer, MOCK_CM_ID, MOCK_RPMA_CQ,
 				rcqs[i], MOCK_CONN_CFG_CUSTOM);
 
 		/* verify the results */
@@ -160,7 +160,7 @@ create_qp__success(void **pprestate)
 		will_return(rdma_create_qp, MOCK_OK);
 
 		/* run test */
-		int ret = rpma_peer_create_qp(prestate->peer, MOCK_CM_ID, MOCK_RPMA_CQ,
+		int ret = rpma_peer_setup_qp(prestate->peer, MOCK_CM_ID, MOCK_RPMA_CQ,
 				rcqs[i], MOCK_CONN_CFG_CUSTOM);
 
 		/* verify the results */
@@ -172,7 +172,7 @@ int
 main(int argc, char *argv[])
 {
 	const struct CMUnitTest tests[] = {
-		/* rpma_peer_create_qp() unit tests */
+		/* rpma_peer_setup_qp() unit tests */
 		cmocka_unit_test(create_qp__peer_NULL),
 		cmocka_unit_test_prestate_setup_teardown(create_qp__id_NULL,
 				setup__peer, teardown__peer, &prestate_OdpCapable),

--- a/tests/unit/peer/peer-mr_reg.c
+++ b/tests/unit/peer/peer-mr_reg.c
@@ -6,7 +6,7 @@
  * peer-mr_reg.c -- a peer unit test
  *
  * API covered:
- * - rpma_peer_mr_reg()
+ * - rpma_peer_setup_mr_reg()
  */
 
 #include <infiniband/verbs.h>
@@ -89,7 +89,7 @@ mr_reg__reg_mr_ERRNO(void **pprestate)
 
 	/* run test */
 	struct ibv_mr *mr = NULL;
-	int ret = rpma_peer_mr_reg(prestate->peer, &mr, MOCK_ADDR,
+	int ret = rpma_peer_setup_mr_reg(prestate->peer, &mr, MOCK_ADDR,
 				MOCK_LEN, MOCK_USAGE);
 
 	/* verify the results */
@@ -115,7 +115,7 @@ mr_reg__reg_mr_EOPNOTSUPP_no_odp(void **pprestate)
 
 	/* run test */
 	struct ibv_mr *mr = NULL;
-	int ret = rpma_peer_mr_reg(prestate->peer, &mr, MOCK_ADDR,
+	int ret = rpma_peer_setup_mr_reg(prestate->peer, &mr, MOCK_ADDR,
 				MOCK_LEN, MOCK_USAGE);
 
 	/* verify the results */
@@ -151,7 +151,7 @@ mr_reg__reg_mr_EOPNOTSUPP_ERRNO(void **pprestate)
 
 	/* run test */
 	struct ibv_mr *mr = NULL;
-	int ret = rpma_peer_mr_reg(prestate->peer, &mr, MOCK_ADDR,
+	int ret = rpma_peer_setup_mr_reg(prestate->peer, &mr, MOCK_ADDR,
 				MOCK_LEN, MOCK_USAGE);
 
 	/* verify the results */
@@ -180,7 +180,7 @@ mr_reg__success(void **pprestate)
 
 	/* run test */
 	struct ibv_mr *mr;
-	int ret = rpma_peer_mr_reg(peer, &mr, MOCK_ADDR,
+	int ret = rpma_peer_setup_mr_reg(peer, &mr, MOCK_ADDR,
 				MOCK_LEN, prestate->usage);
 
 	/* verify the results */
@@ -214,7 +214,7 @@ mr_reg__success_odp(void **pprestate)
 
 	/* run test */
 	struct ibv_mr *mr;
-	int ret = rpma_peer_mr_reg(prestate->peer, &mr, MOCK_ADDR,
+	int ret = rpma_peer_setup_mr_reg(prestate->peer, &mr, MOCK_ADDR,
 				MOCK_LEN, MOCK_USAGE);
 
 	/* verify the results */
@@ -231,7 +231,7 @@ int
 main(int argc, char *argv[])
 {
 	const struct CMUnitTest tests[] = {
-		/* rpma_peer_mr_reg() unit tests */
+		/* rpma_peer_setup_mr_reg() unit tests */
 		{ "mr_reg__reg_mr_ERRNO_no_odp", mr_reg__reg_mr_ERRNO,
 				setup__peer, teardown__peer, &prestate_OdpIncapable},
 		{ "mr_reg__reg_mr_ERRNO_odp", mr_reg__reg_mr_ERRNO,

--- a/tests/unit/private_data/private_data-common.c
+++ b/tests/unit/private_data/private_data-common.c
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: BSD-3-Clause
-/* Copyright 2020, Intel Corporation */
+/* Copyright 2020-2022, Intel Corporation */
 /* Copyright 2021, Fujitsu */
 
 /*
@@ -68,7 +68,7 @@ teardown__private_data(void **pdata_ptr)
 {
 	struct rpma_conn_private_data *pdata = *pdata_ptr;
 
-	rpma_private_data_discard(pdata);
+	rpma_private_data_delete(pdata);
 	assert_null(pdata->ptr);
 	assert_int_equal(pdata->len, 0);
 


### PR DESCRIPTION
I am gonna fix lines (80 -> 100) in another PR

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/pmem/rpma/1963)
<!-- Reviewable:end -->
