### PR TITLE
examples: do not use 0 size when mapping PMem

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - check-headers.sh file - corrected the path of check-ms-license.pl and removed
   unneeded '*' at the start of the grep expressions
 - (examples) use HELLO_STR_SIZE instead of KILOBYTE in case of the hello string
+- the common_pmem_map_file_with_signature_check() function in examples
 
 ### Changed
 - logging of the source and the destination GID addresses in rpma_conn_req_new_from_id()

--- a/examples/03-read-to-persistent/client.c
+++ b/examples/03-read-to-persistent/client.c
@@ -49,9 +49,11 @@ main(int argc, char *argv[])
 	if (argc >= 4) {
 		char *path = argv[3];
 
-		ret = common_pmem_map_file_with_signature_check(path, 0, &mem);
+		ret = common_pmem_map_file_with_signature_check(path, HELLO_T_SIZE, &mem,
+								init_hello);
 		if (ret)
 			goto err_free;
+
 		hello = (struct hello_t *)((uintptr_t)mem.mr_ptr + mem.data_offset);
 	}
 #endif /* USE_PMEM */

--- a/examples/03-read-to-persistent/server.c
+++ b/examples/03-read-to-persistent/server.c
@@ -53,7 +53,8 @@ main(int argc, char *argv[])
 	if (argc >= 4) {
 		pmem_path = argv[3];
 
-		ret = common_pmem_map_file_with_signature_check(pmem_path, HELLO_STR_SIZE, &mem);
+		ret = common_pmem_map_file_with_signature_check(pmem_path, HELLO_STR_SIZE, &mem,
+								NULL);
 		if (ret)
 			goto err_free;
 	}

--- a/examples/04-write-to-persistent/client.c
+++ b/examples/04-write-to-persistent/client.c
@@ -70,9 +70,11 @@ main(int argc, char *argv[])
 	if (argc >= 4) {
 		char *path = argv[3];
 
-		ret = common_pmem_map_file_with_signature_check(path, 0, &mem);
+		ret = common_pmem_map_file_with_signature_check(path, HELLO_T_SIZE, &mem,
+								init_hello);
 		if (ret)
 			goto err_free;
+
 		hello = (struct hello_t *)((uintptr_t)mem.mr_ptr + mem.data_offset);
 	}
 #endif /* USE_PMEM */

--- a/examples/04-write-to-persistent/server.c
+++ b/examples/04-write-to-persistent/server.c
@@ -64,7 +64,8 @@ main(int argc, char *argv[])
 		 * All of the space under the offset is intended for
 		 * the string contents. Space is assumed to be at least 1 KiB.
 		 */
-		ret = common_pmem_map_file_with_signature_check(pmem_path, HELLO_STR_SIZE, &mem);
+		ret = common_pmem_map_file_with_signature_check(pmem_path, HELLO_STR_SIZE, &mem,
+								NULL);
 		if (ret)
 			goto err_free;
 	}

--- a/examples/05-flush-to-persistent/client.c
+++ b/examples/05-flush-to-persistent/client.c
@@ -58,9 +58,11 @@ main(int argc, char *argv[])
 	if (argc >= 4) {
 		char *path = argv[3];
 
-		ret = common_pmem_map_file_with_signature_check(path, 0, &mem);
+		ret = common_pmem_map_file_with_signature_check(path, HELLO_T_SIZE, &mem,
+								init_hello);
 		if (ret)
 			goto err_free;
+
 		hello = (struct hello_t *)((uintptr_t)mem.mr_ptr + mem.data_offset);
 	}
 #endif /* USE_PMEM */

--- a/examples/05-flush-to-persistent/server.c
+++ b/examples/05-flush-to-persistent/server.c
@@ -57,7 +57,8 @@ main(int argc, char *argv[])
 	if (argc >= 4) {
 		pmem_path = argv[3];
 
-		ret = common_pmem_map_file_with_signature_check(pmem_path, HELLO_STR_SIZE, &mem);
+		ret = common_pmem_map_file_with_signature_check(pmem_path, HELLO_STR_SIZE, &mem,
+								NULL);
 		if (ret)
 			goto err_free;
 	}

--- a/examples/09-flush-to-persistent-GPSPM/client.c
+++ b/examples/09-flush-to-persistent-GPSPM/client.c
@@ -71,9 +71,11 @@ main(int argc, char *argv[])
 	if (argc >= 4) {
 		char *path = argv[3];
 
-		ret = common_pmem_map_file_with_signature_check(path, 0, &mem);
+		ret = common_pmem_map_file_with_signature_check(path, HELLO_T_SIZE, &mem,
+								init_hello);
 		if (ret)
 			goto err_free;
+
 		hello = (struct hello_t *)((uintptr_t)mem.mr_ptr + mem.data_offset);
 	}
 #endif /* USE_PMEM */

--- a/examples/09-flush-to-persistent-GPSPM/server.c
+++ b/examples/09-flush-to-persistent-GPSPM/server.c
@@ -65,7 +65,8 @@ main(int argc, char *argv[])
 	if (argc >= 4) {
 		pmem_path = argv[3];
 
-		ret = common_pmem_map_file_with_signature_check(pmem_path, HELLO_STR_SIZE, &mem);
+		ret = common_pmem_map_file_with_signature_check(pmem_path, HELLO_STR_SIZE, &mem,
+								NULL);
 		if (ret)
 			goto err_free;
 	}

--- a/examples/09scch-flush-to-persistent-GPSPM/client.c
+++ b/examples/09scch-flush-to-persistent-GPSPM/client.c
@@ -71,7 +71,8 @@ main(int argc, char *argv[])
 	if (argc >= 4) {
 		char *path = argv[3];
 
-		ret = common_pmem_map_file_with_signature_check(path, 0, &mem);
+		ret = common_pmem_map_file_with_signature_check(path, HELLO_T_SIZE, &mem,
+								init_hello);
 		if (ret)
 			goto err_free;
 

--- a/examples/09scch-flush-to-persistent-GPSPM/server.c
+++ b/examples/09scch-flush-to-persistent-GPSPM/server.c
@@ -63,7 +63,8 @@ main(int argc, char *argv[])
 	if (argc >= 4) {
 		pmem_path = argv[3];
 
-		ret = common_pmem_map_file_with_signature_check(pmem_path, HELLO_STR_SIZE, &mem);
+		ret = common_pmem_map_file_with_signature_check(pmem_path, HELLO_STR_SIZE, &mem,
+								NULL);
 		if (ret)
 			goto err_free;
 	}

--- a/examples/common/common-hello.c
+++ b/examples/common/common-hello.c
@@ -31,3 +31,17 @@ translate(struct hello_t *hello)
 	enum lang_t lang = (enum lang_t)((hello->lang + 1) % LANG_NUM);
 	write_hello_str(hello, lang);
 }
+
+ssize_t
+init_hello(char *pmem_data, size_t size)
+{
+	if (size < HELLO_T_SIZE) {
+		(void) fprintf(stderr, "PMem has too small size (%zu < %zu)\n",
+				size, HELLO_T_SIZE);
+		return -1;
+	}
+
+	write_hello_str((struct hello_t *)pmem_data, en);
+
+	return HELLO_T_SIZE;
+}

--- a/examples/common/common-hello.h
+++ b/examples/common/common-hello.h
@@ -21,7 +21,7 @@ struct hello_t {
 #define HELLO_T_SIZE (sizeof(struct hello_t))
 
 void write_hello_str(struct hello_t *hello, enum lang_t lang);
-
 void translate(struct hello_t *hello);
+ssize_t init_hello(char *pmem_data, size_t size);
 
 #endif /* COMMON_HELLO_H */

--- a/examples/common/common-map_file_with_signature_check.c
+++ b/examples/common/common-map_file_with_signature_check.c
@@ -7,20 +7,14 @@
 
 #include <stdio.h>
 #include "common-conn.h"
-#include "common-hello.h"
 #include "common-map_file_with_signature_check.h"
 #include "common-pmem_map_file.h"
 
-/* size is used only on server side when no initiation with write_hello_str is required */
 int
-common_pmem_map_file_with_signature_check(char *path, size_t size, struct common_mem *mem)
+common_pmem_map_file_with_signature_check(char *path, size_t size, struct common_mem *mem,
+						common_init_func_t init_pmem)
 {
-	size_t min_size = size;
-
-	if (min_size == 0)
-		min_size = sizeof(struct hello_t);
-
-	if (common_pmem_map_file(path, SIGNATURE_LEN + min_size, mem))
+	if (path == NULL || size == 0 || mem == NULL)
 		return -1;
 
 	/*
@@ -28,26 +22,36 @@ common_pmem_map_file_with_signature_check(char *path, size_t size, struct common
 	 * as valid. So the total space is assumed to be at least SIGNATURE_LEN + the size expected
 	 * by the user.
 	 */
-	if (mem->mr_size < SIGNATURE_LEN + min_size) {
+	size += SIGNATURE_LEN;
+	mem->data_offset = SIGNATURE_LEN;
+
+	if (common_pmem_map_file(path, size, mem))
+		return -1;
+
+	if (mem->mr_size < size) {
 		(void) fprintf(stderr, "%s has too small size (%zu < %zu)\n",
-				path, mem->mr_size, SIGNATURE_LEN + min_size);
+				path, mem->mr_size, size);
 		return -1;
 	}
-	mem->data_offset = SIGNATURE_LEN;
 
 	/*
 	 * If the signature is not in place the persistent content has
 	 * to be initialized and persisted.
 	 */
 	if (strncmp(mem->mr_ptr, SIGNATURE_STR, SIGNATURE_LEN) != 0) {
-		if (size == 0) {
-			/* write an initial value and persist it */
-			write_hello_str((struct hello_t *)(mem->mr_ptr + mem->data_offset), en);
-			mem->persist(mem->mr_ptr + mem->data_offset, sizeof(struct hello_t));
+		char *pmem_data = mem->mr_ptr + mem->data_offset;
+		if (init_pmem) {
+			/* write the initial hello string and persist it */
+			ssize_t size_to_persist = (*init_pmem)(pmem_data, size - SIGNATURE_LEN);
+			if (size_to_persist < 0) {
+				(void) fprintf(stderr, "Initialization of PMem failed.\n");
+				return -1;
+			}
+			mem->persist(pmem_data, (size_t)size_to_persist);
 		} else {
-			/* write an initial empty string and persist it */
-			(mem->mr_ptr + mem->data_offset)[0] = '\0';
-			mem->persist(mem->mr_ptr + mem->data_offset, 1);
+			/* write the initial empty string and persist it */
+			pmem_data[0] = '\0';
+			mem->persist(pmem_data, 1);
 		}
 		/* write the signature to mark the content as valid */
 		memcpy(mem->mr_ptr, SIGNATURE_STR, SIGNATURE_LEN);

--- a/examples/common/common-map_file_with_signature_check.h
+++ b/examples/common/common-map_file_with_signature_check.h
@@ -11,6 +11,9 @@
 
 #include "common-pmem_map_file.h"
 
-int common_pmem_map_file_with_signature_check(char *path, size_t size, struct common_mem *mem);
+typedef ssize_t (*common_init_func_t)(char *pmem_data, size_t size);
+
+int common_pmem_map_file_with_signature_check(char *path, size_t size, struct common_mem *mem,
+						common_init_func_t init_pmem);
 
 #endif /* COMMON_MAP_FILE_WITH_SIGNATURE_CHECK_H */


### PR DESCRIPTION
Do not use 0 size when mapping PMem.
A size of PMem should be set explicitly.

Add to common_pmem_map_file_with_signature_check()
a function pointer argument to a function writing the initial data to PMem.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/pmem/rpma/2048)
<!-- Reviewable:end -->
