### PR TITLE
examples: do not overwrite the previous errors

### DIFF
--- a/examples/03-read-to-persistent/server.c
+++ b/examples/03-read-to-persistent/server.c
@@ -182,7 +182,7 @@ err_disconnect:
 	 * Wait for RPMA_CONN_CLOSED, disconnect and delete the connection
 	 * structure.
 	 */
-	ret = common_disconnect_and_wait_for_conn_close(&conn);
+	ret |= common_disconnect_and_wait_for_conn_close(&conn);
 
 err_mr_dereg:
 	/* deregister the memory region */
@@ -206,5 +206,5 @@ err_free:
 	if (mem.mr_ptr != NULL)
 		free(mem.mr_ptr);
 
-	return ret;
+	return ret ? -1 : 0;
 }


### PR DESCRIPTION
Do not overwrite the previous errors (ret = -1)
set when `(wc.status != IBV_WC_SUCCESS)` or `(wc.opcode != IBV_WC_RDMA_READ)`.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/pmem/rpma/2061)
<!-- Reviewable:end -->
