### PR TITLE
common: install python3-devel in Fedora Rawhide (fix)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 - DEVELOPMENT.md file - `CMAKE_BUILD_TYPE` must be set to `Debug` when running the tests
+- docker file of Fedora Rawhide (the python3-devel package added)
 
 ## [1.1.0] - 2022-09-08
 ### Added

--- a/utils/docker/images/Dockerfile.fedora-rawhide
+++ b/utils/docker/images/Dockerfile.fedora-rawhide
@@ -44,6 +44,7 @@ ENV EXAMPLES_DEPS "\
 
 # performance tools deps
 ENV TOOLS_DEPS "\
+	python3-devel \
 	python3-jinja2 \
 	pylint \
 	python3-pip \


### PR DESCRIPTION
Fix the rebuild of Fedora Rawhide by installing the python3-devel package.

See failed builds: https://github.com/pmem/rpma/actions/workflows/nightly_experimental.yml
See the build with this fix: https://github.com/ldorau/rpma/runs/8299831697?check_suite_focus=true

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/pmem/rpma/2029)
<!-- Reviewable:end -->
