### PR TITLE
examples: expand 08srq-simple-messages-ping-pong-with-srq

### DIFF
--- a/examples/08srq-simple-messages-ping-pong-with-srq/README.md
+++ b/examples/08srq-simple-messages-ping-pong-with-srq/README.md
@@ -15,8 +15,12 @@ message and waits for disconnection.
 ## Usage
 
 ```bash
-[user@server]$ ./server $server_address $port
+[user@server]$ ./server $server_address $port [m|r]
 ```
+**Note** The third parameter can be one of the following values:
+- unspecified - get receive completions by the receive CQ of the shared RQ
+- m - get receive completions by the main CQ of the connection
+- r - get receive completions by the separate receive CQ of the connection
 
 ```bash
 [user@client]$ ./client $server_address $port $seed $rounds [$sleep]

--- a/examples/08srq-simple-messages-ping-pong-with-srq/server.c
+++ b/examples/08srq-simple-messages-ping-pong-with-srq/server.c
@@ -1,5 +1,6 @@
 // SPDX-License-Identifier: BSD-3-Clause
 /* Copyright 2022, Intel Corporation */
+/* Copyright (c) 2022 Fujitsu Limited */
 
 /*
  * server.c -- a server of the simple-messages-ping-pong-with-srq example
@@ -12,13 +13,12 @@
 #include <stdlib.h>
 #include <stdio.h>
 #include <unistd.h>
-#include <sys/epoll.h>
 
 #include "common-conn.h"
 #include "common-messages-ping-pong.h"
-#include "common-epoll.h"
 
-#define USAGE_STR "usage: %s <server_address> <port>\n"
+#define USAGE_STR	"usage: %s <server_address> <port> [m|r]\n"
+#define RCQ_SIZE	10
 
 int
 main(int argc, char *argv[])
@@ -36,7 +36,25 @@ main(int argc, char *argv[])
 	/* read common parameters */
 	char *addr = argv[1];
 	char *port = argv[2];
+	char rcq_flag;
 	int ret;
+
+	/* validate the third parameter */
+	if (argv[3]) {
+		if (strcmp(argv[3], "m") == 0) {
+			rcq_flag = 'm';
+		} else if (strcmp(argv[3], "r") == 0) {
+			rcq_flag = 'r';
+		} else {
+			(void) fprintf(stderr,
+					"The third parameter should be one of m or r (%s given)\n",
+					argv[3]);
+			return -1;
+		}
+	} else {
+		/* set rcq_flag to the default 's' when the third parameter is not specified. */
+		rcq_flag = 's';
+	}
 
 	/* prepare memory */
 	struct rpma_mr_local *recv_mr, *send_mr;
@@ -53,8 +71,9 @@ main(int argc, char *argv[])
 	/* RPMA resources */
 	struct rpma_peer *peer = NULL;
 	struct rpma_srq *srq = NULL;
+	struct rpma_srq_cfg *srq_cfg = NULL;
 	struct rpma_conn *conn = NULL;
-	struct rpma_conn_cfg *cfg = NULL;
+	struct rpma_conn_cfg *conn_cfg = NULL;
 	struct rpma_ep *ep = NULL;
 	struct rpma_cq *rcq = NULL;
 	int num_got = 0;
@@ -67,16 +86,30 @@ main(int argc, char *argv[])
 	if ((ret = server_peer_via_address(addr, &peer)))
 		goto err_free_send;
 
-	/* create a shared RQ object */
-	if ((ret = rpma_srq_new(peer, NULL, &srq)))
+	if ((ret = rpma_srq_cfg_new(&srq_cfg)))
 		goto err_peer_delete;
 
+	if (rcq_flag != 's') {
+		if ((ret = rpma_srq_cfg_set_rcq_size(srq_cfg, 0)))
+			goto err_srq_cfg_delete;
+	}
+
+	/* create a shared RQ object with given configuration */
+	if ((ret = rpma_srq_new(peer, srq_cfg, &srq)))
+		goto err_srq_cfg_delete;
+
 	/* create a new connection configuration */
-	if ((ret = rpma_conn_cfg_new(&cfg)))
+	if ((ret = rpma_conn_cfg_new(&conn_cfg)))
 		goto err_srq_delete;
 
+	/* The default receive CQ size of the connection is 0 when rcq_flag is not 'r'. */
+	if (rcq_flag == 'r') {
+		if ((ret = rpma_conn_cfg_set_rcq_size(conn_cfg, RCQ_SIZE)))
+			goto err_conn_cfg_delete;
+	}
+
 	/* set the shared RQ object for the connection configuration */
-	if ((ret = rpma_conn_cfg_set_srq(cfg, srq)))
+	if ((ret = rpma_conn_cfg_set_srq(conn_cfg, srq)))
 		goto err_conn_cfg_delete;
 
 	/* start a listening endpoint at addr:port */
@@ -100,15 +133,28 @@ main(int argc, char *argv[])
 	/*
 	 * Wait for an incoming connection request, accept it and wait for its establishment.
 	 */
-	if ((ret = server_accept_connection(ep, cfg, NULL, &conn)))
+	if ((ret = server_accept_connection(ep, conn_cfg, NULL, &conn)))
 		goto err_conn_disconnect;
 
 	/* get the qp_num of the connection */
 	if ((ret = rpma_conn_get_qp_num(conn, &qp_num)))
 		goto err_conn_disconnect;
 
-	/* get the receive CQ of the rpma_srq object */
-	if ((ret = rpma_srq_get_rcq(srq, &rcq)))
+	switch (rcq_flag) {
+		case 's':
+			/* get the receive CQ of the shared RQ */
+			ret = rpma_srq_get_rcq(srq, &rcq);
+			break;
+		case 'm':
+			/* get the main CQ of the connection */
+			ret = rpma_conn_get_cq(conn, &rcq);
+			break;
+		case 'r':
+			/* get the separate receive CQ of the connection */
+			ret = rpma_conn_get_rcq(conn, &rcq);
+	}
+
+	if (ret)
 		goto err_conn_disconnect;
 
 	int recv_cmpl = 0;
@@ -184,10 +230,13 @@ err_ep_shutdown:
 	ret |= rpma_ep_shutdown(&ep);
 
 err_conn_cfg_delete:
-	ret |= rpma_conn_cfg_delete(&cfg);
+	ret |= rpma_conn_cfg_delete(&conn_cfg);
 
 err_srq_delete:
 	ret |= rpma_srq_delete(&srq);
+
+err_srq_cfg_delete:
+	ret |= rpma_srq_cfg_delete(&srq_cfg);
 
 err_peer_delete:
 	/* delete the peer object */


### PR DESCRIPTION
expand 08srq-simple-messages-ping-pong-with-srq so that it can
get receive completions by one of the following CQs:
- the receive CQ of the shared RQ
- the main CQ of the connection
- the separate receive CQ of the connection

Signed-off-by: Xiao Yang <yangx.jy@fujitsu.com>

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/pmem/rpma/1985)
<!-- Reviewable:end -->
