### PR TITLE
common: remove Debian 10 from the on_pull_request CI workflow

### DIFF
--- a/.github/workflows/on_pull_request.yml
+++ b/.github/workflows/on_pull_request.yml
@@ -26,8 +26,7 @@ jobs:
         CONFIG: ["N=1 OS=ubuntu OS_VER=22.04 TYPE=normal CC=gcc   TESTS_COVERAGE=1",
                  "N=2 OS=ubuntu OS_VER=22.04 TYPE=normal CC=clang PUSH_IMAGE=1",
                  "N=3 OS=fedora OS_VER=34    TYPE=normal CC=gcc   PUSH_IMAGE=1",
-                 "N=4 OS=fedora OS_VER=34    TYPE=normal CC=clang AUTO_DOC_UPDATE=1",
-                 "N=5 OS=debian OS_VER=10    TYPE=normal CC=gcc   PUSH_IMAGE=1"]
+                 "N=4 OS=fedora OS_VER=34    TYPE=normal CC=clang AUTO_DOC_UPDATE=1"]
     steps:
        - name: Clone the git repo
          uses: actions/checkout@v1

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -43,6 +43,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - unused doc_snippets
 - meaningless template-example
 - meaningless template unit test
+- Debian 10 from the on_pull_request CI workflow
 
 [bench-frame]: https://github.com/pmem/rpma/tree/benchmarking-framework/tools/perf
 


### PR DESCRIPTION
Remove Debian 10 from the on_pull_request CI workflow.

Debian 10 is a representative of OSes that have
different behavior of the pytest bad-whitespace error (C0326) (see commit 48f8068330c2be1743c77707a8956f6ea805fa7e), but we do not use pytest any more, so remove it.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/pmem/rpma/2088)
<!-- Reviewable:end -->
