### PR TITLE
common: fix COVERITY_SCAN_PROJECT_NAME

### DIFF
--- a/utils/docker/run-coverity.sh
+++ b/utils/docker/run-coverity.sh
@@ -36,7 +36,7 @@ echo -n | openssl s_client -connect scan.coverity.com:443 | \
 
 echo $USERPASS | sudo -S mv $TEMP_CF $CERT_FILE
 
-export COVERITY_SCAN_PROJECT_NAME="$CI_REPO_SLUG"
+export COVERITY_SCAN_PROJECT_NAME="librpma"
 export COVERITY_SCAN_BRANCH_PATTERN="$CI_BRANCH"
 export COVERITY_SCAN_BUILD_COMMAND="./utils/docker/coverity-command.sh $(nproc)"
 


### PR DESCRIPTION
`COVERITY_SCAN_PROJECT_NAME` should be "librpma", not "$CI_REPO_SLUG".

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/pmem/rpma/2066)
<!-- Reviewable:end -->
