### PR TITLE
common: install a newer PMDK with required fixes

### DIFF
--- a/utils/docker/images/Dockerfile.rockylinux-8
+++ b/utils/docker/images/Dockerfile.rockylinux-8
@@ -42,6 +42,7 @@ ENV RPMA_DEPS "\
 
 # PMDK deps
 ENV PMDK_DEPS "\
+	m4 \
 	ndctl \
 	wget"
 

--- a/utils/docker/images/Dockerfile.rockylinux-9
+++ b/utils/docker/images/Dockerfile.rockylinux-9
@@ -40,6 +40,7 @@ ENV RPMA_DEPS "\
 
 # PMDK deps
 ENV PMDK_DEPS "\
+	m4 \
 	ndctl \
 	wget"
 

--- a/utils/docker/images/install-pmdk.sh
+++ b/utils/docker/images/install-pmdk.sh
@@ -1,23 +1,25 @@
 #!/usr/bin/env bash
 #
 # SPDX-License-Identifier: BSD-3-Clause
-# Copyright 2020-2022, Intel Corporation
+# Copyright 2020-2023, Intel Corporation
 #
 
 #
 # install-pmdk.sh - installs PMDK libraries
 #
 
-# PMDK version: 1.12.0
-PMDK_VERSION=1.12.0
+# PMDK version: 8074b19b1d9b40bcaaed7e0dc0622dccf8007f2f (1.12.1-119-g8074b19b1)
+# with required fixes, see:
+# https://github.com/pmem/pmdk/issues/5540
+PMDK_VERSION=8074b19b1d9b40bcaaed7e0dc0622dccf8007f2f
 
 WORKDIR=$(pwd)
 
 #
-# Install PMDK libraries from a release package with already generated documentation.
+# Install PMDK libraries from sources
 #
-wget https://github.com/pmem/pmdk/releases/download/${PMDK_VERSION}/pmdk-${PMDK_VERSION}.tar.gz
-tar -xzf pmdk-${PMDK_VERSION}.tar.gz
+wget https://github.com/pmem/pmdk/archive/${PMDK_VERSION}.zip
+unzip ${PMDK_VERSION}.zip
 cd pmdk-${PMDK_VERSION}
 make -j$(nproc) NDCTL_ENABLE=n
 sudo make -j$(nproc) install prefix=/usr NDCTL_ENABLE=n


### PR DESCRIPTION
Install a newer PMDK with fixes required for Rocky Linux 8 and 9.

Ref: https://github.com/pmem/pmdk/issues/5540
Ref: https://github.com/pmem/rpma/pull/2109

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/pmem/rpma/2112)
<!-- Reviewable:end -->
