### PR TITLE
common: set DEBIAN_FRONTEND=noninteractive in CircleCI

### DIFF
--- a/.circleci/install-pkgs-ubuntu.sh
+++ b/.circleci/install-pkgs-ubuntu.sh
@@ -42,6 +42,8 @@ RPMA_DEPS="\
 	linux-modules-extra-$(uname -r) \
 	pandoc"
 
+export DEBIAN_FRONTEND=noninteractive
+
 # Update existing packages
 sudo apt-get update --allow-unauthenticated
 


### PR DESCRIPTION
Set `DEBIAN_FRONTEND` to `noninteractive` in CircleCI.
It fixes the CircleCI build stopping at the question:

```
Restarting services...
Package configuration
Daemons using outdated libraries
Which services should be restarted?
```

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/pmem/rpma/1972)
<!-- Reviewable:end -->
