### PR TITLE
common: use _CFLAGS and _LDFLAGS of libraries

### DIFF
--- a/cmake/functions.cmake
+++ b/cmake/functions.cmake
@@ -1,6 +1,6 @@
 #
 # SPDX-License-Identifier: BSD-3-Clause
-# Copyright 2018-2022, Intel Corporation
+# Copyright 2018-2023, Intel Corporation
 # Copyright (c) 2022 Fujitsu Limited
 #
 
@@ -223,7 +223,7 @@ function(check_signature_rdma_getaddrinfo var)
 
 	if(C_HAS_Werror_discarded_qualifiers)
 		set(CMAKE_REQUIRED_FLAGS "${DISCARDED_QUALIFIERS_FLAG};${CMAKE_REQUIRED_FLAGS}")
-		set(CMAKE_REQUIRED_LIBRARIES "-lrdmacm;${CMAKE_REQUIRED_LIBRARIES}")
+		set(CMAKE_REQUIRED_LIBRARIES "${LIBRDMACM_LDFLAGS};${LIBRDMACM_LIBRARIES};${CMAKE_REQUIRED_LIBRARIES}")
 
 		CHECK_C_SOURCE_COMPILES("
 			#include <rdma/rdma_cma.h>

--- a/examples/02-read-to-volatile/CMakeLists.txt
+++ b/examples/02-read-to-volatile/CMakeLists.txt
@@ -1,6 +1,6 @@
 #
 # SPDX-License-Identifier: BSD-3-Clause
-# Copyright 2020, Intel Corporation
+# Copyright 2020-2023, Intel Corporation
 # Copyright 2021, Fujitsu
 #
 
@@ -37,7 +37,10 @@ function(add_example name)
 		PUBLIC
 			${LIBRPMA_INCLUDE_DIRS}
 			../common)
-	target_link_libraries(${name} rpma ${LIBIBVERBS_LIBRARIES} ${LIBRT_LIBRARIES})
+	target_link_libraries(${name}
+		rpma
+		${LIBIBVERBS_LDFLAGS} ${LIBIBVERBS_LIBRARIES}
+		${LIBRT_LIBRARIES})
 endfunction()
 
 add_example(server server.c ../common/common-conn.c)

--- a/examples/06-multiple-connections/CMakeLists.txt
+++ b/examples/06-multiple-connections/CMakeLists.txt
@@ -1,6 +1,6 @@
 #
 # SPDX-License-Identifier: BSD-3-Clause
-# Copyright 2020, Intel Corporation
+# Copyright 2020-2023, Intel Corporation
 # Copyright 2021, Fujitsu
 #
 
@@ -45,7 +45,10 @@ function(add_example name)
 		PRIVATE
 			${LIBRPMA_INCLUDE_DIRS}
 			../common)
-	target_link_libraries(${name} rpma ${LIBIBVERBS_LIBRARIES} ${LIBRT_LIBRARIES})
+	target_link_libraries(${name}
+		rpma
+		${LIBIBVERBS_LDFLAGS} ${LIBIBVERBS_LIBRARIES}
+		${LIBRT_LIBRARIES})
 
 	if(LIBPMEM_FOUND)
 		target_include_directories(${name}

--- a/examples/06scch-multiple-connections/CMakeLists.txt
+++ b/examples/06scch-multiple-connections/CMakeLists.txt
@@ -1,6 +1,6 @@
 #
 # SPDX-License-Identifier: BSD-3-Clause
-# Copyright 2020, Intel Corporation
+# Copyright 2020-2023, Intel Corporation
 # Copyright 2021, Fujitsu
 #
 
@@ -45,7 +45,10 @@ function(add_example name)
 		PRIVATE
 			${LIBRPMA_INCLUDE_DIRS}
 			../common)
-	target_link_libraries(${name} rpma ${LIBIBVERBS_LIBRARIES} ${LIBRT_LIBRARIES})
+	target_link_libraries(${name}
+		rpma
+		${LIBIBVERBS_LDFLAGS} ${LIBIBVERBS_LIBRARIES}
+		${LIBRT_LIBRARIES})
 
 	if(LIBPMEM_FOUND)
 		target_include_directories(${name}

--- a/examples/08-messages-ping-pong/CMakeLists.txt
+++ b/examples/08-messages-ping-pong/CMakeLists.txt
@@ -1,6 +1,6 @@
 #
 # SPDX-License-Identifier: BSD-3-Clause
-# Copyright 2020-2022, Intel Corporation
+# Copyright 2020-2023, Intel Corporation
 #
 
 cmake_minimum_required(VERSION 3.3)
@@ -39,7 +39,10 @@ function(add_example name)
 			${LIBRPMA_INCLUDE_DIRS}
 			${LIBIBVERBS_INCLUDE_DIRS}
 			../common)
-	target_link_libraries(${name} rpma ${LIBIBVERBS_LIBRARIES} ${LIBRT_LIBRARIES})
+	target_link_libraries(${name}
+		rpma
+		${LIBIBVERBS_LDFLAGS} ${LIBIBVERBS_LIBRARIES}
+		${LIBRT_LIBRARIES})
 endfunction()
 
 add_example(server server.c ../common/common-conn.c ../common/common-messages-ping-pong.c)

--- a/examples/08srq-simple-messages-ping-pong-with-srq/CMakeLists.txt
+++ b/examples/08srq-simple-messages-ping-pong-with-srq/CMakeLists.txt
@@ -1,6 +1,6 @@
 #
 # SPDX-License-Identifier: BSD-3-Clause
-# Copyright 2020-2022, Intel Corporation
+# Copyright 2020-2023, Intel Corporation
 #
 
 cmake_minimum_required(VERSION 3.3)
@@ -39,7 +39,10 @@ function(add_example name)
 			${LIBRPMA_INCLUDE_DIRS}
 			${LIBIBVERBS_INCLUDE_DIRS}
 			../common)
-	target_link_libraries(${name} rpma ${LIBIBVERBS_LIBRARIES} ${LIBRT_LIBRARIES})
+	target_link_libraries(${name}
+		rpma
+		${LIBIBVERBS_LDFLAGS} ${LIBIBVERBS_LIBRARIES}
+		${LIBRT_LIBRARIES})
 endfunction()
 
 add_example(server server.c ../common/common-conn.c ../common/common-messages-ping-pong.c)

--- a/examples/10-send-with-imm/CMakeLists.txt
+++ b/examples/10-send-with-imm/CMakeLists.txt
@@ -1,7 +1,7 @@
 #
 # SPDX-License-Identifier: BSD-3-Clause
 # Copyright (c) 2020 Fujitsu
-# Copyright 2021, Intel Corporation
+# Copyright 2021-2023, Intel Corporation
 #
 
 cmake_minimum_required(VERSION 3.3)
@@ -38,7 +38,10 @@ function(add_example name)
 			${LIBRPMA_INCLUDE_DIRS}
 			${LIBIBVERBS_INCLUDE_DIRS}
 			../common)
-	target_link_libraries(${name} rpma ${LIBIBVERBS_LIBRARIES} ${LIBRT_LIBRARIES})
+	target_link_libraries(${name}
+		rpma
+		${LIBIBVERBS_LDFLAGS} ${LIBIBVERBS_LIBRARIES}
+		${LIBRT_LIBRARIES})
 endfunction()
 
 add_example(server server.c ../common/common-conn.c)

--- a/examples/11-write-with-imm/CMakeLists.txt
+++ b/examples/11-write-with-imm/CMakeLists.txt
@@ -1,6 +1,7 @@
 #
 # SPDX-License-Identifier: BSD-3-Clause
 # Copyright (c) 2021 Fujitsu
+# Copyright 2023, Intel Corporation
 #
 
 cmake_minimum_required(VERSION 3.3)
@@ -37,7 +38,10 @@ function(add_example name)
 			${LIBRPMA_INCLUDE_DIRS}
 			${LIBIBVERBS_INCLUDE_DIRS}
 			../common)
-	target_link_libraries(${name} rpma ${LIBIBVERBS_LIBRARIES} ${LIBRT_LIBRARIES})
+	target_link_libraries(${name}
+		rpma
+		${LIBIBVERBS_LDFLAGS} ${LIBIBVERBS_LIBRARIES}
+		${LIBRT_LIBRARIES})
 endfunction()
 
 add_example(server server.c ../common/common-conn.c)

--- a/examples/12-receive-completion-queue/CMakeLists.txt
+++ b/examples/12-receive-completion-queue/CMakeLists.txt
@@ -1,6 +1,6 @@
 #
 # SPDX-License-Identifier: BSD-3-Clause
-# Copyright 2022, Intel Corporation
+# Copyright 2022-2023, Intel Corporation
 #
 
 cmake_minimum_required(VERSION 3.3)
@@ -37,7 +37,10 @@ function(add_example name)
 			${LIBRPMA_INCLUDE_DIRS}
 			${LIBIBVERBS_INCLUDE_DIRS}
 			../common)
-	target_link_libraries(${name} rpma ${LIBIBVERBS_LIBRARIES} ${LIBRT_LIBRARIES})
+	target_link_libraries(${name}
+		rpma
+		${LIBIBVERBS_LDFLAGS} ${LIBIBVERBS_LIBRARIES}
+		${LIBRT_LIBRARIES})
 endfunction()
 
 add_example(server server.c ../common/common-conn.c receive-completion-queue-common.c)

--- a/examples/12scch-receive-completion-queue/CMakeLists.txt
+++ b/examples/12scch-receive-completion-queue/CMakeLists.txt
@@ -1,6 +1,6 @@
 #
 # SPDX-License-Identifier: BSD-3-Clause
-# Copyright 2022, Intel Corporation
+# Copyright 2022-2023, Intel Corporation
 #
 
 cmake_minimum_required(VERSION 3.3)
@@ -37,7 +37,10 @@ function(add_example name)
 			${LIBRPMA_INCLUDE_DIRS}
 			${LIBIBVERBS_INCLUDE_DIRS}
 			../common)
-	target_link_libraries(${name} rpma ${LIBIBVERBS_LIBRARIES} ${LIBRT_LIBRARIES})
+	target_link_libraries(${name}
+		rpma
+		${LIBIBVERBS_LDFLAGS} ${LIBIBVERBS_LIBRARIES}
+		${LIBRT_LIBRARIES})
 endfunction()
 
 add_example(server server.c ../common/common-conn.c)

--- a/examples/13-messages-ping-pong-with-srq/CMakeLists.txt
+++ b/examples/13-messages-ping-pong-with-srq/CMakeLists.txt
@@ -1,7 +1,7 @@
 #
 # SPDX-License-Identifier: BSD-3-Clause
 # Copyright 2022, Fujitsu
-# Copyright 2022, Intel Corporation
+# Copyright 2022-2023, Intel Corporation
 #
 
 cmake_minimum_required(VERSION 3.3)
@@ -40,7 +40,10 @@ function(add_example name)
 			${LIBRPMA_INCLUDE_DIRS}
 			${LIBIBVERBS_INCLUDE_DIRS}
 			../common)
-	target_link_libraries(${name} rpma ${LIBIBVERBS_LIBRARIES} ${LIBRT_LIBRARIES})
+	target_link_libraries(${name}
+		rpma
+		${LIBIBVERBS_LDFLAGS} ${LIBIBVERBS_LIBRARIES}
+		${LIBRT_LIBRARIES})
 endfunction()
 
 add_example(server server.c ../common/common-conn.c ../common/common-epoll.c)

--- a/examples/CMakeLists.txt
+++ b/examples/CMakeLists.txt
@@ -1,6 +1,6 @@
 #
 # SPDX-License-Identifier: BSD-3-Clause
-# Copyright 2018-2022, Intel Corporation
+# Copyright 2018-2023, Intel Corporation
 # Copyright 2021-2022, Fujitsu
 #
 
@@ -78,7 +78,7 @@ function(add_example)
 		OUTPUT_NAME ${EXAMPLE_BIN}
 		RUNTIME_OUTPUT_DIRECTORY ${EXAMPLE_NAME})
 	target_link_libraries(${target} ${LIBRPMA_LIBRARIES} ${LIBRT_LIBRARIES}
-		${LIBIBVERBS_LIBRARIES})
+		${LIBIBVERBS_LDFLAGS} ${LIBIBVERBS_LIBRARIES})
 	target_include_directories(${target} PRIVATE common
 		${LIBRPMA_SOURCE_DIR} ${LIBIBVERBS_INCLUDE_DIRS})
 

--- a/examples/cmake/common.cmake
+++ b/examples/cmake/common.cmake
@@ -1,6 +1,6 @@
 #
 # SPDX-License-Identifier: BSD-3-Clause
-# Copyright 2020-2022, Intel Corporation
+# Copyright 2020-2023, Intel Corporation
 #
 
 cmake_minimum_required(VERSION 3.3)
@@ -38,7 +38,10 @@ function(add_example_with_pmem)
 	add_executable(${target} ${EXAMPLE_SRCS})
 	target_include_directories(${target} PRIVATE ../common
 		${LIBRPMA_INCLUDE_DIR} ${LIBIBVERBS_INCLUDE_DIRS})
-	target_link_libraries(${target} rpma ${LIBIBVERBS_LIBRARIES} ${LIBRT_LIBRARIES})
+	target_link_libraries(${target}
+		rpma
+		${LIBIBVERBS_LDFLAGS} ${LIBIBVERBS_LIBRARIES}
+		${LIBRT_LIBRARIES})
 
 	if(LIBPMEM2_FOUND)
 		target_include_directories(${target}

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -1,6 +1,6 @@
 #
 # SPDX-License-Identifier: BSD-3-Clause
-# Copyright 2020-2022, Intel Corporation
+# Copyright 2020-2023, Intel Corporation
 # Copyright 2021-2022, Fujitsu
 #
 
@@ -37,8 +37,18 @@ add_library(rpma SHARED ${SOURCES})
 
 target_include_directories(rpma PRIVATE . include)
 
+if(LIBIBVERBS_CFLAGS)
+	set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} ${LIBIBVERBS_CFLAGS}")
+endif()
+
+if(LIBRDMACM_CFLAGS)
+	set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} ${LIBRDMACM_CFLAGS}")
+endif()
+
 target_link_libraries(rpma PRIVATE
+	${LIBIBVERBS_LDFLAGS}
 	${LIBIBVERBS_LIBRARIES}
+	${LIBRDMACM_LDFLAGS}
 	${LIBRDMACM_LIBRARIES}
 	-Wl,--version-script=${CMAKE_SOURCE_DIR}/src/librpma.map)
 

--- a/tests/cmake/ctest_helpers.cmake
+++ b/tests/cmake/ctest_helpers.cmake
@@ -1,6 +1,6 @@
 #
 # SPDX-License-Identifier: BSD-3-Clause
-# Copyright 2018-2022, Intel Corporation
+# Copyright 2018-2023, Intel Corporation
 #
 
 #
@@ -224,7 +224,7 @@ function(add_multithreaded)
 	if(MULTITHREADED_USE_LIBIBVERBS)
 		target_include_directories(${target}
 			PRIVATE ${LIBIBVERBS_INCLUDE_DIRS})
-		target_link_libraries(${target} ${LIBIBVERBS_LIBRARIES})
+		target_link_libraries(${target} ${LIBIBVERBS_LDFLAGS} ${LIBIBVERBS_LIBRARIES})
 	endif()
 
 	add_test_generic(NAME ${target} GROUP_SCRIPT TRACERS none memcheck drd helgrind)


### PR DESCRIPTION
Use:
- LIBIBVERBS_CFLAGS, LIBIBVERBS_LDFLAGS,
- LIBRDMACM_CFLAGS and LIBRDMACM_LDFLAGS
in order to be able to locate libibverbs and librdmacm
when they are installed from sources in a non-default location.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/pmem/rpma/2116)
<!-- Reviewable:end -->
