### PR TITLE
common: silent huge number of grep warning messages

### DIFF
--- a/utils/check_license/check-headers.sh
+++ b/utils/check_license/check-headers.sh
@@ -115,17 +115,17 @@ for file in $FILES ; do
 		RV=1
 	elif [[ $file == *.c ]]; then
 		if ! grep -q -e "\/\/ SPDX-License-Identifier: $LICENSE" $src_path; then
-			echo "error: wrong format of SPDX tag in the file: $src_path" >&2
+			echo "error: wrong format of SPDX tag in the file: $src_path" >&2 2>/dev/null
 			RV=1
 		fi
 	elif [[ $file == *.h ]]; then
 		if ! grep -q -e "\/\* SPDX-License-Identifier: $LICENSE \*\/" $src_path; then
-			echo "error: wrong format of SPDX tag in the file: $src_path" >&2
+			echo "error: wrong format of SPDX tag in the file: $src_path" >&2  2>/dev/null
 			RV=1
 		fi
 	elif [[ $file != LICENSE ]]; then
 		if ! grep -q -e "# SPDX-License-Identifier: $LICENSE" $src_path; then
-			echo "error: wrong format of SPDX tag in the file: $src_path" >&2
+			echo "error: wrong format of SPDX tag in the file: $src_path" >&2  2>/dev/null
 			RV=1
 		fi
 	fi


### PR DESCRIPTION
Silent huge number of a grep warning messages on Fedora Rawhide:
```
grep: warning: stray \ before /
```
See:
https://github.com/pmem/rpma/runs/8300758291?check_suite_focus=true

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/pmem/rpma/2031)
<!-- Reviewable:end -->
