### PR TITLE
test: fix the "ibv_query_device_ex_mock undeclared" compiler error

### DIFF
--- a/tests/unit/common/mocks-ibverbs.c
+++ b/tests/unit/common/mocks-ibverbs.c
@@ -49,7 +49,7 @@ ibv_query_device(struct ibv_context *ibv_ctx,
 	return 0;
 }
 
-#ifdef ON_DEMAND_PAGING_SUPPORTED
+#if defined(ON_DEMAND_PAGING_SUPPORTED) || defined(NATIVE_ATOMIC_WRITE_SUPPORTED)
 /*
  * ibv_query_device_ex_mock -- ibv_query_device_ex() mock
  */

--- a/tests/unit/common/mocks-ibverbs.h
+++ b/tests/unit/common/mocks-ibverbs.h
@@ -87,7 +87,7 @@ struct ibv_wr_atomic_write_mock_args {
 };
 #endif
 
-#ifdef ON_DEMAND_PAGING_SUPPORTED
+#if defined(ON_DEMAND_PAGING_SUPPORTED) || defined(NATIVE_ATOMIC_WRITE_SUPPORTED)
 int ibv_query_device_ex_mock(struct ibv_context *ibv_ctx,
 		const struct ibv_query_device_ex_input *input,
 		struct ibv_device_attr_ex *attr,


### PR DESCRIPTION
When ON_DEMAND_PAGING_SUPPORTED is false and NATIVE_ATOMIC_WRITE_SUPPORTED is true, the following compiler error will be triggered: 
 ...
error: 'ibv_query_device_ex_mock' undeclared (first use in this function);
	did you mean 'ibv_query_device_ex'?
...

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/pmem/rpma/2106)
<!-- Reviewable:end -->
