### PR TITLE
examples: continue when rpma_cq_get_wc() returns RPMA_E_NO_COMPLETION

### DIFF
--- a/examples/08-messages-ping-pong/messages-ping-pong-common.c
+++ b/examples/08-messages-ping-pong/messages-ping-pong-common.c
@@ -55,9 +55,14 @@ wait_and_process_completions(struct rpma_cq *cq, uint64_t *recv,
 		if ((ret = rpma_cq_wait(cq)))
 			return ret;
 
+		/* reset num_got to 0  */
+		num_got = 0;
+
 		/* get two next completions at most (1 of send + 1 of recv) */
 		if ((ret = rpma_cq_get_wc(cq, MAX_N_WC, wc, &num_got)))
-			return ret;
+			/* lack of completion is not an error */
+			if (ret != RPMA_E_NO_COMPLETION)
+				return ret;
 
 		/* validate received completions */
 		for (int i = 0; i < num_got; i++) {


### PR DESCRIPTION
When rpma_cq_wait() gets a completion event and rpma_cq_get_wc()
retrieves two completions, it is possible that rpma_cq_wait()
can get another completion event successfully but rpma_cq_get_wc()
returns RPMA_E_NO_COMPLETION in the next loop.

The RPMA_E_NO_COMPLETION breaks wait_and_process_completions() and
make 08-messages-ping-pong end too early on real RDMA HW. For example:

```sh
$ ./examples/08-messages-ping-pong/client 192.168.1.11 8765 1 5
...
... rpma_conn_req_new: Requesting a connection to 192.168.1.11:8765
... rpma_conn_next_event: Connection established
Value sent: 1
Value received: 2
Value sent: 2
... rpma_conn_disconnect: Requesting for disconnection
... rpma_conn_next_event: Connection closed
```

Signed-off-by: Xiao Yang <yangx.jy@fujitsu.com>

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/pmem/rpma/1974)
<!-- Reviewable:end -->
