### PR TITLE
common: show git diff of the generated documentation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - internal APIs:
   - rpma_utils_ibv_context_is_atomic_write_capable() - checks if kernel supports native atomic write
 - Rocky Linux 8 and 9 builds to the "on_pull_request" workflow
+- show git diff of changed documentation when pull requests with updated documentation are not generated
 
 ### Fixed
 - DEVELOPMENT.md file - `CMAKE_BUILD_TYPE` must be set to `Debug` when running the tests

--- a/utils/docker/build.sh
+++ b/utils/docker/build.sh
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
 #
 # SPDX-License-Identifier: BSD-3-Clause
-# Copyright 2017-2022, Intel Corporation
+# Copyright 2017-2023, Intel Corporation
 #
 
 #
@@ -50,9 +50,12 @@ fi
 
 if [ -n "$DNS_SERVER" ]; then DNS_SETTING=" --dns=$DNS_SERVER "; fi
 
-# Run doc update only on $GITHUB_REPO and only on the main branch
-if [[ "${CI_BRANCH}" != "main" || "$CI_EVENT_TYPE" == "pull_request" || "$CI_REPO_SLUG" != "${GITHUB_REPO}" ]]; then
-	AUTO_DOC_UPDATE=0
+if [ "$AUTO_DOC_UPDATE" == "1" ]; then
+	# Create pull requests only on $GITHUB_REPO and only on the main branch,
+	# otherwise show the git diff only.
+	if [[ "$CI_BRANCH" != "main" || "$CI_EVENT_TYPE" == "pull_request" || "$CI_REPO_SLUG" != "$GITHUB_REPO" ]]; then
+		AUTO_DOC_UPDATE="show-diff-only"
+	fi
 fi
 
 WORKDIR=/rpma

--- a/utils/docker/run-build.sh
+++ b/utils/docker/run-build.sh
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
 #
 # SPDX-License-Identifier: BSD-3-Clause
-# Copyright 2016-2022, Intel Corporation
+# Copyright 2016-2023, Intel Corporation
 #
 
 #
@@ -184,12 +184,6 @@ if [ "$TESTS_COVERAGE" == "1" ]; then
 	upload_codecov tests
 fi
 
-# Create a PR with generated docs
-if [ "$AUTO_DOC_UPDATE" == "1" ]; then
-	echo "Running auto doc update"
-	../utils/docker/run-doc-update.sh
-fi
-
 test_compile_all_examples_standalone
 
 # Uninstall libraries
@@ -265,6 +259,14 @@ elif [ $PACKAGE_MANAGER = "deb" ]; then
 elif [ $PACKAGE_MANAGER = "rpm" ]; then
 	echo "$ sudo -S rpm --erase librpma-devel"
 	echo $USERPASS | sudo -S rpm --erase librpma-devel
+fi
+
+# Create pull requests with updated documentation or show the git diff only
+if [[ "$AUTO_DOC_UPDATE" == "1" || $AUTO_DOC_UPDATE == "show-diff-only" ]]; then
+	cd $WORKDIR/build
+	echo
+	echo "Running auto doc update (AUTO_DOC_UPDATE=$AUTO_DOC_UPDATE)"
+	../utils/docker/run-doc-update.sh $AUTO_DOC_UPDATE
 fi
 
 cd $WORKDIR


### PR DESCRIPTION
Introduce a possibility to verify if the changed documentation
is correctly formatted before merging it upstream.

If $AUTO_DOC_UPDATE == "1" then pull requests
with the generated documentation are created
only on $GITHUB_REPO and only on the main branch,
otherwise the git diff is printed out to be able
to verify if the new changes in the documentation
are correct.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/pmem/rpma/2096)
<!-- Reviewable:end -->
