### PR TITLE
rpma: replace rdma_create_qp() with rdma_create_qp_ex()

### DIFF
--- a/tests/drd.supp
+++ b/tests/drd.supp
@@ -508,6 +508,7 @@
 {
    General suppression related to SoftRoCE issue with mutex
    drd:MutexErr
+   ...
    fun:pthread_mutex_init@*
    ...
    fun:rpma_srq_new

--- a/tests/drd.supp
+++ b/tests/drd.supp
@@ -290,7 +290,6 @@
    fun:rxe_create_qp
    fun:UnknownInlinedFun
    fun:rdma_create_qp_ex
-   fun:rdma_create_qp
    ...
 }
 
@@ -444,7 +443,7 @@
    ...
    obj:*librxe-rdmav34.so*
    ...
-   fun:rdma_create_qp
+   fun:rdma_create_qp_ex
    fun:rpma_peer_setup_qp
    ...
 }

--- a/tests/memcheck-libibverbs-librdmacm.supp
+++ b/tests/memcheck-libibverbs-librdmacm.supp
@@ -277,7 +277,7 @@
    Memcheck:Cond
    fun:ibv_icmd_create_srq
    fun:ibv_cmd_create_srq
-   obj:*/libmlx5.so*
+   ...
    fun:ibv_create_srq*
    fun:rpma_peer_create_srq
    fun:rpma_srq_new

--- a/tests/memcheck-libibverbs-librdmacm.supp
+++ b/tests/memcheck-libibverbs-librdmacm.supp
@@ -95,7 +95,6 @@
    fun:calloc
    ...
    fun:rdma_create_qp_ex
-   fun:rdma_create_qp
    fun:rpma_peer_setup_qp
    fun:rpma_conn_req_new_from_id
    fun:rpma_conn_req_new
@@ -188,7 +187,6 @@
    fun:calloc
    ...
    fun:rdma_create_qp_ex
-   fun:rdma_create_qp
    fun:rpma_peer_setup_qp
    fun:rpma_conn_req_new_from_id
    fun:rpma_conn_req_new_from_cm_event

--- a/tests/unit/common/mocks-rdma_cm.c
+++ b/tests/unit/common/mocks-rdma_cm.c
@@ -31,14 +31,12 @@ int Mock_ctrl_defer_destruction = MOCK_CTRL_NO_DEFER;
 const struct rdma_cm_id Cmid_zero = {0};
 
 /*
- * rdma_create_qp -- rdma_create_qp() mock
+ * rdma_create_qp_ex -- rdma_create_qp_ex() mock
  */
 int
-rdma_create_qp(struct rdma_cm_id *id, struct ibv_pd *pd,
-		struct ibv_qp_init_attr *qp_init_attr)
+rdma_create_qp_ex(struct rdma_cm_id *id, struct ibv_qp_init_attr_ex *qp_init_attr)
 {
 	check_expected_ptr(id);
-	check_expected_ptr(pd);
 	assert_non_null(qp_init_attr);
 	check_expected(qp_init_attr->qp_context);
 	check_expected(qp_init_attr->send_cq);
@@ -51,6 +49,8 @@ rdma_create_qp(struct rdma_cm_id *id, struct ibv_pd *pd,
 	check_expected(qp_init_attr->cap.max_inline_data);
 	assert_int_equal(qp_init_attr->qp_type, IBV_QPT_RC);
 	assert_int_equal(qp_init_attr->sq_sig_all, 0);
+	check_expected(qp_init_attr->comp_mask);
+	check_expected(qp_init_attr->pd);
 
 	errno = mock_type(int);
 	if (errno)


### PR DESCRIPTION
1) Make rpma_peer_setup_qp() call rdma_create_qp_ex().
2) Update the related unit tests.
3) Update suppresions for the rdma_create_qp_ex().

This change is to prepare for new libibverbs flush and atomic write.

Signed-off-by: Xiao Yang <yangx.jy@fujitsu.com>

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/pmem/rpma/2084)
<!-- Reviewable:end -->
