### PR TITLE
common: add builds with rdma-core v44.0 on Ubuntu and Fedora CIs

### DIFF
--- a/.github/workflows/on_pull_request.yml
+++ b/.github/workflows/on_pull_request.yml
@@ -24,12 +24,18 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        CONFIG: ["N=1 OS=ubuntu OS_VER=latest CC=gcc   TESTS_COVERAGE=1",
+        CONFIG: ["N=1 OS=ubuntu OS_VER=latest CC=gcc", # to be reverted: TESTS_COVERAGE=1",
                  "N=2 OS=ubuntu OS_VER=latest CC=clang PUSH_IMAGE=1",
                  "N=3 OS=fedora OS_VER=latest CC=gcc   PUSH_IMAGE=1",
                  "N=4 OS=fedora OS_VER=latest CC=clang AUTO_DOC_UPDATE=1",
                  "N=5 OS=rockylinux OS_VER=9  CC=gcc   PUSH_IMAGE=1",
-                 "N=6 OS=rockylinux OS_VER=8  CC=gcc   PUSH_IMAGE=1"]
+                 "N=6 OS=rockylinux OS_VER=8  CC=gcc   PUSH_IMAGE=1",
+                 # Ubuntu-latest with rdma-core v45.0 installed from sources
+                 "N=7 OS=ubuntu OS_VER=latest-with-rdma-core-45 CC=gcc   TESTS_COVERAGE=1",
+                 "N=8 OS=ubuntu OS_VER=latest-with-rdma-core-45 CC=clang PUSH_IMAGE=1",
+                 # Fedora-latest with rdma-core v45.0 installed from sources
+                 "N=9 OS=fedora OS_VER=latest-with-rdma-core-45 CC=gcc   PUSH_IMAGE=1",
+                "N=10 OS=fedora OS_VER=latest-with-rdma-core-45 CC=clang"]
     steps:
        - name: Clone the git repo
          uses: actions/checkout@v1

--- a/utils/docker/images/Dockerfile.fedora-latest-with-rdma-core-45
+++ b/utils/docker/images/Dockerfile.fedora-latest-with-rdma-core-45
@@ -1,0 +1,94 @@
+#
+# SPDX-License-Identifier: BSD-3-Clause
+# Copyright 2016-2023, Intel Corporation
+#
+
+#
+# Dockerfile.fedora-latest-with-rdma-core-45 - Dockerfile for Fedora-latest with rdma-core v45.0
+#                                              installed from sources.
+#
+# This dockerfile is a 'recipe' for Docker to build an image of fedora-based environment
+# prepared for running tests of librpma.
+#
+
+# Pull base image
+FROM fedora:latest
+MAINTAINER tomasz.gromadzki@intel.com
+
+# Update all packages
+RUN dnf update -y
+
+# base Linux deps
+ENV BASE_DEPS "\
+	clang \
+	gcc \
+	git \
+	make \
+	patch \
+	pkg-config \
+	rpm-build \
+	which"
+
+# librpma library deps
+ENV RPMA_DEPS "\
+	cmake \
+	file \
+	gawk \
+	groff \
+	graphviz \
+	pandoc"
+
+# examples deps ('protobuf-c-devel' is required only for examples 9 and 9s)
+ENV EXAMPLES_DEPS "\
+	libpmem-devel \
+	libpmem2-devel \
+	protobuf-c-devel"
+
+# doc update deps
+ENV DOC_UPDATE_DEPS "\
+	hub"
+
+# rdma-core built from sources deps
+ENV RDMA_CORE_FROM_SOURCES_DEPS "\
+	libnl3-devel \
+	wget"
+
+# Install all required packages
+RUN dnf install -y \
+	$BASE_DEPS \
+	$RPMA_DEPS \
+	$EXAMPLES_DEPS \
+	$DOC_UPDATE_DEPS \
+	$RDMA_CORE_FROM_SOURCES_DEPS \
+&& dnf clean all
+
+# Install rdma-core
+COPY install-rdma-core.sh install-rdma-core.sh
+RUN ./install-rdma-core.sh
+
+# Install cmocka
+COPY install-cmocka.sh install-cmocka.sh
+RUN ./install-cmocka.sh
+
+# Install txt2man
+COPY install-txt2man.sh install-txt2man.sh
+RUN ./install-txt2man.sh
+
+# Add user
+ENV USER user
+ENV USERPASS p1a2s3s4
+RUN useradd -m $USER
+RUN echo "$USER:$USERPASS" | chpasswd
+RUN gpasswd wheel -a $USER
+USER $USER
+
+# Set required environment variables
+ENV OS fedora
+ENV OS_VER latest
+ENV PACKAGE_MANAGER rpm
+ENV NOTTY 1
+# Paths to the rdma-core built from sources
+ENV PKG_CONFIG_PATH /rdma-core/build/lib/pkgconfig
+ENV LIBRARY_PATH /rdma-core/build/lib
+ENV LD_LIBRARY_PATH /rdma-core/build/lib
+ENV CPATH /rdma-core/build/include

--- a/utils/docker/images/Dockerfile.ubuntu-latest-with-rdma-core-45
+++ b/utils/docker/images/Dockerfile.ubuntu-latest-with-rdma-core-45
@@ -1,0 +1,103 @@
+#
+# SPDX-License-Identifier: BSD-3-Clause
+# Copyright 2016-2023, Intel Corporation
+#
+
+#
+# Dockerfile.ubuntu-latest-with-rdma-core-45 - Dockerfile for Ubuntu-latest with rdma-core v45.0
+#                                              installed from sources.
+#
+# This dockerfile is a 'recipe' for Docker to build an image of ubuntu-based environment
+# prepared for running tests of librpma.
+#
+
+# Pull base image
+FROM ubuntu:latest
+MAINTAINER tomasz.gromadzki@intel.com
+
+ENV DEBIAN_FRONTEND noninteractive
+
+# Additional parameters to build docker without building components
+ARG SKIP_SCRIPTS_DOWNLOAD
+
+# Update the Apt cache and install basic tools
+RUN apt-get update && apt-get dist-upgrade -y
+
+# base Linux deps
+ENV BASE_DEPS "\
+	apt-utils \
+	build-essential \
+	clang \
+	devscripts \
+	git \
+	pkg-config \
+	sudo \
+	whois"
+
+# librpma library deps
+ENV RPMA_DEPS "\
+	cmake \
+	curl \
+	gawk \
+	groff \
+	graphviz \
+	pandoc"
+
+# examples deps ('libprotobuf-c-dev' is required only for examples 9 and 9s)
+ENV EXAMPLES_DEPS "\
+	libpmem-dev \
+	libpmem2-dev \
+	libprotobuf-c-dev"
+
+# packages required by the Coverity build
+ENV COVERITY_DEPS "\
+	ruby \
+	wget"
+
+# rdma-core built from sources deps
+ENV RDMA_CORE_FROM_SOURCES_DEPS "\
+	libnl-3-dev \
+	libnl-route-3-dev"
+
+# Install all required packages
+RUN apt-get install -y --no-install-recommends \
+	$BASE_DEPS \
+	$RPMA_DEPS \
+	$EXAMPLES_DEPS \
+	$COVERITY_DEPS \
+	$RDMA_CORE_FROM_SOURCES_DEPS \
+&& rm -rf /var/lib/apt/lists/*
+
+# Install rdma-core
+COPY install-rdma-core.sh install-rdma-core.sh
+RUN ./install-rdma-core.sh
+
+# Install cmocka
+COPY install-cmocka.sh install-cmocka.sh
+RUN ./install-cmocka.sh
+
+# Install txt2man
+COPY install-txt2man.sh install-txt2man.sh
+RUN ./install-txt2man.sh
+
+# Download scripts required in run-*.sh
+COPY download-scripts.sh download-scripts.sh
+COPY 0001-fix-generating-gcov-files-and-turn-off-verbose-log.patch 0001-fix-generating-gcov-files-and-turn-off-verbose-log.patch
+RUN ./download-scripts.sh
+
+# Add user
+ENV USER user
+ENV USERPASS p1a2s3s4
+RUN useradd -m $USER -g sudo -p `mkpasswd $USERPASS`
+USER $USER
+
+# Set required environment variables
+ENV OS ubuntu
+ENV OS_VER latest
+ENV PACKAGE_MANAGER deb
+ENV NOTTY 1
+# Paths to the rdma-core built from sources
+ENV PKG_CONFIG_PATH /rdma-core/build/lib/pkgconfig
+ENV LIBRARY_PATH /rdma-core/build/lib
+ENV LD_LIBRARY_PATH /rdma-core/build/lib
+ENV CPATH /rdma-core/build/include

--- a/utils/docker/images/install-rdma-core.sh
+++ b/utils/docker/images/install-rdma-core.sh
@@ -1,0 +1,29 @@
+#!/usr/bin/env bash
+#
+# SPDX-License-Identifier: BSD-3-Clause
+# Copyright 2023, Intel Corporation
+#
+
+#
+# install-rdma-core.sh - installs rdma-core libraries from sources with support for:
+#                        native atomic write and native flush
+#
+
+set -ex
+
+# rdma-core v45.0 with support for native atomic write and native flush
+VERSION="45.0"
+
+WORKDIR=$(pwd)
+
+#
+# Install rdma-core libraries from a release package
+#
+wget https://github.com/linux-rdma/rdma-core/releases/download/v${VERSION}/rdma-core-${VERSION}.tar.gz
+tar -xzf rdma-core-${VERSION}.tar.gz
+rm rdma-core-${VERSION}.tar.gz
+
+mv rdma-core-${VERSION} rdma-core
+cd rdma-core
+./build.sh
+cd $WORKDIR


### PR DESCRIPTION
Add CI builds with rdma-core v44.0 installed from sources
(with support for both native atomic write and native flush)
on Ubuntu-latest and Fedora-latest CIs.

Requires:
- [x] #2116
- [x] #2118

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/pmem/rpma/2119)
<!-- Reviewable:end -->
