### PR TITLE
common: remove unneeded '*' at start of expression

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - build system for CentOS 7 (use cmake3 instead of cmake if a version of cmake is v2.x)
 - check-headers.sh file - corrected the path of check-ms-license.pl
 - removed unused doc_snippets
+- removed unneeded '*' at start of expressions in utils/check_license/check-headers.sh
 
 ### Changed
 - logging of the source and the destination GID addresses in rpma_conn_req_new_from_id()

--- a/utils/check_license/check-headers.sh
+++ b/utils/check_license/check-headers.sh
@@ -94,10 +94,10 @@ else
 fi
 
 FILES=$($GIT $GIT_COMMAND | ${SOURCE_ROOT}/utils/check_license/file-exceptions.sh | \
-	grep    -E -e '*\.[chs]$' -e '*\.[ch]pp$' -e '*\.sh$' \
-		   -e '*\.py$' -e '*\.link$' -e 'Makefile*' -e 'TEST*' \
+	grep    -E -e '\.[chs]$' -e '\.[ch]pp$' -e '\.sh$' \
+		   -e '\.py$' -e '\.link$' -e 'Makefile*' -e 'TEST*' \
 		   -e '/common.inc$' -e '/match$' -e '/check_whitespace$' \
-		   -e 'LICENSE$' -e 'CMakeLists.txt$' -e '*\.cmake$' -e '/Dockerfile.*' | \
+		   -e 'LICENSE$' -e 'CMakeLists.txt$' -e '\.cmake$' -e '/Dockerfile.*' | \
 	xargs)
 
 RV=0


### PR DESCRIPTION
It silents the following warnings:
```
grep: warning: * at start of expression
```

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/pmem/rpma/2042)
<!-- Reviewable:end -->
