### PR TITLE
rpma: move RPMA_FAULT_INJECTION() in rpma_conn_cfg_get_compl_channel()

### DIFF
--- a/src/conn_cfg.c
+++ b/src/conn_cfg.c
@@ -439,7 +439,6 @@ int
 rpma_conn_cfg_get_compl_channel(const struct rpma_conn_cfg *cfg, bool *shared)
 {
 	RPMA_DEBUG_TRACE;
-	RPMA_FAULT_INJECTION(RPMA_E_INVAL, {});
 
 	if (cfg == NULL || shared == NULL)
 		return RPMA_E_INVAL;
@@ -450,6 +449,7 @@ rpma_conn_cfg_get_compl_channel(const struct rpma_conn_cfg *cfg, bool *shared)
 	*shared = cfg->shared_comp_channel;
 #endif /* ATOMIC_OPERATIONS_SUPPORTED */
 
+	RPMA_FAULT_INJECTION(RPMA_E_INVAL, {});
 	return 0;
 }
 


### PR DESCRIPTION
RPMA_FAULT_INJECTION() in rpma_conn_cfg_get_compl_channel()
should be moved just before 'return 0' because the function
is used as void in rpma_conn_req_from_id().

Signed-off-by: Xiao Yang <yangx.jy@fujitsu.com>

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/pmem/rpma/1980)
<!-- Reviewable:end -->
