### PR TITLE
rpma: rpma_conn_cfg_get_timeout() has to return correct value

### DIFF
--- a/src/conn_cfg.c
+++ b/src/conn_cfg.c
@@ -203,7 +203,6 @@ int
 rpma_conn_cfg_get_timeout(const struct rpma_conn_cfg *cfg, int *timeout_ms)
 {
 	RPMA_DEBUG_TRACE;
-	RPMA_FAULT_INJECTION(RPMA_E_INVAL, {});
 
 	if (cfg == NULL || timeout_ms == NULL)
 		return RPMA_E_INVAL;
@@ -214,6 +213,7 @@ rpma_conn_cfg_get_timeout(const struct rpma_conn_cfg *cfg, int *timeout_ms)
 	*timeout_ms = cfg->timeout_ms;
 #endif /* ATOMIC_OPERATIONS_SUPPORTED */
 
+	RPMA_FAULT_INJECTION(RPMA_E_INVAL, {});
 	return 0;
 }
 


### PR DESCRIPTION
`rpma_conn_cfg_get_timeout()` has to always return the correct value,
even in case of fault injection, because it is called
as "`void`" in `rpma_conn_req_new()`.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/pmem/rpma/1982)
<!-- Reviewable:end -->
