### PR TITLE
common: use a newer rdma-core on Ubuntu and Fedora CIs

### DIFF
--- a/utils/docker/images/Dockerfile.fedora-latest
+++ b/utils/docker/images/Dockerfile.fedora-latest
@@ -46,13 +46,23 @@ ENV EXAMPLES_DEPS "\
 ENV DOC_UPDATE_DEPS "\
 	hub"
 
+# rdma-core deps
+ENV RDMA_CORE_DEPS "\
+	libnl3-devel \
+	wget"
+
 # Install all required packages
 RUN dnf install -y \
 	$BASE_DEPS \
 	$RPMA_DEPS \
 	$EXAMPLES_DEPS \
 	$DOC_UPDATE_DEPS \
+	$RDMA_CORE_DEPS \
 && dnf clean all
+
+# Install rdma-core
+COPY install-rdma-core.sh install-rdma-core.sh
+RUN ./install-rdma-core.sh
 
 # Install cmocka
 COPY install-cmocka.sh install-cmocka.sh

--- a/utils/docker/images/Dockerfile.ubuntu-latest
+++ b/utils/docker/images/Dockerfile.ubuntu-latest
@@ -61,6 +61,10 @@ RUN apt-get install -y --no-install-recommends \
 	$COVERITY_DEPS \
 && rm -rf /var/lib/apt/lists/*
 
+# Install rdma-core
+COPY install-rdma-core.sh install-rdma-core.sh
+RUN ./install-rdma-core.sh
+
 # Install cmocka
 COPY install-cmocka.sh install-cmocka.sh
 RUN ./install-cmocka.sh

--- a/utils/docker/images/install-rdma-core.sh
+++ b/utils/docker/images/install-rdma-core.sh
@@ -1,0 +1,31 @@
+#!/usr/bin/env bash
+#
+# SPDX-License-Identifier: BSD-3-Clause
+# Copyright 2023, Intel Corporation
+#
+
+#
+# install-rdma-core.sh - installs rdma-core libraries from sources with support for:
+#                        native atomic write and native flush
+#
+
+set -ex
+
+# rdma-core v44.0 with support for native atomic write and native flush
+VERSION="44.0"
+
+WORKDIR=$(pwd)
+
+#
+# Install rdma-core libraries from a release package
+#
+wget https://github.com/linux-rdma/rdma-core/releases/download/v${VERSION}/rdma-core-${VERSION}.tar.gz
+tar -xzf rdma-core-${VERSION}.tar.gz
+rm rdma-core-${VERSION}.tar.gz
+
+mv rdma-core-${VERSION} rdma-core
+cd rdma-core
+./build.sh
+# saving the revision in the file
+echo $VERSION > ./build/VERSION
+cd $WORKDIR

--- a/utils/docker/verify-libibverbs-version.c
+++ b/utils/docker/verify-libibverbs-version.c
@@ -1,0 +1,31 @@
+// SPDX-License-Identifier: BSD-3-Clause
+/* Copyright 2023, Intel Corporation */
+
+/*
+ * verify-libibverbs-version.c - check if libibverbs supports native atomic write and native flush
+ */
+
+#include <infiniband/verbs.h>
+
+int main() {
+	/*
+	 * Check if IB_UVERBS_DEVICE_ATOMIC_WRITE, IBV_QP_EX_WITH_ATOMIC_WRITE
+	 * and ibv_wr_atomic_write() are defined.
+	 */
+	uint64_t device_cap_flag_1 = IB_UVERBS_DEVICE_ATOMIC_WRITE;
+	uint64_t send_ops_flag_1 = IBV_QP_EX_WITH_ATOMIC_WRITE;
+	int native_atomic_write = (ibv_wr_atomic_write != NULL);
+
+	/*
+	 * Check if IBV_ACCESS_FLUSH_GLOBAL, IBV_ACCESS_FLUSH_PERSISTENT,
+	 * IB_UVERBS_DEVICE_FLUSH_GLOBAL, IB_UVERBS_DEVICE_FLUSH_PERSISTENT,
+	 * IBV_QP_EX_WITH_FLUSH and ibv_wr_flush() are defined.
+	 */
+	int access = IBV_ACCESS_FLUSH_GLOBAL | IBV_ACCESS_FLUSH_PERSISTENT;
+	uint64_t device_cap_flag_2 = IB_UVERBS_DEVICE_FLUSH_GLOBAL |
+					IB_UVERBS_DEVICE_FLUSH_PERSISTENT;
+	uint64_t send_ops_flag_2 = IBV_QP_EX_WITH_FLUSH;
+	int native_flush = (ibv_wr_flush != NULL);
+
+	return !(native_atomic_write && native_flush);
+}


### PR DESCRIPTION
Install rdma-core v44.0 (with support for both native atomic write and native flush) on Ubuntu and Fedora CIs.

During the CI build check if libibverbs installed from an OS package supports both native atomic write and native flush. If libibverbs installed from the OS package does not support native atomic write or native flush and another, built from sources, version of rdma-core exists (which supports both native atomic write and native flush), run one build using the rdma-core installed from the OS package and then switch to using only the built-from-sources version of rdma-core for the rest of the builds.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/pmem/rpma/2108)
<!-- Reviewable:end -->
