### PR TITLE
examples: do not use 0 size when mapping PMem

### DIFF
--- a/examples/03-read-to-persistent/client.c
+++ b/examples/03-read-to-persistent/client.c
@@ -49,7 +49,7 @@ main(int argc, char *argv[])
 	if (argc >= 4) {
 		char *path = argv[3];
 
-		ret = common_pmem_map_file_with_signature_check(path, 0, &mem);
+		ret = common_pmem_map_file_with_signature_check(path, sizeof(struct hello_t), &mem);
 		if (ret)
 			goto err_free;
 		hello = (struct hello_t *)((uintptr_t)mem.mr_ptr + mem.data_offset);

--- a/examples/04-write-to-persistent/client.c
+++ b/examples/04-write-to-persistent/client.c
@@ -70,7 +70,7 @@ main(int argc, char *argv[])
 	if (argc >= 4) {
 		char *path = argv[3];
 
-		ret = common_pmem_map_file_with_signature_check(path, 0, &mem);
+		ret = common_pmem_map_file_with_signature_check(path, sizeof(struct hello_t), &mem);
 		if (ret)
 			goto err_free;
 		hello = (struct hello_t *)((uintptr_t)mem.mr_ptr + mem.data_offset);

--- a/examples/05-flush-to-persistent/client.c
+++ b/examples/05-flush-to-persistent/client.c
@@ -58,7 +58,7 @@ main(int argc, char *argv[])
 	if (argc >= 4) {
 		char *path = argv[3];
 
-		ret = common_pmem_map_file_with_signature_check(path, 0, &mem);
+		ret = common_pmem_map_file_with_signature_check(path, sizeof(struct hello_t), &mem);
 		if (ret)
 			goto err_free;
 		hello = (struct hello_t *)((uintptr_t)mem.mr_ptr + mem.data_offset);

--- a/examples/09-flush-to-persistent-GPSPM/client.c
+++ b/examples/09-flush-to-persistent-GPSPM/client.c
@@ -71,7 +71,7 @@ main(int argc, char *argv[])
 	if (argc >= 4) {
 		char *path = argv[3];
 
-		ret = common_pmem_map_file_with_signature_check(path, 0, &mem);
+		ret = common_pmem_map_file_with_signature_check(path, sizeof(struct hello_t), &mem);
 		if (ret)
 			goto err_free;
 		hello = (struct hello_t *)((uintptr_t)mem.mr_ptr + mem.data_offset);

--- a/examples/09scch-flush-to-persistent-GPSPM/client.c
+++ b/examples/09scch-flush-to-persistent-GPSPM/client.c
@@ -71,7 +71,7 @@ main(int argc, char *argv[])
 	if (argc >= 4) {
 		char *path = argv[3];
 
-		ret = common_pmem_map_file_with_signature_check(path, 0, &mem);
+		ret = common_pmem_map_file_with_signature_check(path, sizeof(struct hello_t), &mem);
 		if (ret)
 			goto err_free;
 

--- a/examples/common/common-map_file_with_signature_check.c
+++ b/examples/common/common-map_file_with_signature_check.c
@@ -18,7 +18,7 @@ common_pmem_map_file_with_signature_check(char *path, size_t size, struct common
 	size_t min_size = size;
 
 	if (min_size == 0)
-		min_size = sizeof(struct hello_t);
+		return -1;
 
 	if (common_pmem_map_file(path, SIGNATURE_LEN + min_size, mem))
 		return -1;


### PR DESCRIPTION
Do not use 0 size when mapping PMem.
A size of PMem should be set explicitly.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/pmem/rpma/2043)
<!-- Reviewable:end -->
