### PR TITLE
common: remove unneeded stray \ before /

### DIFF
--- a/utils/check_license/check-headers.sh
+++ b/utils/check_license/check-headers.sh
@@ -114,12 +114,12 @@ for file in $FILES ; do
 		echo "error: no $LICENSE SPDX tag in file: $src_path" >&2
 		RV=1
 	elif [[ $file == *.c ]]; then
-		if ! grep -q -e "\/\/ SPDX-License-Identifier: $LICENSE" $src_path; then
+		if ! grep -q -e "// SPDX-License-Identifier: $LICENSE" $src_path; then
 			echo "error: wrong format of SPDX tag in the file: $src_path" >&2
 			RV=1
 		fi
 	elif [[ $file == *.h ]]; then
-		if ! grep -q -e "\/\* SPDX-License-Identifier: $LICENSE \*\/" $src_path; then
+		if ! grep -q -e "/\* SPDX-License-Identifier: $LICENSE \*/" $src_path; then
 			echo "error: wrong format of SPDX tag in the file: $src_path" >&2
 			RV=1
 		fi


### PR DESCRIPTION
Remove unneeded stray \ before /. It causes a huge number of the following grep warning messages on Fedora Rawhide:
```
grep: warning: stray \ before /
```
See:
https://github.com/pmem/rpma/runs/8300758291?check_suite_focus=true