### PR TITLE
examples: fix detecting no free slot for a new connection request

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,6 +28,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - `wr` passed to ibv_post_send(), ibv_post_recv() and ibv_post_srq_recv() is initialized to 0
 - `sge` passed to a log message (in rpma_mr_*() functions) is initialized to 0
 - `rq_size` in rpma_peer_create_srq() initialized to 0
+- detecting no free slot for a new connection request in example 13
 
 ### Changed
 - logging of the source and the destination GID addresses in rpma_conn_req_new_from_id()

--- a/examples/13-messages-ping-pong-with-srq/server.c
+++ b/examples/13-messages-ping-pong-with-srq/server.c
@@ -83,8 +83,8 @@ handle_incoming_connections(struct rpma_ep *ep, struct rpma_conn_cfg *cfg,
 		break;
 	}
 
-	/* conn_ctx == NULL means that no free slot is found when i reaches CLIENT_MAX */
-	if (conn_ctx == NULL) {
+	/* conn_ctx->conn != NULL means that no free slot is found when i reaches CLIENT_MAX */
+	if (conn_ctx->conn != NULL) {
 		(void) fprintf(stderr, "No free slot for a new connection request.\n");
 		return -1;
 	}


### PR DESCRIPTION
Fix detecting no free slot for a new connection request in example 13.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/pmem/rpma/2062)
<!-- Reviewable:end -->
