### PR TITLE
test: fix the "ibv_query_device_ex_mock undeclared" compiler error

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - some wrong and misleading comments in tests/unit/peer/peer-mr_reg.c
 - OS version in the Coverity CI build
 - preventing from failing the build when 'rpm -q' or 'dpkg-deb' commands fail
+- the "ibv_query_device_ex_mock undeclared" compiler error when both ON_DEMAND_PAGING_SUPPORTED
+  and NATIVE_ATOMIC_WRITE_SUPPORTED are not defined
 
 ### Changed
 - renamed IBV_WR_ATOMIC_WRITE_SUPPORTED to NATIVE_ATOMIC_WRITE_SUPPORTED

--- a/tests/unit/utils/utils-ibv_context_is_atomic_write_capable.c
+++ b/tests/unit/utils/utils-ibv_context_is_atomic_write_capable.c
@@ -86,7 +86,9 @@ int
 main(int argc, char *argv[])
 {
 	MOCK_VERBS->abi_compat = __VERBS_ABI_IS_EXTENDED;
+#ifdef NATIVE_ATOMIC_WRITE_SUPPORTED
 	Verbs_context.query_device_ex = ibv_query_device_ex_mock;
+#endif
 	Verbs_context.sz = sizeof(struct verbs_context);
 
 	const struct CMUnitTest tests[] = {


### PR DESCRIPTION
When both ON_DEMAND_PAGING_SUPPORTED and NATIVE_ATOMIC_WRITE_SUPPORTED are not defined, the following compiler error will be triggered: 
```
...
error: 'ibv_query_device_ex_mock' undeclared (first use in this function); did you mean 'ibv_query_device_ex'?
	Verbs_context.query_device_ex = ibv_query_device_ex_mock;
...
```

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/pmem/rpma/2123)
<!-- Reviewable:end -->
