### PR TITLE
common: do not fail build when rpm -q fails

### DIFF
--- a/utils/docker/run-build.sh
+++ b/utils/docker/run-build.sh
@@ -239,14 +239,14 @@ else
 
 	if [ $PACKAGE_MANAGER = "deb" ]; then
 		set -x
-		dpkg-deb --info ./librpma*.deb
-		dpkg-deb -c ./librpma*.deb
+		dpkg-deb --info ./librpma*.deb || true
+		dpkg-deb -c ./librpma*.deb || true
 		sudo_password dpkg -i ./librpma*.deb
 		set +x
 	elif [ $PACKAGE_MANAGER = "rpm" ]; then
 		set -x
-		rpm -q --info ./librpma*.rpm && true
-		rpm -q --list ./librpma*.rpm && true
+		rpm -q --info ./librpma*.rpm || true
+		rpm -q --list ./librpma*.rpm || true
 		sudo_password rpm -ivh --force *.rpm
 		set +x
 	fi


### PR DESCRIPTION
Fix preventing from failing the build when `rpm -q` or `dpkg-deb` fails.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/pmem/rpma/2121)
<!-- Reviewable:end -->
