### PR TITLE
rpma: fault injection cannot falsify the results of rpma_cq_get_wc()

### DIFF
--- a/src/cq.c
+++ b/src/cq.c
@@ -252,11 +252,11 @@ rpma_cq_get_wc(struct rpma_cq *cq, int num_entries, struct ibv_wc *wc,
 		return RPMA_E_UNKNOWN;
 	}
 
-	RPMA_FAULT_INJECTION(RPMA_E_NO_COMPLETION, {});
-	RPMA_FAULT_INJECTION(RPMA_E_UNKNOWN, {});
-
 	if (num_entries_got)
 		*num_entries_got = result;
+
+	RPMA_FAULT_INJECTION(RPMA_E_NO_COMPLETION, {});
+	RPMA_FAULT_INJECTION(RPMA_E_UNKNOWN, {});
 
 	return 0;
 }


### PR DESCRIPTION
Fault injection cannot falsify the results of `rpma_cq_get_wc()`,
because the application can hang on waiting for the next completion.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/pmem/rpma/1975)
<!-- Reviewable:end -->
