### PR TITLE
test: update cmake_minimum_required version from 3.3 to 3.5

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+- cmake_minimum_required version from 3.3 to 3.5
+
 ## [1.3.0] - 2023-05-25
 ### Added
 - the native flush support (required support in the kernel and in an RNIC's driver)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -4,7 +4,7 @@
 # Copyright (c) 2022-2023, Fujitsu Limited
 #
 
-cmake_minimum_required(VERSION 3.3)
+cmake_minimum_required(VERSION 3.5)
 
 project(rpma C)
 

--- a/examples/01-connection/CMakeLists.txt
+++ b/examples/01-connection/CMakeLists.txt
@@ -1,9 +1,9 @@
 #
 # SPDX-License-Identifier: BSD-3-Clause
-# Copyright 2020-2021, Intel Corporation
+# Copyright 2020-2023, Intel Corporation
 #
 
-cmake_minimum_required(VERSION 3.3)
+cmake_minimum_required(VERSION 3.5)
 project(connection-example C)
 
 set(CMAKE_MODULE_PATH ${CMAKE_MODULE_PATH}

--- a/examples/02-read-to-volatile/CMakeLists.txt
+++ b/examples/02-read-to-volatile/CMakeLists.txt
@@ -1,10 +1,10 @@
 #
 # SPDX-License-Identifier: BSD-3-Clause
-# Copyright 2020, Intel Corporation
+# Copyright 2020-2023, Intel Corporation
 # Copyright 2021, Fujitsu
 #
 
-cmake_minimum_required(VERSION 3.3)
+cmake_minimum_required(VERSION 3.5)
 project(read-example C)
 
 set(CMAKE_MODULE_PATH ${CMAKE_MODULE_PATH}

--- a/examples/03-read-to-persistent/CMakeLists.txt
+++ b/examples/03-read-to-persistent/CMakeLists.txt
@@ -1,10 +1,10 @@
 #
 # SPDX-License-Identifier: BSD-3-Clause
-# Copyright 2020-2022, Intel Corporation
+# Copyright 2020-2023, Intel Corporation
 # Copyright 2021, Fujitsu
 #
 
-cmake_minimum_required(VERSION 3.3)
+cmake_minimum_required(VERSION 3.5)
 project(read-to-persistent C)
 
 set(CMAKE_MODULE_PATH ${CMAKE_MODULE_PATH}

--- a/examples/04-write-to-persistent/CMakeLists.txt
+++ b/examples/04-write-to-persistent/CMakeLists.txt
@@ -1,10 +1,10 @@
 #
 # SPDX-License-Identifier: BSD-3-Clause
-# Copyright 2020-2022, Intel Corporation
+# Copyright 2020-2023, Intel Corporation
 # Copyright 2021, Fujitsu
 #
 
-cmake_minimum_required(VERSION 3.3)
+cmake_minimum_required(VERSION 3.5)
 project(write-to-persistent C)
 
 set(CMAKE_MODULE_PATH ${CMAKE_MODULE_PATH}

--- a/examples/05-flush-to-persistent/CMakeLists.txt
+++ b/examples/05-flush-to-persistent/CMakeLists.txt
@@ -1,10 +1,10 @@
 #
 # SPDX-License-Identifier: BSD-3-Clause
-# Copyright 2020-2022, Intel Corporation
+# Copyright 2020-2023, Intel Corporation
 # Copyright 2021, Fujitsu
 #
 
-cmake_minimum_required(VERSION 3.3)
+cmake_minimum_required(VERSION 3.5)
 project(flush-to-persistent C)
 
 set(CMAKE_MODULE_PATH ${CMAKE_MODULE_PATH}

--- a/examples/06-multiple-connections/CMakeLists.txt
+++ b/examples/06-multiple-connections/CMakeLists.txt
@@ -1,10 +1,10 @@
 #
 # SPDX-License-Identifier: BSD-3-Clause
-# Copyright 2020, Intel Corporation
+# Copyright 2020-2023, Intel Corporation
 # Copyright 2021, Fujitsu
 #
 
-cmake_minimum_required(VERSION 3.3)
+cmake_minimum_required(VERSION 3.5)
 project(multiple-connections C)
 
 set(CMAKE_MODULE_PATH ${CMAKE_MODULE_PATH}

--- a/examples/06scch-multiple-connections/CMakeLists.txt
+++ b/examples/06scch-multiple-connections/CMakeLists.txt
@@ -1,10 +1,10 @@
 #
 # SPDX-License-Identifier: BSD-3-Clause
-# Copyright 2020, Intel Corporation
+# Copyright 2020-2023, Intel Corporation
 # Copyright 2021, Fujitsu
 #
 
-cmake_minimum_required(VERSION 3.3)
+cmake_minimum_required(VERSION 3.5)
 project(multiple-connections C)
 
 set(CMAKE_MODULE_PATH ${CMAKE_MODULE_PATH}

--- a/examples/07-atomic-write/CMakeLists.txt
+++ b/examples/07-atomic-write/CMakeLists.txt
@@ -1,10 +1,10 @@
 #
 # SPDX-License-Identifier: BSD-3-Clause
-# Copyright 2020-2022, Intel Corporation
+# Copyright 2020-2023, Intel Corporation
 # Copyright 2021, Fujitsu
 #
 
-cmake_minimum_required(VERSION 3.3)
+cmake_minimum_required(VERSION 3.5)
 project(atomic-write C)
 
 set(CMAKE_MODULE_PATH ${CMAKE_MODULE_PATH}

--- a/examples/08-messages-ping-pong/CMakeLists.txt
+++ b/examples/08-messages-ping-pong/CMakeLists.txt
@@ -1,9 +1,9 @@
 #
 # SPDX-License-Identifier: BSD-3-Clause
-# Copyright 2020-2022, Intel Corporation
+# Copyright 2020-2023, Intel Corporation
 #
 
-cmake_minimum_required(VERSION 3.3)
+cmake_minimum_required(VERSION 3.5)
 project(messages-ping-pong C)
 
 set(CMAKE_MODULE_PATH ${CMAKE_MODULE_PATH}

--- a/examples/08srq-simple-messages-ping-pong-with-srq/CMakeLists.txt
+++ b/examples/08srq-simple-messages-ping-pong-with-srq/CMakeLists.txt
@@ -1,9 +1,9 @@
 #
 # SPDX-License-Identifier: BSD-3-Clause
-# Copyright 2020-2022, Intel Corporation
+# Copyright 2020-2023, Intel Corporation
 #
 
-cmake_minimum_required(VERSION 3.3)
+cmake_minimum_required(VERSION 3.5)
 project(messages-ping-pong C)
 
 set(CMAKE_MODULE_PATH ${CMAKE_MODULE_PATH}

--- a/examples/09-flush-to-persistent-GPSPM/CMakeLists.txt
+++ b/examples/09-flush-to-persistent-GPSPM/CMakeLists.txt
@@ -1,10 +1,10 @@
 #
 # SPDX-License-Identifier: BSD-3-Clause
-# Copyright 2020-2022, Intel Corporation
+# Copyright 2020-2023, Intel Corporation
 # Copyright 2021, Fujitsu
 #
 
-cmake_minimum_required(VERSION 3.3)
+cmake_minimum_required(VERSION 3.5)
 project(flush-to-persistent C)
 
 set(CMAKE_MODULE_PATH ${CMAKE_MODULE_PATH}

--- a/examples/09scch-flush-to-persistent-GPSPM/CMakeLists.txt
+++ b/examples/09scch-flush-to-persistent-GPSPM/CMakeLists.txt
@@ -1,10 +1,10 @@
 #
 # SPDX-License-Identifier: BSD-3-Clause
-# Copyright 2020-2022, Intel Corporation
+# Copyright 2020-2023, Intel Corporation
 # Copyright 2021, Fujitsu
 #
 
-cmake_minimum_required(VERSION 3.3)
+cmake_minimum_required(VERSION 3.5)
 project(flush-to-persistent C)
 
 set(CMAKE_MODULE_PATH ${CMAKE_MODULE_PATH}

--- a/examples/10-send-with-imm/CMakeLists.txt
+++ b/examples/10-send-with-imm/CMakeLists.txt
@@ -1,10 +1,10 @@
 #
 # SPDX-License-Identifier: BSD-3-Clause
 # Copyright (c) 2020 Fujitsu
-# Copyright 2021, Intel Corporation
+# Copyright 2021-2023, Intel Corporation
 #
 
-cmake_minimum_required(VERSION 3.3)
+cmake_minimum_required(VERSION 3.5)
 project(send-with-imm C)
 
 set(CMAKE_MODULE_PATH ${CMAKE_MODULE_PATH}

--- a/examples/11-write-with-imm/CMakeLists.txt
+++ b/examples/11-write-with-imm/CMakeLists.txt
@@ -1,9 +1,10 @@
 #
 # SPDX-License-Identifier: BSD-3-Clause
 # Copyright (c) 2021 Fujitsu
+# Copyright 2023, Intel Corporation
 #
 
-cmake_minimum_required(VERSION 3.3)
+cmake_minimum_required(VERSION 3.5)
 project(write-with-imm C)
 
 set(CMAKE_MODULE_PATH ${CMAKE_MODULE_PATH}

--- a/examples/12-receive-completion-queue/CMakeLists.txt
+++ b/examples/12-receive-completion-queue/CMakeLists.txt
@@ -1,9 +1,9 @@
 #
 # SPDX-License-Identifier: BSD-3-Clause
-# Copyright 2022, Intel Corporation
+# Copyright 2022-2023, Intel Corporation
 #
 
-cmake_minimum_required(VERSION 3.3)
+cmake_minimum_required(VERSION 3.5)
 project(receive-completion-queue C)
 
 set(CMAKE_MODULE_PATH ${CMAKE_MODULE_PATH}

--- a/examples/12scch-receive-completion-queue/CMakeLists.txt
+++ b/examples/12scch-receive-completion-queue/CMakeLists.txt
@@ -1,9 +1,9 @@
 #
 # SPDX-License-Identifier: BSD-3-Clause
-# Copyright 2022, Intel Corporation
+# Copyright 2022-2023, Intel Corporation
 #
 
-cmake_minimum_required(VERSION 3.3)
+cmake_minimum_required(VERSION 3.5)
 project(receive-completion-queue C)
 
 set(CMAKE_MODULE_PATH ${CMAKE_MODULE_PATH}

--- a/examples/13-messages-ping-pong-with-srq/CMakeLists.txt
+++ b/examples/13-messages-ping-pong-with-srq/CMakeLists.txt
@@ -1,10 +1,10 @@
 #
 # SPDX-License-Identifier: BSD-3-Clause
 # Copyright 2022, Fujitsu
-# Copyright 2022, Intel Corporation
+# Copyright 2022-2023, Intel Corporation
 #
 
-cmake_minimum_required(VERSION 3.3)
+cmake_minimum_required(VERSION 3.5)
 project(messages-ping-pong-with-srq C)
 
 set(CMAKE_MODULE_PATH ${CMAKE_MODULE_PATH}

--- a/examples/cmake/common.cmake
+++ b/examples/cmake/common.cmake
@@ -1,9 +1,9 @@
 #
 # SPDX-License-Identifier: BSD-3-Clause
-# Copyright 2020-2022, Intel Corporation
+# Copyright 2020-2023, Intel Corporation
 #
 
-cmake_minimum_required(VERSION 3.3)
+cmake_minimum_required(VERSION 3.5)
 
 function(add_example_with_pmem)
 	set(options USE_LIBPROTOBUFC)


### PR DESCRIPTION
Update cmake_minimum_required version from 3.3 to 3.5, because of:
```
CMake Deprecation Warning at CMakeLists.txt:7 (cmake_minimum_required):
  Compatibility with CMake < 3.5 will be removed from a future version of
  CMake.
```

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/pmem/rpma/2136)
<!-- Reviewable:end -->
