### PR TITLE
common: use cmake3 if cmake is v2.x

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 - DEVELOPMENT.md file - `CMAKE_BUILD_TYPE` must be set to `Debug` when running the tests
 - docker file of Fedora Rawhide (the python3-devel package added)
+- build system for CentOS 7 (use cmake3 instead of cmake if a version of cmake is v2.x)
 
 ## [1.1.0] - 2022-09-08
 ### Added

--- a/utils/docker/run-build.sh
+++ b/utils/docker/run-build.sh
@@ -58,7 +58,7 @@ function upload_codecov() {
 	printf "\n$(tput setaf 1)$(tput setab 7)COVERAGE ${FUNCNAME[0]} START$(tput sgr 0)\n"
 
 	# set proper gcov command
-	clang_used=$(cmake -LA -N . | grep CMAKE_C_COMPILER | grep clang | wc -c)
+	clang_used=$($CMAKE -LA -N . | grep CMAKE_C_COMPILER | grep clang | wc -c)
 	if [[ $clang_used > 0 ]]; then
 		gcovexe="llvm-cov gcov"
 	else
@@ -85,7 +85,7 @@ function compile_example_standalone() {
 	mkdir $EXAMPLE_TEST_DIR
 	cd $EXAMPLE_TEST_DIR
 
-	cmake $1
+	$CMAKE $1
 
 	# exit on error
 	if [[ $? != 0 ]]; then
@@ -164,6 +164,12 @@ function run_pytest() {
 
 ./prepare-for-build.sh
 
+# Use cmake3 instead of cmake if a version of cmake is v2.x,
+# because the minimum required version of cmake is 3.3.
+CMAKE_VERSION=$(cmake --version | grep version | cut -d" " -f3 | cut -d. -f1)
+[ "$CMAKE_VERSION" != "" ] && [ $CMAKE_VERSION -lt 3 ] && \
+	[ "$(which cmake3 2>/dev/null)" != "" ] && CMAKE=cmake3 || CMAKE=cmake
+
 # look for libprotobuf-c
 USR=$(find /usr -name "*protobuf-c.so*" || true)
 LIB=$(find /lib* -name "*protobuf-c.so*" || true)
@@ -178,7 +184,7 @@ mkdir -p $WORKDIR/build
 cd $WORKDIR/build
 
 CC=$CC \
-cmake .. -DCMAKE_BUILD_TYPE=Debug \
+$CMAKE .. -DCMAKE_BUILD_TYPE=Debug \
 	-DTEST_DIR=$TEST_DIR \
 	-DBUILD_DEVELOPER_MODE=1 \
 	-DDEBUG_USE_ASAN=${CI_SANITS} \
@@ -201,7 +207,7 @@ mkdir -p $WORKDIR/build
 cd $WORKDIR/build
 
 CC=$CC \
-cmake .. -DCMAKE_BUILD_TYPE=Debug \
+$CMAKE .. -DCMAKE_BUILD_TYPE=Debug \
 	-DTEST_DIR=$TEST_DIR \
 	-DCMAKE_INSTALL_PREFIX=$PREFIX \
 	-DTESTS_COVERAGE=$TESTS_COVERAGE \
@@ -240,7 +246,7 @@ mkdir -p $WORKDIR/build
 cd $WORKDIR/build
 
 CC=$CC \
-cmake .. -DCMAKE_BUILD_TYPE=Release \
+$CMAKE .. -DCMAKE_BUILD_TYPE=Release \
 	-DTEST_DIR=$TEST_DIR \
 	-DCMAKE_INSTALL_PREFIX=$PREFIX \
 	-DCPACK_GENERATOR=$PACKAGE_MANAGER \


### PR DESCRIPTION
Use `cmake3` instead of `cmake` if a version of `cmake` is v2.x, because the minimum required version of `cmake` is 3.3.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/pmem/rpma/2034)
<!-- Reviewable:end -->
