### PR TITLE
examples: fix the client command in README of example 08

### DIFF
--- a/examples/08-messages-ping-pong/README.md
+++ b/examples/08-messages-ping-pong/README.md
@@ -19,5 +19,5 @@ message and disconnects.
 ```
 
 ```bash
-[user@client]$ ./client $server_address $port $seed $rounds # [<sleep>]
+[user@client]$ ./client $server_address $port $seed $rounds [$sleep]
 ```

--- a/examples/08-messages-ping-pong/client.c
+++ b/examples/08-messages-ping-pong/client.c
@@ -19,8 +19,7 @@
 #include "common-conn.h"
 #include "messages-ping-pong-common.h"
 
-#define USAGE_STR "usage: %s <server_address> <port> <seed> <rounds> " \
-		"[<sleep>]\n"
+#define USAGE_STR "usage: %s <server_address> <port> <seed> <rounds> [<sleep>]\n"
 
 static uint64_t
 strtoul_noerror(const char *in)


### PR DESCRIPTION
Remove the `#` character (a comment?), because the last argument
of the client can be an optional `<sleep>` expressed in microseconds:

```sh
$ client <server_address> <port> <seed> <rounds> [<sleep>]
```

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/pmem/rpma/1967)
<!-- Reviewable:end -->
