### PR TITLE
common: rename atomic write macro and function

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -179,13 +179,13 @@ else()
 	message(WARNING "atomic operations are NOT supported (too old gcc/clang compiler). Some *_set*() functions will NOT be thread-safe!")
 endif()
 
-# check if libibverbs has ibv_wr_atomic_write() support
-is_ibv_wr_atomic_write_supported(IBV_WR_ATOMIC_WRITE_SUPPORTED)
-if(IBV_WR_ATOMIC_WRITE_SUPPORTED)
-	message(STATUS "ibv_wr_atomic_write() supported in libibverbs - Success")
-	add_flag(-DIBV_WR_ATOMIC_WRITE_SUPPORTED=1)
+# check if libibverbs supports native atomic write
+is_ibv_atomic_write_supported(NATIVE_ATOMIC_WRITE_SUPPORTED)
+if(NATIVE_ATOMIC_WRITE_SUPPORTED)
+	message(STATUS "Native atomic write supported in libibverbs - Success")
+	add_flag(-DNATIVE_ATOMIC_WRITE_SUPPORTED=1)
 else()
-	message(WARNING "ibv_wr_atomic_write() is NOT supported and will be disabled (too old version of libibverbs)!")
+	message(WARNING "Native atomic write is NOT supported and will be disabled (too old version of libibverbs)!")
 endif()
 
 add_custom_target(checkers ALL)

--- a/cmake/functions.cmake
+++ b/cmake/functions.cmake
@@ -289,8 +289,8 @@ function(atomic_operations_supported var)
 	set(var ${ATOMIC_OPERATIONS_SUPPORTED} PARENT_SCOPE)
 endfunction()
 
-# check if libibverbs has ibv_wr_atomic_write() support
-function(is_ibv_wr_atomic_write_supported var)
+# check if libibverbs supports native atomic write
+function(is_ibv_atomic_write_supported var)
 	CHECK_C_SOURCE_COMPILES("
 		#include <infiniband/verbs.h>
 		/*
@@ -302,6 +302,6 @@ function(is_ibv_wr_atomic_write_supported var)
 			uint64_t send_ops_flag = IBV_QP_EX_WITH_ATOMIC_WRITE;
 			return !ibv_wr_atomic_write;
 		}"
-		IBV_WR_ATOMIC_WRITE_SUPPORTED)
-	set(var ${IBV_WR_ATOMIC_WRITE_SUPPORTED} PARENT_SCOPE)
+		NATIVE_ATOMIC_WRITE_SUPPORTED)
+	set(var ${NATIVE_ATOMIC_WRITE_SUPPORTED} PARENT_SCOPE)
 endfunction()

--- a/src/mr.c
+++ b/src/mr.c
@@ -197,7 +197,7 @@ rpma_mr_atomic_write(struct ibv_qp *qp, struct rpma_mr_remote *dst, size_t dst_o
 {
 	RPMA_DEBUG_TRACE;
 
-#ifdef IBV_WR_ATOMIC_WRITE_SUPPORTED
+#ifdef NATIVE_ATOMIC_WRITE_SUPPORTED
 	struct ibv_qp_ex *qpx = ibv_qp_to_qp_ex(qp);
 	/* check if the created QP supports native atomic write */
 	if (qpx && qpx->wr_atomic_write) {

--- a/src/peer.c
+++ b/src/peer.c
@@ -191,7 +191,7 @@ rpma_peer_setup_qp(struct rpma_peer *peer, struct rdma_cm_id *id, struct rpma_cq
 
 	qp_init_attr.comp_mask = IBV_QP_INIT_ATTR_PD;
 
-#ifdef IBV_WR_ATOMIC_WRITE_SUPPORTED
+#ifdef NATIVE_ATOMIC_WRITE_SUPPORTED
 	if (peer->is_native_atomic_write_supported) {
 		qp_init_attr.comp_mask |= IBV_QP_INIT_ATTR_SEND_OPS_FLAGS;
 		qp_init_attr.send_ops_flags = IBV_QP_EX_WITH_ATOMIC_WRITE;

--- a/src/utils.c
+++ b/src/utils.c
@@ -29,7 +29,7 @@ rpma_utils_ibv_context_is_atomic_write_capable(struct ibv_context *ibv_ctx,
 
 	*is_atomic_write_capable = 0;
 
-#ifdef IBV_WR_ATOMIC_WRITE_SUPPORTED
+#ifdef NATIVE_ATOMIC_WRITE_SUPPORTED
 	/* query an RDMA device's attributes */
 	struct ibv_device_attr_ex attr = {{{0}}};
 	errno = ibv_query_device_ex(ibv_ctx, NULL /* input */, &attr);

--- a/tests/unit/common/mocks-ibverbs.c
+++ b/tests/unit/common/mocks-ibverbs.c
@@ -24,7 +24,7 @@ struct ibv_cq Ibv_rcq;
 struct ibv_cq Ibv_srq_rcq;
 struct ibv_cq Ibv_cq_unknown;
 struct ibv_qp Ibv_qp;
-#ifdef IBV_WR_ATOMIC_WRITE_SUPPORTED
+#ifdef NATIVE_ATOMIC_WRITE_SUPPORTED
 struct ibv_qp_ex Ibv_qp_ex;
 #endif
 struct ibv_mr Ibv_mr;
@@ -433,7 +433,7 @@ ibv_destroy_srq(struct ibv_srq *srq)
 	return mock_type(int);
 }
 
-#ifdef IBV_WR_ATOMIC_WRITE_SUPPORTED
+#ifdef NATIVE_ATOMIC_WRITE_SUPPORTED
 /*
  * ibv_qp_to_qp_ex -- ibv_qp_to_qp_ex() mock
  */

--- a/tests/unit/common/mocks-ibverbs.h
+++ b/tests/unit/common/mocks-ibverbs.h
@@ -22,7 +22,7 @@ extern struct ibv_cq Ibv_rcq;
 extern struct ibv_cq Ibv_srq_rcq;
 extern struct ibv_cq Ibv_cq_unknown;
 extern struct ibv_qp Ibv_qp;
-#ifdef IBV_WR_ATOMIC_WRITE_SUPPORTED
+#ifdef NATIVE_ATOMIC_WRITE_SUPPORTED
 extern struct ibv_qp_ex Ibv_qp_ex;
 #endif
 extern struct ibv_mr Ibv_mr;
@@ -37,7 +37,7 @@ extern struct ibv_srq Ibv_srq;
 #define MOCK_IBV_CQ_UNKNOWN	(struct ibv_cq *)&Ibv_cq_unknown
 #define MOCK_IBV_PD		(struct ibv_pd *)&Ibv_pd
 #define MOCK_QP			(struct ibv_qp *)&Ibv_qp
-#ifdef IBV_WR_ATOMIC_WRITE_SUPPORTED
+#ifdef NATIVE_ATOMIC_WRITE_SUPPORTED
 #define MOCK_QPX		(struct ibv_qp_ex *)&Ibv_qp_ex
 #endif
 #define MOCK_MR			(struct ibv_mr *)&Ibv_mr
@@ -76,7 +76,7 @@ struct ibv_post_srq_recv_mock_args {
 	int ret;
 };
 
-#ifdef IBV_WR_ATOMIC_WRITE_SUPPORTED
+#ifdef NATIVE_ATOMIC_WRITE_SUPPORTED
 struct ibv_wr_atomic_write_mock_args {
 	struct ibv_qp_ex *qp;
 	uint64_t wr_id;
@@ -114,7 +114,7 @@ struct ibv_srq *ibv_create_srq(struct ibv_pd *pd, struct ibv_srq_init_attr *srq_
 
 int ibv_destroy_srq(struct ibv_srq *srq);
 
-#ifdef IBV_WR_ATOMIC_WRITE_SUPPORTED
+#ifdef NATIVE_ATOMIC_WRITE_SUPPORTED
 struct ibv_qp_ex *ibv_qp_to_qp_ex(struct ibv_qp *qp);
 
 void ibv_wr_start_mock(struct ibv_qp_ex *qp);

--- a/tests/unit/common/mocks-rdma_cm.c
+++ b/tests/unit/common/mocks-rdma_cm.c
@@ -50,7 +50,7 @@ rdma_create_qp_ex(struct rdma_cm_id *id, struct ibv_qp_init_attr_ex *qp_init_att
 	assert_int_equal(qp_init_attr->qp_type, IBV_QPT_RC);
 	assert_int_equal(qp_init_attr->sq_sig_all, 0);
 	check_expected(qp_init_attr->comp_mask);
-#ifdef IBV_WR_ATOMIC_WRITE_SUPPORTED
+#ifdef NATIVE_ATOMIC_WRITE_SUPPORTED
 	if (qp_init_attr->comp_mask & IBV_QP_INIT_ATTR_SEND_OPS_FLAGS)
 		check_expected(qp_init_attr->send_ops_flags);
 #endif

--- a/tests/unit/mr/mr-atomic_write.c
+++ b/tests/unit/mr/mr-atomic_write.c
@@ -20,7 +20,7 @@
 
 static const char Mock_src[8];
 
-#ifdef IBV_WR_ATOMIC_WRITE_SUPPORTED
+#ifdef NATIVE_ATOMIC_WRITE_SUPPORTED
 static struct ibv_wr_atomic_write_mock_args atomic_write_args;
 #endif
 static struct ibv_post_send_mock_args args;
@@ -32,7 +32,7 @@ static void
 configure_mr_atomic_write(int flags, int ret)
 {
 	/* configure mock */
-#ifdef IBV_WR_ATOMIC_WRITE_SUPPORTED
+#ifdef NATIVE_ATOMIC_WRITE_SUPPORTED
 	expect_value(ibv_qp_to_qp_ex, qp, MOCK_QP);
 	will_return(ibv_qp_to_qp_ex, MOCK_QPX);
 	expect_value(ibv_wr_start_mock, qp, MOCK_QPX);
@@ -59,7 +59,7 @@ configure_mr_atomic_write(int flags, int ret)
 #endif
 }
 
-#ifdef IBV_WR_ATOMIC_WRITE_SUPPORTED
+#ifdef NATIVE_ATOMIC_WRITE_SUPPORTED
 /*
  * atomic_write__qpx_NULL_success - rpma_mr_atomic_write
  * succeeded when ibv_qp_to_qp_ex() returned NULL
@@ -177,7 +177,7 @@ static int
 group_setup_mr_atomic_write(void **unused)
 {
 	/* configure global mocks */
-#ifdef IBV_WR_ATOMIC_WRITE_SUPPORTED
+#ifdef NATIVE_ATOMIC_WRITE_SUPPORTED
 	/*
 	 * ibv_wr_start(), ibv_wr_atomic_write() and ibv_wr_complete() are defined
 	 * as static inline functions in the included header <infiniband/verbs.h>,
@@ -215,7 +215,7 @@ group_setup_mr_atomic_write(void **unused)
 
 static const struct CMUnitTest tests_mr__atomic_write[] = {
 	/* rpma_mr_atomic_write() unit tests */
-#ifdef IBV_WR_ATOMIC_WRITE_SUPPORTED
+#ifdef NATIVE_ATOMIC_WRITE_SUPPORTED
 	cmocka_unit_test_setup_teardown(
 			atomic_write__qpx_NULL_success,
 			setup__mr_local_and_remote,

--- a/tests/unit/peer/peer-create_qp.c
+++ b/tests/unit/peer/peer-create_qp.c
@@ -74,7 +74,7 @@ configure_create_qp_ex(struct prestate *prestate, struct rpma_cq *rcq)
 	expect_value(rdma_create_qp_ex, qp_init_attr->cap.max_inline_data,
 		RPMA_MAX_INLINE_DATA);
 	expect_value(rdma_create_qp_ex, qp_init_attr->pd, MOCK_IBV_PD);
-#ifdef IBV_WR_ATOMIC_WRITE_SUPPORTED
+#ifdef NATIVE_ATOMIC_WRITE_SUPPORTED
 	if (prestate->is_atomic_write_capable) {
 		expect_value(rdma_create_qp_ex, qp_init_attr->comp_mask,
 				IBV_QP_INIT_ATTR_PD | IBV_QP_INIT_ATTR_SEND_OPS_FLAGS);

--- a/tests/unit/utils/utils-ibv_context_is_atomic_write_capable.c
+++ b/tests/unit/utils/utils-ibv_context_is_atomic_write_capable.c
@@ -19,7 +19,7 @@
 static void
 ibvc_atomic_write__cap_no(void **unused)
 {
-#ifdef IBV_WR_ATOMIC_WRITE_SUPPORTED
+#ifdef NATIVE_ATOMIC_WRITE_SUPPORTED
 	/* configure mocks */
 	struct ibv_device_attr_ex attr = {
 		.device_cap_flags_ex = 0, /* atomic write attribute is not set */
@@ -37,7 +37,7 @@ ibvc_atomic_write__cap_no(void **unused)
 	assert_int_equal(is_atomic_write_capable, 0);
 }
 
-#ifdef IBV_WR_ATOMIC_WRITE_SUPPORTED
+#ifdef NATIVE_ATOMIC_WRITE_SUPPORTED
 /*
  * ibvc_atomic_write__query_fail -- ibv_query_device_ex() failed
  */
@@ -92,7 +92,7 @@ main(int argc, char *argv[])
 	const struct CMUnitTest tests[] = {
 		/* rpma_utils_ibv_context_is_atomic_write_capable() unit tests */
 		cmocka_unit_test(ibvc_atomic_write__cap_no),
-#ifdef IBV_WR_ATOMIC_WRITE_SUPPORTED
+#ifdef NATIVE_ATOMIC_WRITE_SUPPORTED
 		cmocka_unit_test(ibvc_atomic_write__query_fail),
 		cmocka_unit_test(ibvc_atomic_write__cap_yes),
 #endif


### PR DESCRIPTION
Both IBV_WR_ATOMIC_WRITE_SUPPORTED and is_ibv_wr_atomic_write_supported() are used to check if libibverbs supports the whole native atomic write instead of ibv_wr_atomic_write() so rename them to the following names: 1) IBV_WR_ATOMIC_WRITE_SUPPORTED => NATIVE_ATOMIC_WRITE_SUPPORTED 2) is_ibv_wr_atomic_write_supported() => is_ibv_atomic_write_supported()

Signed-off-by: Xiao Yang <yangx.jy@fujitsu.com>

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/pmem/rpma/2103)
<!-- Reviewable:end -->
