### PR TITLE
common: correct the path of check-ms-license.pl

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - DEVELOPMENT.md file - `CMAKE_BUILD_TYPE` must be set to `Debug` when running the tests
 - docker file of Fedora Rawhide (the python3-devel package added)
 - build system for CentOS 7 (use cmake3 instead of cmake if a version of cmake is v2.x)
+- check-headers.sh file - correct the path of check-ms-license.pl
 
 ## [1.1.0] - 2022-09-08
 ### Added

--- a/utils/check_license/check-headers.sh
+++ b/utils/check_license/check-headers.sh
@@ -1,11 +1,11 @@
 #!/usr/bin/env bash
 # SPDX-License-Identifier: BSD-3-Clause
 # Copyright 2016-2022, Intel Corporation
+# Copyright (c) 2022 Fujitsu Limited
 
 # check-headers.sh - check copyright and license in source files
 
 SELF=$0
-DIR=$(dirname $SELF)
 
 function usage() {
 	echo "Usage: $SELF <source_root_path> <license_tag> [-h|-v|-a]"
@@ -188,7 +188,7 @@ s/.*Copyright \([0-9]\+\),.*/\1-\1/' $src_path`
 done
 rm -f $TMP $TMP2 $TEMPFILE
 
-$DIR/check-ms-license.pl $FILES
+${SOURCE_ROOT}/utils/check_license/check-ms-license.pl $FILES
 
 # check if error found
 if [ $RV -eq 0 ]; then


### PR DESCRIPTION
fix the following error when running 'make check-license': 
---------------------------------------------------------
 Checking copyright headers of all files...
../utils/check_license/check-headers.sh: line 191: \
    ../utils/check_license/check-ms-license.pl: No such file or directory
...
---------------------------------------------------------

Signed-off-by: Xiao Yang <yangx.jy@fujitsu.com>

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/pmem/rpma/2035)
<!-- Reviewable:end -->
